### PR TITLE
Change security-proxy so that sec-username and sec-roles always are removed

### DIFF
--- a/config/defaults/extractorapp/WEB-INF/classes/log4j.properties
+++ b/config/defaults/extractorapp/WEB-INF/classes/log4j.properties
@@ -16,7 +16,7 @@
 #------------------------------------------------------------------------------
 log4j.rootLogger=@shared.default.log.level@, R
 
-log4j.logger.extractorapp=@shared.default.log.level@, R
+log4j.logger.org.georchestra.extractorapp=@shared.default.log.level@, R
 log4j.logger.org.geotools=@other.framework.log.level@, R
 
 log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender

--- a/config/defaults/security-proxy/maven.filter
+++ b/config/defaults/security-proxy/maven.filter
@@ -45,3 +45,6 @@ psql.db=@shared.psql.checkhealth.db@
 psql.user=@shared.psql.user@
 psql.pass=@shared.psql.pass@
 max.database.connections=@shared.checkhealth.max_db_connections@
+
+privileged_admin_name=@shared.privileged.geoserver.user@
+

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.1.2</version>
+			<version>4.3.3</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
@@ -1,18 +1,27 @@
 package org.georchestra.extractorapp.ws.extractor;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryCollection;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFactorySpi;
@@ -36,16 +45,15 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 import org.opengis.util.ProgressListener;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Obtains data from a WFS and write the data out to the filesystem
@@ -134,18 +142,35 @@ public class WfsExtractor {
         URL capabilitiesURL = request.capabilitiesURL("WFS", "1.0.0");
 
     	DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpClientContext localContext = HttpClientContext.create();
+        final HttpHost httpHost = new HttpHost(capabilitiesURL.getHost(), capabilitiesURL.getPort());
     	HttpGet get = new HttpGet(capabilitiesURL.toExternalForm());
         if(secureHost.equalsIgnoreCase(request._url.getHost())
                 || "127.0.0.1".equalsIgnoreCase(request._url.getHost())
                 || "localhost".equalsIgnoreCase(request._url.getHost())) {
         	LOG.debug("WfsExtractor.checkPermission - Secured Server: adding username header and role headers to request for checkPermission");
-            if(username != null) get.addHeader("sec-username", username);
-            if(roles != null) get.addHeader("sec-roles", roles);
+            if(username != null) get.addHeader("imp-username", username);
+            if(roles != null) get.addHeader("imp-roles", roles);
+
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(
+                    new AuthScope(capabilitiesURL.getHost(), capabilitiesURL.getPort()),
+                    new UsernamePasswordCredentials(_adminUsername, _adminPassword));
+            httpclient.setCredentialsProvider(credsProvider);
+
+            AuthCache authCache = new BasicAuthCache();
+            // Generate BASIC scheme object and add it to the local
+            // auth cache
+            BasicScheme basicAuth = new BasicScheme();
+            authCache.put(httpHost, basicAuth);
+
+            // Add AuthCache to the execution context
+            localContext.setAuthCache(authCache);
         } else {
         	LOG.debug("WfsExtractor.checkPermission - Non Secured Server");
         }
 
-        String capabilities = FileUtils.asString(httpclient.execute(get).getEntity().getContent());
+        String capabilities = FileUtils.asString(httpclient.execute(httpHost, get, localContext).getEntity().getContent());
         Pattern regex = Pattern.compile("(?m)<FeatureType[^>]*>(\\\\n|\\s)*<Name>\\s*(\\w*:)?"+Pattern.quote(request._layerName)+"\\s*</Name>");
         boolean permitted = regex.matcher(capabilities).find();
         

--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -60,6 +60,13 @@ ${proxy.mapping}
         <property name="headerProviders">
             <list>
                 <bean class="org.georchestra.security.SecurityRequestHeaderProvider"/>
+                <bean class="org.georchestra.security.ImpersonateUserRequestHeaderProvider">
+                    <property name="trustedUsers">
+                        <list>
+                            <value>${privileged_admin_name}</value>
+                        </list>
+                    </property>
+                </bean>
                 <bean class="org.georchestra.security.LdapUserDetailsRequestHeaderProvider">
                     <constructor-arg index="0" ref="ldapUserSearch"/>
                     <constructor-arg index="1">
@@ -72,16 +79,7 @@ ${proxy.mapping}
         </property>
         <property name="filters">
             <list>
-                <bean class="org.georchestra.security.SecurityRequestHeaderFilter">
-                    <property name="trustedHosts">
-                        <list>
-                            <value>localhost</value>
-                            <value>127.0.0.1</value>
-                            <value>127.0.1.1</value>
-                            <value>${public.host}</value>
-                        </list>
-                    </property>
-                </bean>
+                <bean class="org.georchestra.security.SecurityRequestHeaderFilter" />
             </list>
         </property>
     </bean>

--- a/security-proxy/src/main/filtered-resources/WEB-INF/security-proxy.properties
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/security-proxy.properties
@@ -56,3 +56,4 @@ psql.pass=${psql.pass}
 max.database.connections=${max.database.connections}
 
 realmName=georchestra
+

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
@@ -1,0 +1,24 @@
+package org.georchestra.security;
+
+/**
+ * A collection of header names used in the proxy.
+ *
+ * @author Jesse on 5/5/2014.
+ */
+public class HeaderNames {
+    public static final String SEC_USERNAME = "sec-username";
+    public static final String SEC_ROLES = "sec-roles";
+    public static final String REFERER_HEADER_NAME = "referer";
+    static final String IMP_ROLES = "imp-roles";
+    static final String IMP_USERNAME = "imp-username";
+    public static final String JSESSION_ID = "JSESSIONID";
+    public static final String SET_COOKIE_ID ="Set-Cookie";
+    public static final String COOKIE_ID ="Cookie";
+    public static final String CONTENT_LENGTH = "content-length";
+    public static final String ACCEPT_ENCODING = "Accept-Encoding";
+    public static final String HOST = "host";
+    public static final String SEC_PROXY = "sec-proxy";
+    public static final String LOCATION = "location";
+    public static final String TRANSFER_ENCODING = "Transfer-Encoding";
+    public static final String CHUNKED = "chunked";
+}

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
@@ -14,7 +14,7 @@ public abstract class HeaderProvider {
      * Called by {@link HeadersManagementStrategy#configureRequestHeaders(HttpServletRequest, HttpRequestBase)} to allow
      * extra headers to be added to the copied headers.
      */
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session) {
+    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
         return Collections.emptyList();
     }
 

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -18,6 +18,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import static org.georchestra.security.HeaderNames.ACCEPT_ENCODING;
+import static org.georchestra.security.HeaderNames.CONTENT_LENGTH;
+import static org.georchestra.security.HeaderNames.COOKIE_ID;
+import static org.georchestra.security.HeaderNames.HOST;
+import static org.georchestra.security.HeaderNames.LOCATION;
+import static org.georchestra.security.HeaderNames.REFERER_HEADER_NAME;
+import static org.georchestra.security.HeaderNames.SEC_PROXY;
+import static org.georchestra.security.HeaderNames.SEC_ROLES;
+import static org.georchestra.security.HeaderNames.SEC_USERNAME;
+import static org.georchestra.security.HeaderNames.TRANSFER_ENCODING;
+
 /**
  * A strategy for copying headers from the request to the proxied request and
  * the same for the response headers.
@@ -26,10 +37,6 @@ import javax.servlet.http.HttpSession;
  */
 public class HeadersManagementStrategy {
     protected static final Log logger = LogFactory.getLog(Proxy.class.getPackage().getName());
-    private static final String JSESSION_ID = "JSESSIONID";
-    private static final String SET_COOKIE_ID ="Set-Cookie";
-    private static final String COOKIE_ID ="Cookie";
-    public static final String REFERER_HEADER_NAME = "referer";
 
     /**
      * If true (default is false) AcceptEncoding headers are removed from request headers
@@ -60,7 +67,7 @@ public class HeadersManagementStrategy {
         }
         while (headerNames.hasMoreElements()) {
             headerName = headerNames.nextElement();
-            if (headerName.compareToIgnoreCase("content-length") == 0) {
+            if (headerName.compareToIgnoreCase(CONTENT_LENGTH) == 0) {
                 continue;
             }
             if (headerName.equalsIgnoreCase(COOKIE_ID)) {
@@ -69,10 +76,13 @@ public class HeadersManagementStrategy {
             if (filter(originalRequest, headerName, proxyRequest)) {
                 continue;
             }
-            if (noAcceptEncoding && headerName.equalsIgnoreCase("Accept-Encoding")) {
+            if (noAcceptEncoding && headerName.equalsIgnoreCase(ACCEPT_ENCODING)) {
                 continue;
             }
-            if (headerName.equalsIgnoreCase("host")) {
+            if (headerName.equalsIgnoreCase(HOST)) {
+                continue;
+            }
+            if (headerName.equalsIgnoreCase(SEC_USERNAME) || headerName.equalsIgnoreCase(SEC_ROLES) ) {
                 continue;
             }
             if (referer != null && headerName.equalsIgnoreCase(REFERER_HEADER_NAME)) {
@@ -82,15 +92,15 @@ public class HeadersManagementStrategy {
             addHeaderToRequestAndLog(proxyRequest, headersLog, headerName, value);
         }
         // see https://github.com/georchestra/georchestra/issues/509:
-        addHeaderToRequestAndLog(proxyRequest, headersLog, "sec-proxy", "true");
+        addHeaderToRequestAndLog(proxyRequest, headersLog, SEC_PROXY, "true");
 
         handleRequestCookies(originalRequest, proxyRequest, headersLog);
         HttpSession session = originalRequest.getSession();
 
         for (HeaderProvider provider : headerProviders) {
-            for (Header header : provider.getCustomRequestHeaders(session)) {
-                if ((header.getName().equalsIgnoreCase("sec-username") ||
-                     header.getName().equalsIgnoreCase("sec-roles")) &&
+            for (Header header : provider.getCustomRequestHeaders(session, originalRequest)) {
+                if ((header.getName().equalsIgnoreCase(SEC_USERNAME) ||
+                     header.getName().equalsIgnoreCase(SEC_ROLES)) &&
                     proxyRequest.getHeaders(header.getName()) != null &&
                     proxyRequest.getHeaders(header.getName()).length > 0) {
                     Header[] originalHeaders = proxyRequest.getHeaders(header.getName());
@@ -134,7 +144,7 @@ public class HeadersManagementStrategy {
             for(String requestCookies : value.split(";")) {
                 String trimmed = requestCookies.trim();
                 if(trimmed.length() > 0) {
-                    if(!trimmed.startsWith(JSESSION_ID)) {
+                    if(!trimmed.startsWith(HeaderNames.JSESSION_ID)) {
                         if(cookies.length() > 0) cookies.append("; ");
                         cookies.append(trimmed);
                     }
@@ -143,8 +153,8 @@ public class HeadersManagementStrategy {
         }
         HttpSession session = originalRequest.getSession();
         String requestPath = proxyRequest.getURI().getPath();
-        if(session != null && session.getAttribute(JSESSION_ID)!=null) {
-            Map<String,String> jessionIds = (Map) session.getAttribute(JSESSION_ID);
+        if(session != null && session.getAttribute(HeaderNames.JSESSION_ID)!=null) {
+            Map<String,String> jessionIds = (Map) session.getAttribute(HeaderNames.JSESSION_ID);
             String currentPath = null;
             String currentId = null;
             for (String path : jessionIds.keySet()) {
@@ -197,9 +207,9 @@ public class HeadersManagementStrategy {
         // Set Response headers
         for (Header header : proxyResponse.getAllHeaders()) {
             headersLog.append("\t");
-            if (header.getName().equalsIgnoreCase(SET_COOKIE_ID)) {
+            if (header.getName().equalsIgnoreCase(HeaderNames.SET_COOKIE_ID)) {
                 continue;
-            } else if ("location".equalsIgnoreCase(header.getName())) {
+            } else if (LOCATION.equalsIgnoreCase(header.getName())) {
 //            	DO NOTHING
 //            	Handle in Proxy.java
 //            	if (logger.isDebugEnabled()) {
@@ -228,7 +238,7 @@ public class HeadersManagementStrategy {
             }
         }
 
-        Header[] cookieHeaders = proxyResponse.getHeaders(SET_COOKIE_ID);
+        Header[] cookieHeaders = proxyResponse.getHeaders(HeaderNames.SET_COOKIE_ID);
         if(cookieHeaders!=null) {
             handleResponseCookies(originalRequestURI, finalResponse, cookieHeaders, session,headersLog);
         }
@@ -276,7 +286,7 @@ public class HeadersManagementStrategy {
     		String [] requestPath = StringUtils.split(location.substring(1), "/");
     		if (logger.isDebugEnabled()) {
     			if (requestPath.length > 0)
-    				logger.debug("Santize location: " + requestPath[0]);
+    				logger.debug("Sanitize location: " + requestPath[0]);
     		}
     		if (requestPath.length > 0 && targets.containsKey(requestPath[0])) {
     			requestPath[0] = targets.get(requestPath[0]);
@@ -298,7 +308,7 @@ public class HeadersManagementStrategy {
                 if(cookie.trim().length() == 0) {
                     continue;
                 }
-                if(cookie.trim().startsWith(JSESSION_ID)) {
+                if(cookie.trim().startsWith(HeaderNames.JSESSION_ID)) {
                     String path = "";
                     if(parts.length == 2) {
                         path = parts[1];
@@ -312,8 +322,8 @@ public class HeadersManagementStrategy {
 
             if(cookies.length() > 0) {
                 cookies.append("; Path= /" + originalPath);
-                finalResponse.addHeader(SET_COOKIE_ID, cookies.toString());
-                headersLog.append("\t" + SET_COOKIE_ID);
+                finalResponse.addHeader(HeaderNames.SET_COOKIE_ID, cookies.toString());
+                headersLog.append("\t" + HeaderNames.SET_COOKIE_ID);
                 headersLog.append("=");
                 headersLog.append(cookies);
                 headersLog.append("\n");
@@ -323,10 +333,10 @@ public class HeadersManagementStrategy {
     }
 
     private void storeJsessionHeader(HttpSession session, String path, String cookie, StringBuilder headersLog) {
-        Map<String,String> map = (Map<String, String>) session.getAttribute(JSESSION_ID);
+        Map<String,String> map = (Map<String, String>) session.getAttribute(HeaderNames.JSESSION_ID);
         if(map==null) {
             map = new HashMap<String,String>();
-            session.setAttribute(JSESSION_ID, map);
+            session.setAttribute(HeaderNames.JSESSION_ID, map);
         }
         if(path.length() > 0) {
             // clean out session IDs with longer path since this should supercede them
@@ -348,7 +358,7 @@ public class HeadersManagementStrategy {
     }
 
     private boolean defaultIgnores(Header header) {
-        boolean transferEncoding = header.getName().equalsIgnoreCase("Transfer-Encoding") && header.getValue().equalsIgnoreCase("chunked");
+        boolean transferEncoding = header.getName().equalsIgnoreCase(TRANSFER_ENCODING) && header.getValue().equalsIgnoreCase(HeaderNames.CHUNKED);
         
         return transferEncoding;
     }

--- a/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
@@ -1,0 +1,51 @@
+package org.georchestra.security;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+/**
+ * Allows certain white-listed users to impersonate other users.
+ *
+ * @author Jesse on 5/5/2014.
+ */
+public class ImpersonateUserRequestHeaderProvider extends HeaderProvider {
+    private List<String> trustedUsers = new ArrayList<String>();
+
+    @Override
+    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+        if (originalRequest.getHeader(HeaderNames.IMP_USERNAME) != null) {
+
+            Authentication authentication = SecurityContextHolder.getContext()
+                    .getAuthentication();
+
+            if (authentication != null && trustedUsers != null && trustedUsers.contains(authentication.getName())) {
+                List<Header> headers = new ArrayList<Header>(2);
+
+                headers.add(new BasicHeader(HeaderNames.SEC_USERNAME, originalRequest.getHeader(HeaderNames.IMP_USERNAME)));
+                headers.add(new BasicHeader(HeaderNames.SEC_ROLES, originalRequest.getHeader(HeaderNames.IMP_ROLES)));
+
+                return headers;
+            }
+        }
+        return Collections.emptyList();
+
+    }
+
+    /**
+     * Set the users who are allowed to impersonate other users.
+     *
+     * @param trustedUsers list of trusted users
+     */
+    public void setTrustedUsers(List<String> trustedUsers) {
+        this.trustedUsers = trustedUsers;
+    }
+}

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.Attribute;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
@@ -42,7 +43,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
 
     @SuppressWarnings("unchecked")
 	@Override
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session) {
+    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication instanceof AnonymousAuthenticationToken){
             return Collections.emptyList();

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderFilter.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderFilter.java
@@ -7,10 +7,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.HttpRequestBase;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -20,43 +16,13 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class SecurityRequestHeaderFilter implements HeaderFilter {
 	protected static transient Log log = LogFactory.getLog(SecurityRequestHeaderFilter.class);
-	
-    List<String> trustedHosts = Collections.emptyList();
+
 
     @Override
     public boolean filter(String headerName, HttpServletRequest originalRequest, HttpRequestBase proxyRequest) {
-    	try {
-	        String remoteHost = originalRequest.getRemoteHost();
-	        InetAddress remoteHostAddress =  InetAddress.getByName(remoteHost);
-	        
-	        for (String host : trustedHosts) {
-	
-	        	InetAddress hostAddress = InetAddress.getByName(host);
-	        	
-	        	if (log.isDebugEnabled()) {
-	            	log.debug("filter: headerName: " + headerName + " check remote host: " + remoteHost + " against: " + host);
-	            }
-	        	
-	        	if (remoteHostAddress.equals(hostAddress)) {
-	        		if (log.isDebugEnabled()) {
-	        			log.debug("Return false for header: " + headerName + " because host: " + remoteHost + " is trusted.");
-	        		}
-	                return false;
-	            }
-	        }
-	        //
-	        // Return false if host is not trusted and header is sensitive
-	        //
-	        return headerName.equalsIgnoreCase("sec-username") ||
-	                headerName.equalsIgnoreCase("sec-roles");
-
-    	} catch (UnknownHostException e) {
-			log.error(e);
-			throw new IllegalStateException(e.getMessage() +  ". Check the trusted host configuration.");
-		}
-    }
-
-    public void setTrustedHosts(List<String> trustedHosts) {
-        this.trustedHosts = trustedHosts;
+	        return headerName.equalsIgnoreCase(HeaderNames.SEC_USERNAME) ||
+	                headerName.equalsIgnoreCase(HeaderNames.SEC_ROLES) ||
+	                headerName.equalsIgnoreCase(HeaderNames.IMP_USERNAME) ||
+	                headerName.equalsIgnoreCase(HeaderNames.IMP_ROLES);
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
@@ -1,21 +1,21 @@
 package org.georchestra.security;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import javax.servlet.http.HttpSession;
-
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 public class SecurityRequestHeaderProvider extends HeaderProvider {
 
     @Override
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session) {
+    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
 
         Authentication authentication = SecurityContextHolder.getContext()
                 .getAuthentication();
@@ -23,14 +23,14 @@ public class SecurityRequestHeaderProvider extends HeaderProvider {
         List<Header> headers = new ArrayList<Header>();
         if (authentication.getName().equals("anonymousUser"))
              return headers;
-        headers.add(new BasicHeader("sec-username", authentication.getName()));
+        headers.add(new BasicHeader(HeaderNames.SEC_USERNAME, authentication.getName()));
         StringBuilder roles = new StringBuilder();
         for (GrantedAuthority grantedAuthority : authorities) {
             if (roles.length() != 0) roles.append(",");
 
             roles.append(grantedAuthority.getAuthority());
         }
-        headers.add(new BasicHeader("sec-roles", roles.toString()));
+        headers.add(new BasicHeader(HeaderNames.SEC_ROLES, roles.toString()));
 
         return headers;
     }

--- a/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
@@ -1,13 +1,9 @@
 package org.georchestra.security;
 
-import org.apache.http.Header;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -16,42 +12,6 @@ import static org.junit.Assert.assertTrue;
  * @author Jesse on 4/24/2014.
  */
 public class HeadersManagementStrategyTest {
-    @Test
-    public void testConfigureRequestHeaders_RemoveSecHeaders() throws Exception {
-        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
-        List<HeaderFilter> filters = createTrustLocalHostFilter();
-        headerManagement.setFilters(filters);
-
-        HttpRequestBase proxyRequest = new HttpGet("http://localhost/geonetwork");
-        MockHttpServletRequest originalRequest = createTestRequest();
-        headerManagement.configureRequestHeaders(originalRequest, proxyRequest);
-
-        assertFalse(hasHeader("sec-username", proxyRequest));
-        assertFalse(hasHeader("sec-roles", proxyRequest));
-        assertTrue(hasHeader("other_header", proxyRequest));
-    }
-
-    /**
-     * show that they are not removed when the request server is trustworthy
-     */
-    @Test
-    public void testConfigureRequestHeaders_KeepSecHeaders_WhenRequestServerIsTrusted() throws Exception {
-        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
-        List<HeaderFilter> filters = createTrustLocalHostFilter();
-        headerManagement.setFilters(filters);
-
-        HttpRequestBase proxyRequest = new HttpGet("http://localhost/geonetwork");
-        MockHttpServletRequest originalRequest = createTestRequest();
-
-        proxyRequest.setHeaders(new Header[0]);
-        originalRequest.setRemoteHost("localhost");
-        headerManagement.configureRequestHeaders(originalRequest, proxyRequest);
-
-        assertTrue(hasHeader("sec-username", proxyRequest));
-        assertTrue(hasHeader("sec-roles", proxyRequest));
-        assertTrue(hasHeader("other_header", proxyRequest));
-
-    }
 
     /**
      * Show that by default the headers are removed
@@ -67,6 +27,10 @@ public class HeadersManagementStrategyTest {
 
         assertFalse(hasHeader("sec-username", proxyRequest));
         assertFalse(hasHeader("sec-roles", proxyRequest));
+
+        assertFalse(hasHeader("imp-username", proxyRequest));
+        assertFalse(hasHeader("imp-roles", proxyRequest));
+
         assertTrue(hasHeader("other_header", proxyRequest));
     }
 
@@ -76,18 +40,10 @@ public class HeadersManagementStrategyTest {
         originalRequest.setRemoteHost("someserver.com");
         originalRequest.addHeader("sec-username", "jeichar");
         originalRequest.addHeader("sec-roles", "ROLE_SV_ADMIN");
+        originalRequest.addHeader("imp-username", "imp_user");
+        originalRequest.addHeader("imp-roles", "ROLE_SV_IMP");
         originalRequest.addHeader("other_header", "value");
         return originalRequest;
-    }
-
-    private List<HeaderFilter> createTrustLocalHostFilter() {
-        List<HeaderFilter> filters = new ArrayList<HeaderFilter>();
-        List<String> trustedHosts = new ArrayList<String>();
-        trustedHosts.add("localhost");
-        final SecurityRequestHeaderFilter filter = new SecurityRequestHeaderFilter();
-        filter.setTrustedHosts(trustedHosts);
-        filters.add(filter);
-        return filters;
     }
 
     private boolean hasHeader(String headerName, HttpRequestBase proxyRequest) {

--- a/security-proxy/src/test/java/org/georchestra/security/ImpersonateUserRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ImpersonateUserRequestHeaderProviderTest.java
@@ -1,0 +1,68 @@
+package org.georchestra.security;
+
+import org.apache.http.Header;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImpersonateUserRequestHeaderProviderTest {
+
+    @Test
+    public void testGetCustomRequestHeadersUntrustedUser() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HeaderNames.IMP_USERNAME, "imp-user");
+        request.addHeader(HeaderNames.IMP_ROLES, "ROLE_IMP");
+
+        final ImpersonateUserRequestHeaderProvider provider = new ImpersonateUserRequestHeaderProvider();
+        List<String> trustedUsers = new ArrayList<String>();
+        trustedUsers.add("jeichar");
+        provider.setTrustedUsers(trustedUsers);
+        assertEquals(0, provider.getCustomRequestHeaders(null, request).size());
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("randomUser", "random");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        assertEquals(0, provider.getCustomRequestHeaders(null, request).size());
+    }
+
+    @Test
+    public void testGetCustomRequestHeadersTrustedUser() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HeaderNames.IMP_USERNAME, "imp-user");
+        request.addHeader(HeaderNames.IMP_ROLES, "ROLE_IMP");
+
+        final ImpersonateUserRequestHeaderProvider provider = new ImpersonateUserRequestHeaderProvider();
+        List<String> trustedUsers = new ArrayList<String>();
+        trustedUsers.add("jeichar");
+        provider.setTrustedUsers(trustedUsers);
+        assertEquals(0, provider.getCustomRequestHeaders(null, request).size());
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("jeichar", "random");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        final Collection<Header> customRequestHeaders = provider.getCustomRequestHeaders(null, request);
+        assertEquals(2, customRequestHeaders.size());
+        assertContains(customRequestHeaders, HeaderNames.SEC_USERNAME, "imp-user");
+        assertContains(customRequestHeaders, HeaderNames.SEC_ROLES, "ROLE_IMP");
+    }
+
+    private void assertContains(Collection<Header> customRequestHeaders, String headerName, String expectedHeaderValue) {
+
+        for (Header header : customRequestHeaders) {
+            if (header.getName().equals(headerName)) {
+                assertEquals("Wrong value for header: " + headerName, expectedHeaderValue, header.getValue());
+                return;
+            }
+        }
+
+        throw new AssertionError("No header "+ headerName +": "+ expectedHeaderValue + " in: " + customRequestHeaders);
+    }
+
+
+}

--- a/security-proxy/src/test/java/org/georchestra/security/SecurityRequestHeaderFilterTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/SecurityRequestHeaderFilterTest.java
@@ -5,9 +5,6 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -17,49 +14,20 @@ import static org.junit.Assert.assertTrue;
 public class SecurityRequestHeaderFilterTest {
     @Test
     public void testFilterLocalhost() throws Exception {
-        List<String> trustedHosts = new ArrayList<String>();
-        trustedHosts.add("localhost");
         final SecurityRequestHeaderFilter filter = new SecurityRequestHeaderFilter();
-        filter.setTrustedHosts(trustedHosts);
         HttpRequestBase proxyRequest = new HttpGet("http://localhost/geonetwork");
 
         MockHttpServletRequest untrustWorthyServer = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        untrustWorthyServer.setRemoteHost("someServer.com");
         assertUntrustworthyServerFiltering(filter, untrustWorthyServer, proxyRequest);
 
-        MockHttpServletRequest ipV4UntrustWorthyServer = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        ipV4UntrustWorthyServer.setRemoteHost("192.8.8.2");
-        assertUntrustworthyServerFiltering(filter, ipV4UntrustWorthyServer, proxyRequest);
-
-        MockHttpServletRequest ipV6UntrustWorthyServer = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        ipV6UntrustWorthyServer.setRemoteHost("2607:f0d0:1002:51::4");
-        assertUntrustworthyServerFiltering(filter, ipV6UntrustWorthyServer, proxyRequest);
-
-        MockHttpServletRequest ipV6UntrustWorthy2Server = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        ipV6UntrustWorthy2Server.setRemoteHost("2607:f0d0:1002:0051:0000:0000:0000:0004");
-        assertUntrustworthyServerFiltering(filter, ipV6UntrustWorthy2Server, proxyRequest);
-
-        MockHttpServletRequest trustWorthyServer = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        assertTrustworthyServerFiltering(filter, proxyRequest, trustWorthyServer);
-
-        MockHttpServletRequest ipv4TrustWorthyServer = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        ipv4TrustWorthyServer.setRemoteAddr("127.0.0.1");
-        assertTrustworthyServerFiltering(filter, proxyRequest, ipv4TrustWorthyServer);
-
-        MockHttpServletRequest ipv6TrustWorthyServer = new MockHttpServletRequest("get", "http://destServer/geonetwork");
-        ipv6TrustWorthyServer.setRemoteAddr("::1");
-        assertTrustworthyServerFiltering(filter, proxyRequest, ipv6TrustWorthyServer);
     }
 
     private void assertUntrustworthyServerFiltering(SecurityRequestHeaderFilter filter, MockHttpServletRequest untrustWorthyServer, HttpRequestBase proxyRequest) {
         assertFalse(filter.filter("some-random-header", untrustWorthyServer, proxyRequest));
         assertTrue(filter.filter("sec-username", untrustWorthyServer, proxyRequest));
         assertTrue(filter.filter("sec-roles", untrustWorthyServer, proxyRequest));
+        assertTrue(filter.filter("imp-username", untrustWorthyServer, proxyRequest));
+        assertTrue(filter.filter("imp-roles", untrustWorthyServer, proxyRequest));
     }
 
-    private void assertTrustworthyServerFiltering(SecurityRequestHeaderFilter filter, HttpRequestBase proxyRequest, MockHttpServletRequest ipv4TrustWorthyServer) {
-        assertFalse(filter.filter("some-random-header", ipv4TrustWorthyServer, proxyRequest));
-        assertFalse(filter.filter("sec-username", ipv4TrustWorthyServer, proxyRequest));
-        assertFalse(filter.filter("sec-roles", ipv4TrustWorthyServer, proxyRequest));
-    }
 }


### PR DESCRIPTION
Added new header provider in security-proxy that checks the currently logged in user and if that user is one of the "special"/"trusted" users then it will map

imp-username -> sec-username
imp-roles -> sec-roles

Allowing trusted users to impersonate another user.  This is required for the extractorapp to enforce the security on the end user.
