### PR TITLE
Try to find a text/html metadataURL entry after GN ticket #1227.

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
@@ -512,10 +512,18 @@ GEOR.managelayers = (function() {
         menuItems.push("-");
 
         // metadata action
-        if (layerRecord.get("metadataURLs") &&
-            layerRecord.get("metadataURLs")[0]) {
-            url = layerRecord.get("metadataURLs")[0];
-            url = (url.href) ? url.href : url;
+        if (layerRecord.get("metadataURLs")) {
+            var murls = layerRecord.get("metadataURLs");
+            var murl = murls[0];
+            // default to first entry
+            url = (murl.href) ? murl.href : murl;
+            for (var i=1 ; i < murls.length ; i++) {
+               murl = murls[i];
+               // prefer text/html format if found
+               if (murl.format && murl.format == 'text/html') {
+                   url = (murl.href) ? murl.href : murl;
+               }
+            }
             menuItems.push({
                 iconCls: 'geor-btn-metadata',
                 text: tr("Show metadata"),


### PR DESCRIPTION
Better than taking the first returned entry.

By default, for the show metadata link in the menu, mapfishapp uses the first entry. It'd be nicer to check all metadataURL values, and prefer one with text/html format.

In my case when using geopublishing from geonetwork to geoserver, it appends two metadataURL entries, one pointing back to the text/xml format, and one with text/html format. See http://trac.osgeo.org/geonetwork/ticket/1227
