### PR TITLE
security-proxy - ignores non HTTPS request check

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -47,6 +47,7 @@
                 <value>.*QGIS.*</value>
             </list>
         </property>
+        <property name="ignoreHttps" value="true" />
         <property name="ignoreFailure" value="false"/>
         <property name="credentialsCharset" value="UTF-8"/>
         <property name="authenticationManager" ref="authenticationManager"/>


### PR DESCRIPTION
The security-proxy can bypass CAS authentication in case of specific
user-agents and a HTTP basic-auth is provided. But the filter discards
requests that are not targetted onto https.

This adds an option to ignore if the request targets or not an HTTPS
server (anyway, the geOrchestra instances spread over multiple servers
should be bound over a trusted network, so the risk of sniffing
passwords _should_ be mitigated).
