### PR TITLE
Redirection of /ldapadmin depending on roles

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/HomeController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/HomeController.java
@@ -3,10 +3,17 @@
  */
 package org.georchestra.ldapadmin.ws;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.ldapadmin.Configuration;
 import org.georchestra.ldapadmin.bs.ExpiredTokenManagement;
-import org.georchestra.ldapadmin.ds.UserTokenDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,13 +31,39 @@ public class HomeController {
 	private static final Log LOG = LogFactory.getLog(HomeController.class.getName());
 	private ExpiredTokenManagement tokenManagement;
 	
+	private Configuration config;
+	
 	@Autowired
-	public HomeController(ExpiredTokenManagement tokenManagment) {
+	public HomeController(ExpiredTokenManagement tokenManagment, Configuration cfg) {
 		if(LOG.isDebugEnabled()){
 			LOG.debug("home controller initialization");
 		}
+		this.config = cfg;
+		
 		this.tokenManagement = tokenManagment;
 		this.tokenManagement.start();
 	}
 	
+	@RequestMapping(value={"/privateui","/"})
+	public void root(HttpServletRequest request, HttpServletResponse response) throws IOException{
+		
+		String roles = request.getHeader("sec-roles");
+		
+		if(roles != null && !roles.equals("ROLE_ANONYMOUS")) {
+			String redirectUrl;
+			List<String> rolesList = Arrays.asList(roles.split(","));
+			
+			if(rolesList.contains("MOD_LDAPADMIN")) {
+				redirectUrl = "/privateui/index.html";
+			}
+			else {
+				redirectUrl = "/account/userdetails";
+			}
+			if(LOG.isDebugEnabled()){
+				LOG.debug("root page request -> redirection to " +
+						config.getPasswordRecoveryContext() + redirectUrl);
+			}
+			response.sendRedirect(config.getPasswordRecoveryContext() + redirectUrl);
+		}
+	}
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/edituserdetails/EditUserDetailsFormController.java
@@ -4,29 +4,23 @@
 package org.georchestra.ldapadmin.ws.edituserdetails;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.georchestra.ldapadmin.ds.AccountDao;
 import org.georchestra.ldapadmin.ds.DataServiceException;
 import org.georchestra.ldapadmin.ds.DuplicatedEmailException;
 import org.georchestra.ldapadmin.dto.Account;
-import org.georchestra.ldapadmin.dto.AccountFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
-import org.springframework.web.context.request.RequestScope;
 
 /**
  * Support for the Edit Account user interactions.
@@ -58,7 +52,6 @@ public class EditUserDetailsFormController {
 	/**
 	 * Retrieves the account data and sets the model before presenting the edit form view.
 	 * 
-	 * @param uid
 	 * @param model
 	 * 
 	 * @return the edit form view
@@ -66,18 +59,15 @@ public class EditUserDetailsFormController {
 	 * @throws IOException
 	 */
 	@RequestMapping(value="/account/userdetails", method=RequestMethod.GET)
-	public String setupForm(HttpServletRequest request, @RequestParam("uid") String uid,  Model model) throws IOException{
-		try {
-			if(!request.getHeader("sec-username").equals(uid)){
-				return "forbidden";
-			}
-		} catch (NullPointerException e) {
+	public String setupForm(HttpServletRequest request,  Model model) throws IOException{
+		
+		if(request.getHeader("sec-username") == null){
 			return "forbidden";
 		}
 
 		try {
 			
-			this.accountBackup = this.accountDao.findByUID(uid);
+			this.accountBackup = this.accountDao.findByUID(request.getHeader("sec-username"));
 			
 			EditUserDetailsFormBean formBean = createForm(this.accountBackup);
 


### PR DESCRIPTION
Fix https://github.com/georchestra/georchestra/issues/270

/ldapadmin/ is redirected to :
- /privateui/index.html if user is MOD_LDAPADMIN
- /account/userdetails if user is connected but not MOD_LDAPADMIN
- nowhere if not connected

Also fix https://github.com/georchestra/georchestra/issues/333
