### PR TITLE
Evolution/2385/extract button

### DIFF
--- a/extractorapp/src/main/webapp/app/css/main.css
+++ b/extractorapp/src/main/webapp/app/css/main.css
@@ -1,6 +1,12 @@
 .geor-btn-extract {
     background-image: url(../img/famfamfam/basket_go.png) !important;
 }
+.geor-primary {
+    background-color: #4460B0;
+    background-image: linear-gradient(#6D8ADD, #4460B0);
+    background-repeat: repeat-x;
+    border-color: #415CA9;
+}
 .basket {
     background-image: url(../img/famfamfam/basket.gif) !important;
 }

--- a/extractorapp/src/main/webapp/app/js/GEOR.js
+++ b/extractorapp/src/main/webapp/app/js/GEOR.js
@@ -236,6 +236,7 @@ Ext.namespace("GEOR");
             }, {
                 layout: "form",
                 region: 'south',
+                footerCssClass: "geor-primary",
                 buttons: [{
                     xtype: 'button',
                     id: "geor-btn-extract-id",


### PR DESCRIPTION
for http://forge.applis-bretagne.fr/issues/2385

For the second part of the issue:

> De plus, modifier la couleur pour que le bouton soit visible (même apparence que le bouton Modifier cette emprise)

I tried to set the panel background to blue gradient, copied from Github button and shifted from green to blue. I don't know if it's a good idea, principally because of the non-respect of the Ext themes (we use the "gray" theme). Please give feedback. I join a screenshot.

![extractor screenshot](https://f.cloud.github.com/assets/1676121/850939/aea74cba-f492-11e2-9dc1-9cc6fb74748c.png)

<!---
@huboard:{"order":160.0}
-->
