### PR TITLE
proxy - always adding an extra sec-proxy header

### DIFF
--- a/catalogapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
+++ b/catalogapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
@@ -113,13 +113,14 @@ if(sec_roles != null) {
     <script type="text/javascript">
         // remove the loading element
         Ext.get("loading").remove();
-        
+
         <% 
           String proxyHost = "/proxy/?url=";
-          if(request.getContextPath().equals("/catalogapp")) {
+          if(request.getHeader("sec-proxy") == null) {
             proxyHost = "ws/ogcproxy/?url=";
           }
         %>
+
         // set proxy host
         OpenLayers.ProxyHost = '<%= proxyHost %>';
         

--- a/extractorapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
+++ b/extractorapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
@@ -133,7 +133,7 @@ window.location = "?login";
         <% 
           String proxyHost = "/proxy/?url=";
           Boolean jettyrun = false;
-          if(request.getContextPath().equals("/extractorapp")) {
+          if(request.getHeader("sec-proxy") == null) {
             proxyHost = "/extractorapp/ws/ogcproxy/?url=";
             jettyrun = true;
           }

--- a/mapfishapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
+++ b/mapfishapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
@@ -162,7 +162,7 @@ if(sec_roles != null) {
 
         <% 
           String proxyHost = "/proxy/?url=";
-          if(request.getContextPath().equals("/mapfishapp")) {
+          if(request.getHeader("sec-proxy") == null) {
             proxyHost = "ws/ogcproxy/?url=";
           }
         %>

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -78,6 +78,8 @@ public class HeadersManagementStrategy {
             String value = originalRequest.getHeader(headerName);
             addHeaderToRequestAndLog(proxyRequest, headersLog, headerName, value);
         }
+        // see https://github.com/georchestra/georchestra/issues/509:
+        addHeaderToRequestAndLog(proxyRequest, headersLog, "sec-proxy", "true");
 
         handleRequestCookies(originalRequest, proxyRequest, headersLog);
         HttpSession session = originalRequest.getSession();


### PR DESCRIPTION
3 webapps (catalogapp, extractorapp, mapfishapp) check the existence of this header and use the security proxy if present / their local ogc proxy if not.

PR for #509
