### PR TITLE
added hyphen allowed character in uids

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/utils/UserUtils.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/utils/UserUtils.java
@@ -37,7 +37,7 @@ public class UserUtils {
 	}
 	
 	/**
-	 * An user identifier (uid) valid only can contain characters, numbers or dot. It must begin with a character.
+	 * An user identifier (uid) valid only can contain characters, numbers, dot, hyphen. It must begin with a character.
 	 * 
 	 * @param uid user identifier
 	 * @return true if the uid is valid
@@ -50,7 +50,7 @@ public class UserUtils {
 		}
 		for(int i=1; i < uid.length(); i++){
 			
-			if( !(Character.isLetter( uid.charAt(i)) ||  Character.isDigit( uid.charAt(i)) || ( uid.charAt(i) == '.')) ){
+			if( !(Character.isLetter( uid.charAt(i)) ||  Character.isDigit( uid.charAt(i)) || ( uid.charAt(i) == '.') || ( uid.charAt(i) == '-')) ){
 				
 				return false;
 			} 

--- a/ldapadmin/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/ldapadmin/src/main/webapp/WEB-INF/i18n/application.properties
@@ -108,4 +108,4 @@ uid.label=User ID
 uid.placeholder=User ID
 uid.error.required=user identifier is required
 uid.error.exist=This identifier has already been selected. Please choose another one.
-uid.error.invalid=Invalid uid. It must begin with a letter followed by one or more letters, digits or \".\" (dots)
+uid.error.invalid=Invalid uid. It must begin with a letter followed by one or more letters, digits, \"-\" (hyphens) or \".\" (dots)

--- a/ldapadmin/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/ldapadmin/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -108,4 +108,4 @@ uid.label=ID Usuario
 uid.placeholder=ID Usuario
 uid.error.required=Requerido
 uid.error.exist=Este identificador ya fue seleccionado. Por favor elija otro.
-uid.error.invalid=uid invalido. Debe comenzar por una letra y estar seguido de uno o más letras, dígitos o puntos (\".\")
+uid.error.invalid=uid invalido. Debe comenzar por una letra y estar seguido de uno o más letras, dígitos, guión (\"-\") o puntos (\".\")

--- a/ldapadmin/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/ldapadmin/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -108,4 +108,4 @@ uid.label=Login
 uid.placeholder=Login
 uid.error.required=Requis
 uid.error.exist=Ce login est déjà utilisé. Choisissez-en un autre.
-uid.error.invalid=Login invalide. Il doit commencer par une lettre et être suivi par un ou plusieurs chiffres, lettres ou points (\".\")
+uid.error.invalid=Login invalide. Il doit commencer par une lettre et être suivi par un ou plusieurs chiffres, lettres, traits d'union (\"-\") ou points (\".\")

--- a/ldapadmin/src/main/webapp/WEB-INF/views/validation.jsp
+++ b/ldapadmin/src/main/webapp/WEB-INF/views/validation.jsp
@@ -208,13 +208,13 @@ function isFieldRequired(id) {
  * Test if a uid string is valid
  * 
  * The first character must be a letter, and the uid must contain only
- * letters, digits and/or the '.' character
+ * letters, digits, and/or the '.' or '-' character
  * 
  * @param {String} uid
  * @returns {boolean}
  */
 function isUidValid(uid) {
-	if (uid.charAt(0).match(/[a-z]/ig) && (uid.match(/[a-z0-9\.]/ig).length == uid.length)) {
+	if (uid.charAt(0).match(/[a-z]/ig) && (uid.match(/[a-z0-9\.-]/ig).length == uid.length)) {
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
ldapadmin restricts uid with [a-z][a-z0-9.]*
a more open yet valid regex would be [a-z][a-z0-9.-]\* allowing spaces in names to be replaced by hyphen
tested successfully on dev.geob.fr

partial fix #676
