### PR TITLE
mapfishapp-fails loading files, when gdal is not instlled

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/UpLoadGeoFileController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/UpLoadGeoFileController.java
@@ -139,7 +139,7 @@ public final class UpLoadGeoFileController {
 	private long gpxSizeLimit;
 	private long gmlSizeLimit;
 	
-	private UpLoadFileManagement fileManagement = new UpLoadFileManagement();
+	private UpLoadFileManagement fileManagement = UpLoadFileManagement.create();
 
 	
 	/**
@@ -290,8 +290,6 @@ public final class UpLoadGeoFileController {
 			}
 			
 			// save the file in the temporal directory
-			this.fileManagement = UpLoadFileManagement.create(); 
-			// this.fileManagement = UpLoadFileManagement.create(UpLoadFileManagement.Implementation.geotools); HACK to use Geotools Implementation
 
 			this.fileManagement.setWorkDirectory(workDirectory); 
 			this.fileManagement.setFileDescriptor(currentFile);

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/AbstractFeatureGeoFileReader.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/AbstractFeatureGeoFileReader.java
@@ -6,6 +6,8 @@ package org.georchestra.mapfishapp.ws.upload;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
@@ -18,22 +20,39 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 class AbstractFeatureGeoFileReader implements FeatureGeoFileReader{
 
-	/** check if the OGR implementation is live */
-	private static boolean OGR_AVAILABLE;
-	static{
-		OGR_AVAILABLE = OGRFeatureReader.isOK();
-	}
+	
+	private static final Log LOG = LogFactory.getLog(AbstractFeatureGeoFileReader.class.getPackage().getName());
+
 
 	protected FeatureGeoFileReader readerImpl = null;
 
+	private FeatureGeoFileReader getReaderImpl() {
+		
+		LOG.info("Using implementation: " + this.readerImpl.getClass().getName());
+		return this.readerImpl;
+	}
+
+
+	private void setReaderImpl(FeatureGeoFileReader readerImpl) {
+		
+		LOG.info("It was set: " + readerImpl.getClass().getName());
+		
+		this.readerImpl = readerImpl;
+	}
+
+
 	/**
 	 * Creates a new instance of {@link AbstractFeatureGeoFileReader}.
+	 * 
+	 * <p>
+	 * The default implementation will be OGR if it was installed in the system.
+	 * </p>
 	 * 
 	 * @param basedir file to read
 	 * @param fileFormat the format
 	 */
 	public AbstractFeatureGeoFileReader() {
-		this.readerImpl = createImplementationStrategy();
+		setReaderImpl(createImplementationStrategy());
 	}
 	
 
@@ -44,7 +63,7 @@ class AbstractFeatureGeoFileReader implements FeatureGeoFileReader{
 	 */
 	public AbstractFeatureGeoFileReader(FeatureGeoFileReader impl) {
 		
-		this.readerImpl = impl;
+		setReaderImpl(impl);
 	}
 
 	/**
@@ -53,7 +72,7 @@ class AbstractFeatureGeoFileReader implements FeatureGeoFileReader{
 	@Override
 	public FileFormat[] getFormatList(){
 
-		return this.readerImpl.getFormatList();
+		return getReaderImpl().getFormatList();
 	}
 
 
@@ -90,19 +109,17 @@ class AbstractFeatureGeoFileReader implements FeatureGeoFileReader{
 	public SimpleFeatureCollection getFeatureCollection(final File file, final FileFormat fileFormat, final CoordinateReferenceSystem targetCrs) throws IOException, UnsupportedGeofileFormatException {
 		
 		try{
-			return  this.readerImpl.getFeatureCollection(file, fileFormat, targetCrs);
+			return  getReaderImpl().getFeatureCollection(file, fileFormat, targetCrs);
 			
 		} catch(IOException e){
 
-			if (!(this.readerImpl instanceof GeotoolsFeatureReader)) {
-				// switches to geotools implementation
-
-				OGR_AVAILABLE = false;
-				this.readerImpl = new GeotoolsFeatureReader();
+			if (!(getReaderImpl() instanceof GeotoolsFeatureReader)) {
+				
+				switchToGeotoolsImplementation();
 
 				// now try to read using the geotools implementation
 				try {
-					return this.readerImpl.getFeatureCollection(file, fileFormat, targetCrs);
+					return getReaderImpl().getFeatureCollection(file, fileFormat, targetCrs);
 					
 				} catch (UnsupportedGeofileFormatException gtUnsupoortFileFormat) {
 					throw gtUnsupoortFileFormat;
@@ -118,16 +135,24 @@ class AbstractFeatureGeoFileReader implements FeatureGeoFileReader{
 	}
 
 	/**
+	 * switches to geotools implementation
+	 */
+	private void switchToGeotoolsImplementation() {
+		setReaderImpl( new GeotoolsFeatureReader() );
+	}
+
+
+	/**
 	 * Selects which of the implementations must be created.
 	 */
 	private static FeatureGeoFileReader createImplementationStrategy(){
 
 		FeatureGeoFileReader implementor = null; 
-		if( isOgrAvailable() ){
+		if( OGRFeatureReader.isOK() ){
 
 			implementor = new OGRFeatureReader();
 
-		} else { // by default the geotools implementation is created
+		} else { 
 
 			implementor = new GeotoolsFeatureReader();
 		}
@@ -135,14 +160,5 @@ class AbstractFeatureGeoFileReader implements FeatureGeoFileReader{
 	}
 
 
-	/**
-	 * Decides what is the implementation must be instantiate.
-	 *  
-	 * @return true if ogr is available in the platform.
-	 */
-	private static boolean isOgrAvailable() {
-		
-		return OGR_AVAILABLE;
-	}
 
 }

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/OGRFeatureReader.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/OGRFeatureReader.java
@@ -155,6 +155,16 @@ final class OGRFeatureReader implements FeatureGeoFileReader {
 	public static boolean isOK() {
 		
 		try{
+			Class.forName("org.geotools.data.ogr.jni.JniOGR");
+			
+		} catch (Throwable e){
+		
+			LOG.info("gdal/ogr is not available in the system", e);
+
+			return false;
+		} 
+		
+		try{
 			JniOGR ogr  = new JniOGR();
 		
 			ArrayList<String> availableDrivers = new ArrayList<String>();
@@ -171,10 +181,10 @@ final class OGRFeatureReader implements FeatureGeoFileReader {
 				}
 			}
 		} catch(Error e)  {
-			String msg = "cannot use the ogr implementation";
-			LOG.warn(msg, e);
+			LOG.warn("the ogr installed in the system doesn't have the drivers required by mapfish", e);
 			return false;
 		}
+		LOG.info("gdal/ogr is available in the system");
 		
 		return true;
 	}

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagement.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagement.java
@@ -75,8 +75,11 @@ public class UpLoadFileManagement {
 	
 	private String workDirectory;
 
-    private AbstractFeatureGeoFileReader reader  = new AbstractFeatureGeoFileReader();
+    private AbstractFeatureGeoFileReader reader;
 
+    private UpLoadFileManagement(){
+    	//use the method factory
+    }
 
 	/**
 	 * Creates an instance of {@link UpLoadFileManagement}  which is set to use the implementation specified as parameter.
@@ -95,12 +98,15 @@ public class UpLoadFileManagement {
 	}
 
 	/**
-	 * Creates an instance of {@link UpLoadFileManagement} which is set to use the OGR implementation (default implementation) 
+	 * Creates an instance of {@link UpLoadFileManagement} which is set to use the OGR implementation if only if gdal/ogr is installed in the system
 	 * @return new instance of {@link UpLoadFileManagement} 
 	 */
 	public static UpLoadFileManagement create() {
 
-		return create(Implementation.ogr);
+		UpLoadFileManagement manager = new UpLoadFileManagement();
+		manager.reader = new AbstractFeatureGeoFileReader();
+
+		return manager;
 	}
 	
 	public void unzip() throws IOException {


### PR DESCRIPTION
When gdal is not installed the application fails trying to upload geofiles. 
