### PR TITLE
ldapadmin - scrollbar in left pane 

### DIFF
--- a/ldapadmin/src/main/webapp/privateui/css/main.css
+++ b/ldapadmin/src/main/webapp/privateui/css/main.css
@@ -1,10 +1,27 @@
-.sidebar {
-  margin-top: 20px;
+#container {
+  bottom: 0;
+  width: 100%;
+  top: 90px;
+  position: absolute;
+  margin: 0;
+  padding: 0;
 }
-.sidebar a {
+#container>.row-fluid {
+  height: 100%;
+}
+#content {
+  height: 100%;
+  position: relative;
+}
+#sidebar {
+  padding: 10px;
+  overflow: auto;
+  height: 100%;
+}
+#sidebar a {
   color: black;
 }
-.sidebar a.active {
+#sidebar a.active {
   font-weight: bold;
   color: #08c;
 }
@@ -15,15 +32,35 @@
   display: block;
 }
 
+#users {
+  width: 100%;
+  margin-bottom: 20px;
+  position: absolute;
+  top: 76px;
+  bottom: 0;
+  overflow: auto;
+  z-index: 0;
+}
+
+#users .table td {
+  border-top: 0;
+  border-bottom: 1px solid #ddd;
+}
+
 .toolbar {
-  margin-top: 10px;
-  margin-bottom: 10px;
   height: 30px;
   line-height: 20px;
+  padding-bottom: 4px;
+  padding-top: 4px;
 }
 .toolbar .checkbox-wrap {
   padding: 4px 20px 4px 4px;
   display: inline-block;
+}
+.toolbar.shadow {
+  box-shadow: 0 10px 10px -10px grey;
+  position: relative;
+  z-index: 1;
 }
 .groups li a i {
   display: inline-block;

--- a/ldapadmin/src/main/webapp/privateui/index.html
+++ b/ldapadmin/src/main/webapp/privateui/index.html
@@ -19,7 +19,7 @@
         };
     </script>
 
-    <div class="container-fluid" ng-controller="UsersCtrl">
+    <div id="container" class="container-fluid" ng-controller="UsersCtrl">
       <!-- Subscribe to success flash messages. -->
       <div flash-alert="success" active-class="in" class="alert hide">
         <span class="alert-message">{{flash.message}}</span>
@@ -31,7 +31,7 @@
       </div>
 
       <div class="row-fluid">
-        <div class="span3 sidebar">
+        <div id="sidebar" class="span3">
           <!--Sidebar content-->
           <i class="icon-blank"></i>
           <a href="#/" ng-class="{active: selectedGroup == null}">
@@ -72,7 +72,7 @@
             New group
           </a>
         </div>
-        <div class="span9" ng-view>
+        <div id="content" class="span9" ng-view>
         <!--Body content-->
         </div>
       </div>

--- a/ldapadmin/src/main/webapp/privateui/partials/users-list.html
+++ b/ldapadmin/src/main/webapp/privateui/partials/users-list.html
@@ -12,7 +12,7 @@
     </ul>
   </div>
 </div>
-<div class="toolbar">
+<div class="toolbar shadow">
   <div class="checkbox-wrap">
     <input id="checkAll" type="checkbox" ldapadmin-check-all="!allSelected && selectedUsers().length" ng-change="selectAll()" ng-model="allSelected"/>
   </div>
@@ -28,10 +28,12 @@
 <div ng-hide="!selectedGroup || selectedGroup.users.length">
   There are no users in this group.
 </div>
-<table class="users table table-striped table-hover table-condensed">
-  <tr ng-repeat="user in users | filter:groupFilter | orderBy:'givenName'" class="">
-    <td><input type="checkbox" ng-model="user.selected" /></td>
-    <td><a href="#/users/{{user.uid}}">{{user.sn}} {{user.givenName}}</a></td>
-    <td>{{user.o}}</td>
-  </tr>
-</table>
+<div id="users">
+  <table class="users table table-striped table-hover table-condensed">
+    <tr ng-repeat="user in users | filter:groupFilter | orderBy:'givenName'" class="">
+      <td><input type="checkbox" ng-model="user.selected" /></td>
+      <td><a href="#/users/{{user.uid}}">{{user.sn}} {{user.givenName}}</a></td>
+      <td>{{user.o}}</td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
When there are too many LDAP groups to display in one group (eg: EL_\* on dev.pigma.org), the user has to scroll down the whole screen.

Expected: have a scrollbar for the left pane when required.
