### PR TITLE
Fix for Geowebcache log4j config error

### DIFF
--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -21,6 +21,12 @@
             <artifactId>gwc-web</artifactId>
             <version>${geowebcache.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -100,7 +106,7 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <excludes>**/acegi-config.xml,**/geowebcache-servlet.xml,**/log4j.*,**/web.xml,${geowebcache.war.excludes}</excludes>
+                            <excludes>**/acegi-config.xml,**/geowebcache-servlet.xml,**/lib/log4j-*.jar,**/log4j.*,**/web.xml,${geowebcache.war.excludes}</excludes>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.geowebcache</groupId>


### PR DESCRIPTION
Exclude log4j from geowebcache webapp

This is a fix for https://github.com/georchestra/georchestra/issues/647.
