### PR TITLE
LDAP groups memberUid vs member

### DIFF
--- a/config/defaults/geonetwork-main/webapp/WEB-INF/config-security.properties
+++ b/config/defaults/geonetwork-main/webapp/WEB-INF/config-security.properties
@@ -34,12 +34,11 @@ ldap.privilege.pattern.idx.profil=2
 # 3. Define custom location for extracting group and role (no support for group/role combination) (use LDAPUserDetailsContextMapperWithProfileSearch in config-security.xml).
 ldap.privilege.search.group.attribute=cn
 ldap.privilege.search.group.object=ou=groups
-ldap.privilege.search.group.query=(&(objectClass=posixGroup)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=EL_*))
-#ldap.privilege.search.group.query=(&(objectClass=*)(uid={0},${ldap.base.search.base},${ldap.base.dn})(|(cn=SP_*)(cn=EL_*)))
+ldap.privilege.search.group.query=(&(objectClass=posixGroup)(memberUid={0})(cn=EL_*))
 ldap.privilege.search.group.pattern=EL_(.*)
 ldap.privilege.search.privilege.attribute=cn
 ldap.privilege.search.privilege.object=ou=groups
-ldap.privilege.search.privilege.query=(&(objectClass=posixGroup)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=SV_*))
+ldap.privilege.search.privilege.query=(&(objectClass=posixGroup)(memberUid={0})(cn=SV_*))
 ldap.privilege.search.privilege.pattern=SV_(.*)
 
 

--- a/security-proxy/src/main/filtered-resources/WEB-INF/security-proxy.properties
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/security-proxy.properties
@@ -28,7 +28,7 @@ userSearchFilter=(uid={0})
 # The base DN to use for looking up the roles/groups/authorities of the logged in user.  Normally the ldap is configured like:
 # 	ou=groups
 # 		ou=somegroup
-# 			memberUid=uid=username,ou=users,dc=georchestra,dc=org
+# 			memberUid=username
 # 
 # 	ou can be cn, ou, or some other option.  member is often uniquemember as well.  If you don't know what this means you need to
 # 	research LDAP
@@ -37,7 +37,7 @@ authoritiesBaseDN=${authoritiesBaseDN}
 groupRoleAttribute=cn
 # the search filter that selects the groups that the user is part of. 
 # If a match is found the containing object is one of the groups the user is part of
-groupSearchFilter=(memberUid=uid={1},${userSearchBaseDN},${baseDN})
+groupSearchFilter=(memberUid={1})
 # the admin user's DN (distinguished name) 
 # 	 Depending on how the LDAP is configured you may be able to comment this and password out and add
 # 	 	<property name="anonymousReadOnly" value="true" />


### PR DESCRIPTION
Currently, our LDAP groups (objectClass: posixGroup) reference users by the way of memberUid attributes

eg:

```
dn: cn=SV_ADMIN,ou=groups,dc=georchestra,dc=org
objectClass: top
objectClass: posixGroup
gidNumber: 2
cn: SV_ADMIN
memberUid: uid=testadmin,ou=users,dc=georchestra,dc=org
```

As a result, geOrchestra uses filters such as this one

```
ldap.privilege.search.privilege.query=(&(objectClass=posixGroup)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=SV_*))
```

(see https://github.com/georchestra/georchestra/blob/master/config/defaults/geonetwork-main/webapp/WEB-INF/config-security.properties)

On the other hand, GeoBretagne uses memberUid like this:

```
memberUid: testadmin
```

rather than

```
memberUid: uid=testadmin,ou=users,dc=georchestra,dc=org
```

I found out that they are right : the memberUid attribute is meant to specify a uid, not a complete dn. See for instance http://www.rainingpackets.com/ldap-posixgroup-groupofnames/

As a result, we have to update the config files which specify how LDAP filters are defined. 

To my knowledge, this impacts the security proxy, cas and geonetwork.
