### PR TITLE
log4j.rootCategory replaced by log4j.rootLogger since log4j 1.2

### DIFF
--- a/ogc-server-statistics/src/main/java/com/camptocamp/ogcservstatistics/log4j/OGCServicesAppender.java
+++ b/ogc-server-statistics/src/main/java/com/camptocamp/ogcservstatistics/log4j/OGCServicesAppender.java
@@ -23,7 +23,7 @@ import com.camptocamp.ogcservstatistics.dataservices.InsertCommand;
  * The example shows how to configure the appender to work with postgres database: 
  * <pre>
  * 
- * log4j.rootCategory= INFO, OGCSERVICES
+ * log4j.rootLogger= INFO, OGCSERVICES
  * log4j.appender.OGCSERVICES=com.camptocamp.ogcservstatistics.log4j.OGCServicesAppender
  * log4j.appender.OGCSERVICES.activated=true
  * log4j.appender.OGCSERVICES.jdbcURL=jdbc:postgresql://localhost:5432/testdb

--- a/ogc-server-statistics/src/test/resources/com/camptocamp/ogcservstatistics/log4j-disable.properties
+++ b/ogc-server-statistics/src/test/resources/com/camptocamp/ogcservstatistics/log4j-disable.properties
@@ -23,7 +23,7 @@
 # priority in which case they inherit their priority from the
 # hierarchy.
 # test log4j.rootLogger=INFO, OGCSERVICES
-log4j.rootCategory= INFO, OGCSERVICES
+log4j.rootLogger= INFO, OGCSERVICES
 
 log4j.appender.OGCSERVICES=com.camptocamp.ogcservstatistics.log4j.OGCServicesAppender
 log4j.appender.OGCSERVICES.activated=false

--- a/ogc-server-statistics/src/test/resources/com/camptocamp/ogcservstatistics/log4j.properties
+++ b/ogc-server-statistics/src/test/resources/com/camptocamp/ogcservstatistics/log4j.properties
@@ -23,7 +23,7 @@
 # priority in which case they inherit their priority from the
 # hierarchy.
 #log4j.rootLogger=INFO, OGCSERVICES
-log4j.rootCategory=INFO
+log4j.rootLogger=INFO
 
 log4j.logger.OGCServiceMessageFormatter=DEBUG, REQUEST_FILE
 log4j.logger.com.camptocamp.ogcservstatistics.log4j=INFO, OGCSERVICES


### PR DESCRIPTION
and we're using 1.2.16
