### PR TITLE
Use org.codehaus.gmaven instead of org.codehaus.groovy.maven.

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -108,7 +108,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
 		<plugin>
-			<groupId>org.codehaus.groovy.maven</groupId>
+			<groupId>org.codehaus.gmaven</groupId>
 			<artifactId>gmaven-plugin</artifactId>
 			<dependencies>
 				<dependency>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -126,7 +126,7 @@
 			  <artifactId>maven-dependency-plugin</artifactId>
   	        </plugin>
 			<plugin>
-				<groupId>org.codehaus.groovy.maven</groupId>
+				<groupId>org.codehaus.gmaven</groupId>
 				<artifactId>gmaven-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/catalogapp/pom.xml
+++ b/catalogapp/pom.xml
@@ -94,7 +94,7 @@
 		<artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-			<groupId>org.codehaus.groovy.maven</groupId>
+			<groupId>org.codehaus.gmaven</groupId>
 			<artifactId>gmaven-plugin</artifactId>
 			<dependencies>
 				<dependency>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -170,7 +170,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.groovy.maven</groupId>
+				<groupId>org.codehaus.gmaven</groupId>
 				<artifactId>gmaven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/downloadform/pom.xml
+++ b/downloadform/pom.xml
@@ -87,7 +87,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
 		<plugin>
-			<groupId>org.codehaus.groovy.maven</groupId>
+			<groupId>org.codehaus.gmaven</groupId>
 			<artifactId>gmaven-plugin</artifactId>
 			<dependencies>
 				<dependency>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -243,7 +243,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
 		<plugin>
-			<groupId>org.codehaus.groovy.maven</groupId>
+			<groupId>org.codehaus.gmaven</groupId>
 			<artifactId>gmaven-plugin</artifactId>
 			<dependencies>
 				<dependency>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -208,7 +208,7 @@
 				<artifactId>maven-dependency-plugin</artifactId>
             </plugin>
 			<plugin>
-				<groupId>org.codehaus.groovy.maven</groupId>
+				<groupId>org.codehaus.gmaven</groupId>
 				<artifactId>gmaven-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -144,7 +144,7 @@
 				<artifactId>maven-dependency-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.groovy.maven</groupId>
+				<groupId>org.codehaus.gmaven</groupId>
 				<artifactId>gmaven-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/server-deploy-support/pom.xml
+++ b/server-deploy-support/pom.xml
@@ -38,7 +38,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.groovy.maven</groupId>
+                <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/server-deploy/pom.xml
+++ b/server-deploy/pom.xml
@@ -54,7 +54,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.groovy.maven</groupId>
+                <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/static/pom.xml
+++ b/static/pom.xml
@@ -65,7 +65,7 @@
         </configuration>
       </plugin>
       <plugin>
-			<groupId>org.codehaus.groovy.maven</groupId>
+			<groupId>org.codehaus.gmaven</groupId>
 			<artifactId>gmaven-plugin</artifactId>
 			<dependencies>
 				<dependency>


### PR DESCRIPTION
See http://jira.codehaus.org/browse/MNG-4863
Works with both maven 2.2.x and 3.0.x.

If using groovy.maven with mvn 3.0.x build fails with:

[ERROR] Failed to execute goal org.codehaus.groovy.maven:gmaven-plugin:1.0:execute (create-missingpost-treatment) on project cas-server-webapp: Execution create-missingpost-treatment of goal org.codehaus.groovy.maven:gmaven-plugin:1.0:execute failed: Plugin org.codehaus.groovy.maven:gmaven-plugin:1.0 or one of its dependencies could not be resolved: Could not find artifact org.georchestra:config:jar:13.12-SNAPSHOT -> [Help 1]

If using mvn 2.2.1 build fails because it tries to fetch org.georchestra:config:jar:13.12-SNAPSHOT from the repos.

[INFO] Failed to resolve artifact.
## Missing:

1) org.georchestra:config:jar:13.12-SNAPSHOT

  Try downloading the file manually from the project website.

  Then, install it using the command:
      mvn install:install-file -DgroupId=org.georchestra -DartifactId=config -Dversion=13.12-SNAPSHOT -Dpackaging=jar -Dfile=/path/to/file

  Alternatively, if you host your own repository you can deploy the file there:
      mvn deploy:deploy-file -DgroupId=org.georchestra -DartifactId=config -Dversion=13.12-SNAPSHOT -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]

  Path to dependency:
        1) org.codehaus.groovy.maven:gmaven-plugin:maven-plugin:1.0
        2) org.georchestra:config:jar:13.12-SNAPSHOT

---

1 required artifact is missing.

for artifact:
  org.codehaus.groovy.maven:gmaven-plugin:maven-plugin:1.0
