### PR TITLE
ldapadmin - Fix proposal for issue #565

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
@@ -3,7 +3,6 @@
  */
 package org.georchestra.ldapadmin.ds;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import javax.naming.Name;
@@ -270,9 +269,6 @@ public final class AccountDaoImpl implements AccountDao{
 	 */
 	private DistinguishedName buildDn(String  uid) {
 		DistinguishedName dn = new DistinguishedName();
-				
-//		dn.add("dc", "org");
-//		dn.add("dc", "georchestra");
 		dn.add("ou", "users");
 		dn.add("uid", uid);
 		

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/dto/AccountImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/dto/AccountImpl.java
@@ -32,7 +32,7 @@ class AccountImpl implements Serializable, Account, Comparable<Account>{
 
 	// user details
 	// sn, givenName, o, title, postalAddress, postalCode, registeredAddress, postOfficeBox, physicalDeliveryOfficeName
-	private String givenName; // givenName (optonal)
+	private String givenName; // givenName (optional)
 	private String title; // title
 	private String postalAddress; //postalAddress
 	private String postalCode; // postalCode

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersController.java
@@ -126,7 +126,7 @@ public class UsersController {
 	@RequestMapping(value=REQUEST_MAPPING+"/*", method=RequestMethod.GET)
 	public void findByUid( HttpServletRequest request, HttpServletResponse response) throws IOException{
 		
-		String uid = RequestUtil.getKeyFromPathVariable(request);
+		String uid = RequestUtil.getKeyFromPathVariable(request).toLowerCase();
 		
 		if(this.userRule.isProtected(uid) ){
 			
@@ -341,7 +341,7 @@ public class UsersController {
 	@RequestMapping(value=REQUEST_MAPPING+ "/*", method=RequestMethod.PUT)
 	public void update( HttpServletRequest request, HttpServletResponse response) throws IOException{
 		
-		final String uid = RequestUtil.getKeyFromPathVariable(request);
+		final String uid = RequestUtil.getKeyFromPathVariable(request).toLowerCase();
 
 		if(this.userRule.isProtected(uid) ){
 			
@@ -405,7 +405,7 @@ public class UsersController {
 	@RequestMapping(value=REQUEST_MAPPING + "/*", method=RequestMethod.DELETE)
 	public void delete( HttpServletRequest request, HttpServletResponse response) throws IOException{
 		try{
-			final String uid = RequestUtil.getKeyFromPathVariable(request);
+			final String uid = RequestUtil.getKeyFromPathVariable(request).toLowerCase();
 			
 			if(this.userRule.isProtected(uid) ){
 				

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/newaccount/NewAccountFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/newaccount/NewAccountFormController.java
@@ -138,7 +138,7 @@ public final class NewAccountFormController {
 		try {
 			
 			Account account =  AccountFactory.createBrief(
-					formBean.getUid(),
+					formBean.getUid().toLowerCase(),
 					formBean.getPassword(),
 					formBean.getFirstName(),
 					formBean.getSurname(),


### PR DESCRIPTION
Normalizes the user input so that we consider the uid is always lowercased.

Note: subject to change in a near future to allow using an other LDAP field in distinguished name, see issue #567.
