### PR TITLE
Improving GDAL/OGR handling in extractorapp

### DIFF
--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -118,6 +118,14 @@
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-imageio-ext-gdal</artifactId>
 			<version>${gt.version}</version>
+			<exclusions>
+			  <!-- This should be provided by the system because highly dependent of the compiled version 
+			       of underlying native GDAL/OGR library  -->
+			  <exclusion>
+			  	<groupId>it.geosolutions.imageio-ext</groupId>
+          		<artifactId>imageio-ext-gdal-bindings</artifactId>
+			  </exclusion>
+			</exclusions>			
 		</dependency>
 		<dependency>
 			<groupId>org.geotools.xsd</groupId>
@@ -141,6 +149,14 @@
 				<groupId>org.geotools</groupId>
 				<artifactId>gt-ogr-jni</artifactId>
 				<version>${gt.version}</version>
+				<!-- Same remark as above: this can lead to mismatch between already provided jars
+				     (native libraries loaded twice or more ...) -->
+				<exclusions>
+				  <exclusion>
+					<groupId>org.gdal</groupId>
+					<artifactId>gdal</artifactId>
+				  </exclusion>
+			    </exclusions>				
 		</dependency>
 		<dependency>
 				<groupId>org.geotools</groupId>

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/OGRFeatureWriter.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/OGRFeatureWriter.java
@@ -13,6 +13,7 @@ import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.ogr.OGRDataStore;
 import org.geotools.data.ogr.OGRDataStoreFactory;
+import org.geotools.data.ogr.jni.JniOGRDataStoreFactory;
 import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -20,32 +21,32 @@ import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.util.ProgressListener;
 
 /**
- * This writer sets the OGRDataStore that is responsible of generating the vector file in the format required. 
- * 
+ * This writer sets the OGRDataStore that is responsible of generating the vector file in the format required.
+ *
  * <p>
  * Note: this was written thinking in future extensions to support more format. Right now TAB format is my goal.
  * The extension should be very simple adding the new format and driver in the {@link FileFormat} enumerate type.
  * </p>
- * 
+ *
  * @author Mauricio Pazos
- * 
+ *
  */
 class OGRFeatureWriter implements FeatureWriterStrategy {
     private static final Log LOG = LogFactory.getLog(OGRFeatureWriter.class.getPackage().getName());
-    
+
 	/**
 	 * Maintains the set of valid formats with theirs driver descriptors associated
 	 */
-	
+
 	public  enum FileFormat{
-		
+
 		tab {
 			@Override
 			public String getDriver(){return "MapInfo File";}
-			
+
 			@Override
 			public String[] getFormatOptions(){return new String[]{};}
-		}, 
+		},
 		mif {
 
 			@Override
@@ -53,65 +54,72 @@ class OGRFeatureWriter implements FeatureWriterStrategy {
 
 			@Override
 			public String[] getFormatOptions() { return new String[]{"FORMAT=MIF"};	}
-			
-		}, 
+
+		},
 		shp {
 			@Override
 			public String getDriver(){return "ESRI shapefile";}
-			
-		}, 
+
+		},
 		kml {
 			@Override
 			public String getDriver(){return "KML file";}
-			
+
 		};
-		
+
 		/**
 		 * Returns the OGR driver for this format
 		 * @return the driver
 		 */
 		public abstract String getDriver();
-		
-		/** 
+
+		/**
 		 * Returns the options related with the indicated file format.
 		 * @return the options for the file format
 		 */
 		public String[] getFormatOptions(){return null;}
 	}
 
-	private ProgressListener progresListener;
+	private ProgressListener progressListener;
 	private final SimpleFeatureType schema;
 	private final File basedir;
 	private final SimpleFeatureCollection features;
 	private final FileFormat fileFormat;
-	private final String[] options; 
-	
+	private final String[] options;
+
 	/**
 	 * New instance of {@link OGRFeatureWriter}
-	 * 
-	 * @param progressListener 
+	 *
+	 * @param progressListener
 	 * @param schema		output schema
 	 * @param basedir		output folder
 	 * @param fileFormat 	output fileExtension
 	 * @param features		input the set of Features to write
 	 */
 	public OGRFeatureWriter(
-			ProgressListener progressListener,
+			ProgressListener _progressListener,
 			SimpleFeatureType schema,
 			File basedir,
 			FileFormat fileFormat,
 			SimpleFeatureCollection features) {
 
 		assert schema != null && basedir != null && features != null;
-		
-		this.progresListener = progresListener;
+
+		// This is needed since this class relies heavily on JniOGR
+		try {
+            Class.forName("org.geotools.data.ogr.jni.JniOGR");
+        } catch (Throwable e) {
+            LOG.info("gdal/ogr is not available in the system, some of the features won't be available.", e);
+        }
+
+		this.progressListener = _progressListener;
 		checkSchema(schema);
 		this.schema = schema;
 		this.basedir = basedir;
 		this.fileFormat = fileFormat;
-		
+
 		this.options = fileFormat.getFormatOptions();
-		
+
 		this.features = features;
 	}
 
@@ -124,12 +132,12 @@ class OGRFeatureWriter implements FeatureWriterStrategy {
 	 * @param schema
 	 */
 	private boolean checkSchema(SimpleFeatureType schema) {
-		
+
 		boolean hasGeometry = false;
 		boolean hasAttr = false;
 		boolean nameLimitOK = true;
         for (int i = 0, j = 0; i < schema.getAttributeCount(); i++) {
-        	
+
             AttributeDescriptor ad = schema.getDescriptor(i);
             if (ad == schema.getGeometryDescriptor()) {
             	hasGeometry = true;
@@ -138,7 +146,7 @@ class OGRFeatureWriter implements FeatureWriterStrategy {
             }
             if(ad.getLocalName().length() > 10){
             	nameLimitOK = false;
-            	LOG.warn("Some format requires that the properties' name have got less than 10 character. Take into account this warnning if you experiment problems." 
+            	LOG.warn("Some format requires that the properties' name have got less than 10 character. Take into account this warnning if you experiment problems."
             			+ " Schema: "+ schema.getTypeName() + " Property:" + ad.getLocalName());
             }
         }
@@ -148,42 +156,51 @@ class OGRFeatureWriter implements FeatureWriterStrategy {
         if(!hasAttr){
         	LOG.warn("The Schema " + schema.getTypeName() + "doesn't contain any alfanumeric property");
         }
-        
+
         return hasGeometry && hasAttr && nameLimitOK;
 	}
 
 
 	/**
 	 * Generate the file's vector specified
-	 * @return array {@link File} of created files 
+	 * @return array {@link File} of created files
 	 */
 	@Override
 	public File[] generateFiles() throws IOException {
-        
+
 		Map<String, Serializable> map = new java.util.HashMap<String, Serializable>();
-		
+
         final String pathName = this.basedir.getAbsolutePath() + File.separatorChar + FileUtils.createFileName(this.basedir.getAbsolutePath(), this.schema, this.fileFormat);
 		map.put(OGRDataStoreFactory.OGR_NAME.key, pathName);
 		map.put(OGRDataStoreFactory.OGR_DRIVER_NAME.key, this.fileFormat.getDriver());
-		
+
 		File[] files = new File[]{};
         OGRDataStore ds = null;
         try {
             ds = (OGRDataStore) DataStoreFinder.getDataStore(map);
-            
+
+        	// Sometimes, GeoTools is unable to enumerate the OGR Datastore
+        	// Hence it cannot be resolved. Let's try to construct a one
+        	// by hand.
+            if (ds == null) {
+            	OGRDataStoreFactory f = new JniOGRDataStoreFactory();
+            	ds = (OGRDataStore) f.createDataStore(map);
+            }
 	        ds.createSchema(this.features, true, this.options); //TODO OGR require the following improvements:  use the output crs required (progress Listener should be a parameter)
 
 	        files =  new File[]{new File( pathName)};
-	        
+
         } catch (NullPointerException e) {
         	LOG.error("OGRDataStore couldn't be created, please check GDAL librairies are correctly installed on your machine");
         	throw e;
+        } catch (Exception e) {
+        	LOG.error(e);
         }
         finally {
             if(ds != null){
             	ds.dispose();
             }
-        }		
+        }
         return files;
 	}
 
@@ -193,9 +210,9 @@ class OGRFeatureWriter implements FeatureWriterStrategy {
         if(!basedir.exists()){
             ds.createSchema(this.schema);
         }
-        
+
         return ds;
-		
+
 	}
 
 }


### PR DESCRIPTION
- Check if native libs are available at bean instantiation
- Excluding some redundant jars at build time: having the gdal/ogr
  bindings twice could lead to version mismatches. In addition, we should use the
  generated bindings coming with the targeted native libs.
- Better logging if unavailable libs.

TODO:
- Propagate the modifications to other concerned webapps (mapfishapp,
  geoserver).

<!---
@huboard:{"order":589.53125}
-->
