### PR TITLE
mapfishapp-upload geofile- improve the memory handle related with the feature collection response.

### DIFF
--- a/mapfishapp/src/main/filtered-resources/WEB-INF/ws-servlet.xml
+++ b/mapfishapp/src/main/filtered-resources/WEB-INF/ws-servlet.xml
@@ -19,6 +19,10 @@
                   org.georchestra.mapfishapp.ws.UpLoadGeoFileController -->
             <value>8589934592</value> 
         </property>
+        <property name="MaxInMemorySize">
+            <!--  default value 10240 bytes -->
+            <value>10240</value> 
+        </property>
     </bean>
 
     <bean class="org.georchestra.mapfishapp.ws.UpLoadGeoFileController">

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/UpLoadGeoFileController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/UpLoadGeoFileController.java
@@ -6,6 +6,8 @@ package org.georchestra.mapfishapp.ws;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -76,6 +79,8 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 	
 	private static final Log LOG = LogFactory.getLog(UpLoadGeoFileController.class.getPackage().getName());
 	
+	private static final int MEGABYTE = 1048576;
+
 	/**
 	 * Status of the upload process
 	 * 
@@ -86,9 +91,14 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 		ok{
 			@Override
 			public String getMessage( final String jsonFeatures){
-				return "{\"success\": \"true\", \"geojson\":" + jsonFeatures+"}"; 
+				return "{\"success\": \"true\", \"geojson\": }"; 
 			}
 			
+		},
+		outOfMemoryError{
+			
+			@Override
+			public String getMessage( final String detail){return "{\"success\":false, \"msg\": \"out of memory"+ detail + "\"}"; }
 		},
 		ioError{
 			@Override
@@ -132,7 +142,7 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 		 * 
 		 * @return JSON string
 		 */
-		public abstract String getMessage( final String detail);
+		public abstract String getMessage( final String detail );
 		
 		public  String getMessage(){ return getMessage("");};
 		
@@ -282,7 +292,7 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 			
 			// validate the format
 			if( ! currentFile.isValidFormat() ) {
-				writeResponse(response, Status.unsupportedFormat);
+				writeErrorResponse(response, Status.unsupportedFormat);
 				return;
 			}
 			// validate the size
@@ -292,7 +302,7 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 				long size = limit / 1048576; // converts to Mb
 				final String msg = Status.sizeError.getMessage( size + "MB");
 				
-				writeResponse(response, Status.sizeError, msg);
+				writeErrorResponse(response, Status.sizeError, msg, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
 				return;
 			}
 			
@@ -309,7 +319,7 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 
 				st  = checkGeoFiles(fileManagement);
 				if( st != Status.ok ){
-					writeResponse(response, st);
+					writeErrorResponse(response, st);
 					return;
 				}
 			}
@@ -317,9 +327,9 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 			// create a CRS object from the srs parameter
 			CoordinateReferenceSystem crs = null;
 			try {
-				String srsParam = request.getParameter("srs");
-				if( (srsParam != null) && (srsParam.length() > 0) ){
-					crs = CRS.decode(srsParam);
+				final String crsParam = request.getParameter("srs");
+				if( (crsParam != null) && (crsParam.length() > 0) ){
+					crs = CRS.decode(crsParam);
 				}
 			} catch (NoSuchAuthorityCodeException e) {
 				LOG.error(e.getMessage());
@@ -329,12 +339,8 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 				throw new IOException(e);
 			}
 			
-			// encode the feature collection as json string
-			String jsonFeatureCollection = (crs != null) 
-						?this.fileManagement.getFeatureCollectionAsJSON(crs)
-						:this.fileManagement.getFeatureCollectionAsJSON();
-
-			writeResponse(response, Status.ok, jsonFeatureCollection);
+			// retrieves the feature collection and write the response
+			writeOKResponse(response, this.fileManagement, crs);
 		
 		} catch (IOException e) {
 			LOG.error(e);
@@ -343,6 +349,131 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 			if(workDirectory!= null) cleanTemporalDirectory(workDirectory);
 		}
 	}
+	
+	/**
+	 * Write the features in the response object.
+	 * <p>
+	 * The output to build is like to
+	 * 
+	 * "{\"success\": \"true\", \"geojson\":" + jsonFeatures+"}"
+	 * </p> 
+	 * 
+	 * @param response
+	 * @param fileMnagement
+	 * @param crs
+	 * 
+	 * @throws IOException
+	 */
+	private void writeOKResponse( final HttpServletResponse response, final UpLoadFileManagement fileMnagement, final CoordinateReferenceSystem crs) throws IOException {
+		
+		response.setCharacterEncoding(responseCharset);
+		response.setContentType("text/html");
+		response.setStatus(HttpServletResponse.SC_OK);
+
+		PrintWriter out = response.getWriter();
+		try {
+
+			// builds the following response: "{\"success\": \"true\", \"geojson\":" + jsonFeatures+"}");
+			out.print("{\"success\": \"true\", \"geojson\":");
+			
+			fileManagement.writeFeatureCollectionAsJSON(out, crs);
+			
+			out.println("}");
+
+			out.flush();
+
+			if(LOG.isDebugEnabled()){
+				LOG.debug("RESPONSE: OK");
+			}
+			
+		} catch(OutOfMemoryError e){
+			
+			writeErrorResponse(response, Status.outOfMemoryError, buildOutOfMemoryErrorMessage(), HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+		
+		} catch (IOException e) {
+			
+			writeErrorResponse(response, Status.ioError, e.getMessage(), HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+			
+		} finally {
+
+			if(out != null) out.close();
+		}
+	}
+	
+
+	/**
+	 * Writes in the response object the message taking into account the process {@link Status}.
+	 * Additionally the working directory is removed.
+	 * 
+	 * @param response
+	 * @param st
+	 * @param errorDetail 
+	 * @param responseStatusError 
+	 * 
+	 * @throws IOException
+	 */
+	private void writeErrorResponse( HttpServletResponse response, final Status st, final String errorDetail, final int responseStatusError)  {
+		response.reset();
+		PrintWriter out = null;
+		try {
+			out = response.getWriter();
+			response.setCharacterEncoding(responseCharset);
+			response.setContentType("text/html");
+			response.setStatus(responseStatusError);
+
+			String statusMsg;
+			if("".equals(errorDetail)){
+				statusMsg = st.getMessage();
+			} else {
+				statusMsg = st.getMessage(errorDetail);
+			}
+			out.println(statusMsg);
+			out.flush();			
+
+			if(LOG.isDebugEnabled()){
+				LOG.debug("RESPONSE:" + statusMsg);
+			}
+			
+		} catch (IOException e) {
+			
+			LOG.error(e.getMessage());
+			
+        } finally {
+
+			if(out != null) out.close();
+		}
+	}
+
+	/**
+	 * writes the response using the information provided as parameter
+	 * 
+	 *  
+	 * @param response
+	 * @param st
+	 * @param workDirectory
+	 * @throws IOException
+	 */
+	private void writeErrorResponse( HttpServletResponse response, final Status st) throws IOException {
+		
+		writeErrorResponse(response, st, "", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+	}
+
+
+	/**
+	 * Builds the out of memory Error
+	 * @return out of memory error message
+	 */
+	private String buildOutOfMemoryErrorMessage() {
+
+		MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+		final long max = memoryMXBean.getHeapMemoryUsage().getMax() / MEGABYTE;
+		final long used = memoryMXBean.getHeapMemoryUsage().getUsed() / MEGABYTE;
+		final String msg = Status.outOfMemoryError.getMessage("There is not enough memory. Maximum = " + max + "Mb, Used = " + used + " Mb.");
+		
+		LOG.error(msg);
+		
+	    return msg;
+    }
 
 	/**
 	 * Handles the exception throws by the {@link CommonsMultipartResolver}. A response error will be made if the size of the uploaded file 
@@ -351,23 +482,21 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 	@Override
 	public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception exception) {
 
-		try {
+			LOG.error(exception.getMessage());
+
 			if (exception instanceof MaxUploadSizeExceededException) {
 
 				MaxUploadSizeExceededException sizeException = (MaxUploadSizeExceededException) exception;
-				long size = sizeException.getMaxUploadSize() / 1048576; // converts to Mb
-				writeResponse(
+				long size = sizeException.getMaxUploadSize() / MEGABYTE; // converts to Mb
+				writeErrorResponse(
 				        response,
 				        Status.sizeError,
-				        "The configured maximum size is " + size + " MB. ("+sizeException.getMaxUploadSize()+" bytes)");
+				        "The configured maximum size is " + size + " MB. ("+sizeException.getMaxUploadSize()+" bytes)", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			} else {
 
-				writeResponse(response, Status.ioError, exception.getMessage());
+				writeErrorResponse(response, Status.ioError, exception.getMessage(), HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			}
-		} catch (IOException e) {
-			LOG.error(e);
-		}
-		
+			
 		return null ;
 	}
 	
@@ -406,54 +535,6 @@ public final class UpLoadGeoFileController implements HandlerExceptionResolver {
 		}
 	}
 
-
-	/**
-	 * Writes in the response object the message taking into account the process {@link Status}.
-	 * Additionally the working directory is removed.
-	 * 
-	 * @param response
-	 * @param st
-	 * @param errorDetail 
-	 * 
-	 * @throws IOException
-	 */
-	private void writeResponse( HttpServletResponse response, final Status st, final String errorDetail) throws IOException {
-		PrintWriter out = null;
-		try {
-			out = response.getWriter();
-			response.setCharacterEncoding(responseCharset);
-			response.setContentType("text/html");
-
-			String statusMsg;
-			if("".equals(errorDetail)){
-				statusMsg = st.getMessage();
-			} else {
-				statusMsg = st.getMessage(errorDetail);
-			}
-			out.println(statusMsg);
-			if(LOG.isDebugEnabled()){
-				LOG.debug("RESPONSE:" + statusMsg);
-			} 
-
-		} finally {
-
-			if(out != null) out.close();
-		}
-	}
-
-	/**
-	 * writes the response using the information provided as parameter
-	 * 
-	 *  
-	 * @param response
-	 * @param st
-	 * @param workDirectory
-	 * @throws IOException
-	 */
-	private void writeResponse( HttpServletResponse response, final Status st) throws IOException {
-		
-		writeResponse(response, st, "");
-	}
 
 	/**
 	 * Creates a work directory for this request. An 

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/FeatureJSON2.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/FeatureJSON2.java
@@ -253,36 +253,6 @@ final class FeatureJSON2 extends FeatureJSON {
     public SimpleFeature readFeature(InputStream input) throws IOException {
         return readFeature((Object)input);
     }
-//
-//    /**
-//     * Writes a feature collection as GeoJSON.
-//     * 
-//     * @param features The feature collection.
-//     * @param output The output. See {@link GeoJSONUtil#toWriter(Object)} for details.
-//     */
-//    public void writeFeatureCollection(FeatureCollection features, Object output) throws IOException {
-//        LinkedHashMap obj = new LinkedHashMap();
-//        obj.put("type", "FeatureCollection");
-//        if (encodeFeatureCollectionBounds || encodeFeatureCollectionCRS) {
-//            final ReferencedEnvelope bounds = features.getBounds();
-//            
-//            if (encodeFeatureCollectionBounds) {
-//                obj.put("bbox", new JSONStreamAware() {
-//                    public void writeJSONString(Writer out) throws IOException {
-//                        JSONArray.writeJSONString(Arrays.asList(bounds.getMinX(),
-//                                bounds.getMinY(),bounds.getMaxX(),bounds.getMaxY()), out);
-//                    }
-//                });
-//            }
-//            
-//            if (encodeFeatureCollectionCRS) {
-//                obj.put("crs", createCRS(bounds.getCoordinateReferenceSystem()));
-//            }
-//        }
-//        obj.put("features", new FeatureCollectionEncoder(features, gjson));
-//        GeoJSONUtil.encode(obj, output);
-//    }
-    //
   /**
    * REDEFINED
    * Writes a feature collection as GeoJSON.

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagement.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagement.java
@@ -8,7 +8,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -326,21 +326,19 @@ public class UpLoadFileManagement {
 	 *		assumed EPSG:4326 for all gpx files
 	 *</pre>
 	 *
+	 * @param 	writer where the featrue must be written.
 	 * @param 	crs if it is not null the features should be transformed to this {@link CoordinateReferenceSystem}, 
 	 * 			in other case they won't transformed.
 	 * 
-	 * @return 	feature array with the following syntax: "[f1,f2,...fN]"
 	 * @throws 	IOException 
 	 */
-	public String getFeatureCollectionAsJSON(final CoordinateReferenceSystem crs) throws IOException {
+	public void writeFeatureCollectionAsJSON(Writer writer, final CoordinateReferenceSystem crs ) throws IOException {
 		
 			if(LOG.isDebugEnabled()){
 				LOG.debug("CRS to reproject:"+  crs);
 			}
 		
-			// retrieves the feature from file system
-			String jsonResult = "";
-		
+			// retrieves the feature collection from file system and writes the correspondent json string  
 	        String fileName = searchGeoFile();
 	        assert fileName != null; 
 	        
@@ -357,11 +355,8 @@ public class UpLoadFileManagement {
 	        	fjson.setEncodeFeatureCollectionCRS(true); 
 	        	//fjson.setEncodeFeatureCRS(true); it is not necessary right now.
 	        	
-	        	StringWriter writer = new StringWriter();
 	        	fjson.writeFeatureCollection(featureCollection, writer);
 	        	
-				jsonResult = writer.toString();
-				
 			} catch (Exception e) {
 				final String message = "Failed reading " + fileName + ".  " + e.getMessage();
 				LOG.error(message);
@@ -369,7 +364,6 @@ public class UpLoadFileManagement {
 			}finally{
 	        	if(featuresIterator != null) featuresIterator.close();
 	        }
-	        return jsonResult;
 	}
 
     
@@ -395,18 +389,6 @@ public class UpLoadFileManagement {
 		}
 
 		return decimals;
-	}
-
-	/**
-	 * Convenient method. 
-	 * 
-	 * @return 	feature array with the following syntax: "[f1,f2,...fN]"
-	 * @throws IOException
-	 * 
-	 * @see {@link #getFeatureCollectionAsJSON(CoordinateReferenceSystem)
-	 */
-	public String getFeatureCollectionAsJSON() throws IOException {
-		return getFeatureCollectionAsJSON(null);
 	}
 
 

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagementGTImplTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagementGTImplTest.java
@@ -3,16 +3,18 @@
  */
 package org.georchestra.mapfishapp.ws.upload;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.net.URL;
 
 import org.apache.commons.io.FilenameUtils;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.geojson.feature.FeatureJSON;
 import org.geotools.referencing.CRS;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 
@@ -252,13 +254,13 @@ public class UpLoadFileManagementGTImplTest {
 		fm.setWorkDirectory(FilenameUtils.getFullPath(fileName));
 		fm.setFileDescriptor(fd);
 		
-		String json;
+		StringWriter out = new StringWriter();
 		if(epsg != null){
-			json = fm.getFeatureCollectionAsJSON(CRS.decode(epsg));
+			fm.writeFeatureCollectionAsJSON(out, CRS.decode(epsg));
 		} else{
-			json = fm.getFeatureCollectionAsJSON();
+			fm.writeFeatureCollectionAsJSON(out, null);
 		}
-		return  json;
+		return  out.toString();
 	}
 	
 	/**


### PR DESCRIPTION
The following error was thrown building the string to set the response. 

```
2013-09-24 15:41:33 DispatcherServlet [DEBUG] Could not complete request
org.springframework.web.util.NestedServletException: Handler processing failed; nested exception is java.lang.OutOfMemoryError: Java heap space
```

It is necessary to improve in order to manage bigger json string. In this improvement the json features are written in the response object when they are extracted from the collection. 

Additionally, it is included the MaxInMemorySize property  in the CommonsMultipartResolver, thus the upload file manager can check the memory limits 

```
<bean id="multipartResolver"
class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
        <property name="MaxInMemorySize">
            <!--  default value 10240 bytes -->
            <value>10240</value> 
        </property>
</bean>
```
