### PR TITLE
mapfishapp - add TAB  format as Zip in the message

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/es.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/es.js
@@ -129,7 +129,7 @@ OpenLayers.Lang.es = OpenLayers.Util.extend(OpenLayers.Lang.es, {
     "The allowed formats are the following: ":
         "Los formatos aceptados son los siguientes: ",
     "Use ZIP compression for multifiles formats, such as SHP or MIF/MID.":
-        "Usar compresión ZIP para los formatos multiarchivos, como SHP o MIF/MID.",
+        "Usar compresión ZIP para los formatos multiarchivos, como SHP, MIF/MID o TAB.",
     /* GEOR_geonames.js strings */
     /* GEOR_getfeatureinfo.js strings */
     "<div>Searching...</div>": "<div>Buscando...</div>",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/fr.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/fr.js
@@ -124,7 +124,7 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
     "The service is inactive": "Le service est inactif",
     "Upload a vector data file.": "Uploadez un fichier de données vectorielles.",
     "The allowed formats are the following: ": "Les formats acceptés sont les suivants : ",
-    "Use ZIP compression for multifiles formats, such as SHP or MIF/MID.": "Utilisez la compression ZIP pour les formats multi-fichiers comme SHP ou MIF/MID.",
+    "Use ZIP compression for multifiles formats, such as SHP or MIF/MID.": "Utilisez la compression ZIP pour les formats multi-fichiers comme SHP, MIF/MID ou TAB.",
     /* GEOR_geonames.js strings */
     /* GEOR_getfeatureinfo.js strings */
     "<div>Searching...</div>": "<div>Recherche en cours...</div>",


### PR DESCRIPTION
The message in the "Fichier" tab say:
"Les formats acceptés sont les suivants : KML, MIF, GML, SHP, TAB.
Utilisez la compression ZIP pour les formats multi-fichiers comme SHP ou MIF/MID."

TAB is miti fiile too, so it should be in ZIP. 
