### PR TITLE
static - maintain the existing URI parameters when add "login" - fixes #175

### DIFF
--- a/static/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/static/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -228,7 +228,11 @@ if(sec_roles != null) {
                 if (/\/cas\//.test(url)) {
                     a.href = "/cas/login";
                 } else {
-                    a.href = url.split('?')[0] + "?login";
+                    /* Taken from https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Util.js#L557 */
+                    var paramStr="login", parts = (url + " ").split(/[?&]/);
+                    a.href = url + (parts.pop() === " " ?
+                        paramStr :
+                        parts.length ? "&" + paramStr : "?" + paramStr);
                 }
             }
 


### PR DESCRIPTION
This now manage the following possible URI:
- mapfishapp/
- mapfishapp/?

that will give mapfishapp/?login, and
- mapfishapp/?lang=fr
- mapfishapp/?lang=fr&

that will give mapfishapp/?lang=fr&login

Taken from OpenLayers urlAppend function
