### PR TITLE
Find a prefixed layername in a local capabilities

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_ows.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_ows.js
@@ -443,14 +443,14 @@ GEOR.ows = (function() {
          */
         hydrateLayerRecord: function(record, options) {
             var url = record.get('layer').url,
-                layername = record.get('name'),
-                nsalias;
-                
+                layername = record.get('name');
             if (!options.useMainService && url.indexOf("geoserver/wms") > 0) {
                 // try to use virtual service instead of main service
-                var t = layername.split(':');
+                var nsalias,
+                    t = layername.split(':');
                 if (t.length > 1) {
                     nsalias = t.shift();
+                    layername = t.shift();
                     url = url.replace("geoserver/wms", "geoserver/"+nsalias+"/wms");
                 }
             }
@@ -460,7 +460,7 @@ GEOR.ows = (function() {
                     url: url
                 },
                 success: function(store, records) {
-                    var index = store.find("name", nsalias ? nsalias : layername);
+                    var index = store.find("name", layername);
                     if (index < 0) {
                         GEOR.util.errorDialog({
                             msg: OpenLayers.i18n("The NAME layer was not found in WMS service.",


### PR DESCRIPTION
Since the upgrade of GS to 2.3.2, a local capabilities request returns the layer name without a prefix in the xml capabilities document.

Exemple :

http://localhost:8080/geoserver/myws/wms?service=wms&request=getcapabilities
- before :
  
  ```
  <name>myws:layer1</name>
  ```
- now
  
  ```
  <name>layer1</name>
  ```

So i you have a prefixed layername in your WMC (for example a layer coming from Goenetwork), then the hydrateLayer method will send an error message because it can't find the prefixed layer name in the capabilities (because in the local capabilities, the layername has no prefix).
