### PR TITLE
Mousescroll on map bug fix

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_map.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_map.js
@@ -70,6 +70,7 @@ GEOR.map = (function() {
      */
     var createMainBaseLayer = function() {
         
+        // Grid of blank images of 1024x1024
         return new OpenLayers.Layer.Grid("base_layer", '', null, {
             singleTile: false,
             displayInLayerSwitcher: false,


### PR DESCRIPTION
If you mouse scroll on a map without any visible layer, then the map doesn't zoom in/out.

This is a bug in OL.
We hack this by using a OpenLayers.Layer.Grid instead of a OpenLayers.Layer for the fake background layer. This way, there is always a visible blank layer, so the mouse scroll works.
