### PR TITLE
proxy - fix for buggy charset detection

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -832,16 +832,27 @@ public class Proxy {
                             // that the request cannot be fulfilled, nothing good would happen otherwise
                         } 
                         if(charset == null) {
+                            String guessedCharset = null;
                             if(logger.isDebugEnabled()) {
-                                logger.debug("unable to find charset so using default:"+defaultCharset);
+                                logger.debug("unable to find charset so using the first one from the accept-charset request header");
                             }
                             String calculateDefaultCharset = calculateDefaultCharset(orignalRequest);
-                            if (calculateDefaultCharset !=null ) { 
-                                String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + calculateDefaultCharset;
-                                finalResponse.setHeader("Content-Type", adjustedContentType);
-                                first = false; // we found the encoding, don't try to do it again
-                                finalResponse.setCharacterEncoding(calculateDefaultCharset);
+                            if (calculateDefaultCharset !=null ) {
+                                guessedCharset = calculateDefaultCharset;
+                                if(logger.isDebugEnabled()) {
+                                    logger.debug("hopefully the server responded with this charset: "+calculateDefaultCharset);
+                                }
+                            } else {
+                                guessedCharset = defaultCharset;
+                                if(logger.isDebugEnabled()) {
+                                    logger.debug("unable to find charset, so using default:"+defaultCharset);
+                                }
                             }
+                            String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + guessedCharset;
+                            finalResponse.setHeader("Content-Type", adjustedContentType);
+                            first = false; // we found the encoding, don't try to do it again
+                            finalResponse.setCharacterEncoding(guessedCharset);
+
                         } else {
                             if(logger.isDebugEnabled()) {
                                 logger.debug("found charset: "+charset);
@@ -853,7 +864,7 @@ public class Proxy {
                         }
                     }
                 }
-                
+
                 // for everyone, the stream is just forwarded to the client
                 streamToClient.write(buf, 0, len);
             }
@@ -874,7 +885,7 @@ public class Proxy {
     private String calculateDefaultCharset(HttpServletRequest originalRequest) {
         String acceptCharset = originalRequest.getHeader("accept-charset");
         
-        String calculatedCharset = "ISO-8859-1";
+        String calculatedCharset = null;
         
         if(acceptCharset !=null) {
             calculatedCharset = acceptCharset.split(",")[0];


### PR DESCRIPTION
When querying the following WFS service http://geo.somme.fr/arcgis/services/ENS_CANTON_COLLEGE/MapServer/WFSServer, the response content-type is `text/xml` without charset.

IE requires that the charset is set, so the geOrchestra proxy tries to guess it 1) from the response XML 2) from the accept-charset request header.

In the current case, the response XML does not contain charset information, and there is no accept-charset request header => the local "default" is used, which happened to be ISO-8859-1 (in the calculateDefaultCharset method)

The current patch fixes this behavior, by returning the configured global default charset, which is UTF-8.
