### PR TITLE
Fix for Proxy URL parameter vulnerability for 13.09

### DIFF
--- a/config/defaults/security-proxy/WEB-INF/classes/permissions.xml
+++ b/config/defaults/security-proxy/WEB-INF/classes/permissions.xml
@@ -1,0 +1,8 @@
+<permissions>
+    <allowByDefault>true</allowByDefault>
+    <denied>
+        <urimatcher>
+            <host>localhost</host> <!-- All ips for local host irregardless of name will be checked -->
+        </urimatcher>
+    </denied>
+</permissions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <confdir>${project.build.directory}/conf</confdir>
     <encoding>UTF-8</encoding>
     <georchestra.version>${project.version}</georchestra.version>
-    <postTreatmentScript><![CDATA[
+ <!--    <postTreatmentScript><![CDATA[
 def server=project.properties['server']
 def subTarget=project.properties['subTarget']
 						
@@ -35,7 +35,7 @@ def params = new Parameters(
 params.init(false)
 
 new PostTreatment().run(this, log, ant, project.basedir, params.projectDir, server, subTarget, project.build.directory)
-]]></postTreatmentScript>
+]]></postTreatmentScript> -->
   </properties>
   <modules>
     <module>config</module>
@@ -52,7 +52,7 @@ new PostTreatment().run(this, log, ant, project.basedir, params.projectDir, serv
        <plugin>
          <groupId>pl.project13.maven</groupId>
          <artifactId>git-commit-id-plugin</artifactId>
-         <version>2.1.4</version>
+         <version>2.1.10</version>
          <executions>
            <execution>
              <goals>
@@ -70,7 +70,7 @@ new PostTreatment().run(this, log, ant, project.basedir, params.projectDir, serv
     </plugins>
     <pluginManagement>
       <plugins>
-		<plugin>
+<!-- 		<plugin>
 			<groupId>org.codehaus.groovy.maven</groupId>
 			<artifactId>gmaven-plugin</artifactId>
 		    <version>1.0</version>
@@ -115,7 +115,7 @@ class PostTreatment {
 					</configuration>
 				</execution>
 			</executions>
-		</plugin>
+		</plugin> -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -13,7 +13,6 @@
 	<properties>
 		<spring.version>3.0.5.RELEASE</spring.version>
 		<security.version>3.0.5.RELEASE</security.version>
-		<maven.test.skip>true</maven.test.skip>
 	</properties>
 	<dependencies>
 	    <dependency>
@@ -50,11 +49,27 @@
 			<version>${spring.version}</version>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.7</version>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-oxm</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 			<version>${spring.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-aop</artifactId>
@@ -128,6 +143,12 @@
 			<version>2.4</version>
 			<scope>provided</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>17.0</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans 
 						http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-    <bean id="proxy" 
+    <bean id="proxy"  init-method="init"
           class="org.georchestra.security.Proxy">
 <!--          <property name="defaultTarget" value="${proxy.defaultTarget}/sec/"/>-->
           <property name="headerManagement" ref="headerManagementBean"/>
@@ -21,7 +21,8 @@
           <property name="port" value="${psql.port}"/> -->
           <property name="user" value="${psql.user}"/>
           <property name="password" value="${psql.pass}"/>
-          
+          <property name="proxyPermissionsFile" value="permissions.xml"/>
+
           <property name="targets">
                <map>
 ${proxy.mapping}

--- a/security-proxy/src/main/java/org/georchestra/security/permissions/Permissions.java
+++ b/security-proxy/src/main/java/org/georchestra/security/permissions/Permissions.java
@@ -1,0 +1,98 @@
+package org.georchestra.security.permissions;
+
+import com.google.common.collect.Lists;
+
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+
+/**
+ * @author Jesse on 8/15/2014.
+ */
+public class Permissions {
+    private List<UriMatcher> allowed = Lists.newArrayList();
+    private List<UriMatcher> denied = Lists.newArrayList();
+    private boolean allowByDefault = false;
+    private boolean initialized = false;
+
+    public Permissions setAllowed(List<UriMatcher> allowed) {
+        this.allowed = allowed;
+        return this;
+    }
+
+    public Permissions setDenied(List<UriMatcher> denied) {
+        this.denied = denied;
+        return this;
+    }
+
+    public boolean isDenied(URL url) {
+        if (allowByDefault) {
+            if (checkIfAllowed(url)) return false;
+            if (checkIfDenied(url)) return true;
+        } else {
+            if (checkIfDenied(url)) return true;
+            if (checkIfAllowed(url)) return false;
+        }
+        return !allowByDefault;
+    }
+
+    private boolean checkIfDenied(URL url) {
+        for (UriMatcher uriMatcher : denied) {
+            if (uriMatcher.matches(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkIfAllowed(URL url) {
+        for (UriMatcher uriMatcher : allowed) {
+            if (uriMatcher.matches(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<UriMatcher> getAllowed() {
+        return allowed;
+    }
+
+    public List<UriMatcher> getDenied() {
+        return denied;
+    }
+
+    public boolean isAllowByDefault() {
+        return allowByDefault;
+    }
+
+    public void setAllowByDefault(boolean allowByDefault) {
+        this.allowByDefault = allowByDefault;
+    }
+
+    public synchronized void init() throws UnknownHostException {
+        for (UriMatcher uriMatcher : allowed) {
+            uriMatcher.init();
+        }
+
+        for (UriMatcher uriMatcher : denied) {
+            uriMatcher.init();
+        }
+        initialized = true;
+    }
+
+    public synchronized boolean isInitialized() {
+        return this.initialized;
+    }
+
+
+    private Object readResolve() {
+        if (this.denied == null) {
+            this.denied = Lists.newArrayList();
+        }
+        if (this.allowed == null) {
+            this.allowed = Lists.newArrayList();
+        }
+        return this;
+    }
+}

--- a/security-proxy/src/main/java/org/georchestra/security/permissions/UriMatcher.java
+++ b/security-proxy/src/main/java/org/georchestra/security/permissions/UriMatcher.java
@@ -1,0 +1,108 @@
+package org.georchestra.security.permissions;
+
+import com.google.common.collect.Sets;
+
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.regex.Pattern;
+
+/**
+ * @author Jesse on 8/15/2014.
+ */
+public class UriMatcher {
+    private int port = -1;
+    private String path;
+    private Pattern pathPattern;
+    private HashSet<InetAddress> hostNames;
+    private String host;
+
+    public synchronized void init() throws UnknownHostException {
+        this.hostNames = null;
+        if (this.host != null) {
+            this.hostNames = Sets.newHashSet(InetAddress.getAllByName(this.host));
+        }
+        this.pathPattern = null;
+        if (this.path != null) {
+            if (!this.path.startsWith("/")) {
+                this.path = "(/" + this.path + ")|(" + this.path + ")";
+            }
+            this.pathPattern = Pattern.compile(this.path);
+        }
+    }
+
+    public boolean matches(URL url) {
+        if (hostNames != null && !matchesHost(url)) {
+            return false;
+        }
+        if (port != -1 && !matchesPort(url)) {
+            return false;
+        }
+        return !(pathPattern != null && !matchesPath(url));
+    }
+
+    private boolean matchesPath(URL url) {
+        return this.pathPattern.matcher(url.getPath()).matches();
+    }
+
+    private boolean matchesPort(URL url) {
+        if (url.getPort() == this.port) {
+            return true;
+        }
+        return url.getPort() == -1 && url.getDefaultPort() == this.port;
+    }
+
+    private boolean matchesHost(URL url) {
+        final InetAddress[] allByName;
+        try {
+            allByName = InetAddress.getAllByName(url.getHost());
+        } catch (UnknownHostException e) {
+            return false;
+        }
+
+        for (InetAddress inetAddress : allByName) {
+            if (this.hostNames.contains(inetAddress)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public UriMatcher setHost(String host) throws UnknownHostException {
+        this.host = host;
+        return this;
+    }
+
+    public UriMatcher setPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public UriMatcher setPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    private Object readResolve() {
+        // The Xml unmarshaller will set port to 0 if the port element is missing
+        // so I will assume that this means the port is missing and set to -1 which
+        // is the correct ignore port number
+        if (this.port == 0) {
+            this.port = -1;
+        }
+        return this;
+    }
+}

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -1,0 +1,145 @@
+package org.georchestra.security;
+
+import com.google.common.collect.Maps;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.message.BasicHttpResponse;
+import org.georchestra.security.permissions.Permissions;
+import org.georchestra.security.permissions.UriMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProxyTest {
+    private Proxy proxy;
+    private BasicHttpResponse response;
+    private boolean executed = true;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse httpResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        response = null;
+        executed = false;
+        proxy = new Proxy() {
+            @Override
+            protected HttpResponse executeHttpRequest(HttpClient httpclient, HttpRequestBase proxyingRequest) throws IOException {
+                executed = true;
+                return response;
+            }
+        };
+        proxy.setProxyPermissions(new Permissions().
+                setAllowed(Collections.singletonList(new UriMatcher().setHost("localhost"))).
+                setDenied(Collections.singletonList(new UriMatcher().setHost("google.com"))));
+
+        response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+        this.request = new MockHttpServletRequest("GET", "/sec/proxy/");
+        this.request.setServerName("localhost");
+        this.request.setServerPort(80);
+        this.httpResponse = new MockHttpServletResponse();
+
+        Map<String, String> targets = Maps.newHashMap();
+        targets.put("geonetwork", "http://www.google.com/geonetwork-private");
+        targets.put("extractorapp", "http://localhost/extractorapp-private");
+        proxy.setTargets(targets);
+
+    }
+
+    @Test
+    public void testGetUrlLegalUrl() throws Exception {
+        proxy.handleUrlGETRequest(request, httpResponse, "http://localhost:8080/path");
+        assertTrue(executed);
+    }
+
+    /**
+     * All url proxy requests (http://server/sec/proxy?url=...) that try to directly access protected services like extractorapp should
+     * be rejected.  In the cases where the protected services are required, the url parameter should be the public url of the
+     * protected service (not the private one).
+     */
+    @Test
+    public void testGetUrlTarget() throws Exception {
+        proxy.handleUrlGETRequest(request, httpResponse, "http://localhost:8080/geonetwork-private");
+        assertFalse(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+        proxy.handleUrlGETRequest(request, httpResponse, "http://localhost:8080/extractorapp");
+        assertTrue(executed);
+    }
+
+    /**
+     * Ensure that when the proxy form: http://server.com/sec/geonetwork/srv/eng/home is used to access a protected service,
+     * the request should always be allowed no matter the proxy permissions.
+     */
+    @Test
+    public void testGetUrlLegalUrlButTarget() throws Exception {
+        request = new MockHttpServletRequest("GET", "http://localhost:8080/geonetwork-private");
+        proxy.handleGETRequest(request, httpResponse);
+        assertFalse(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        request = new MockHttpServletRequest("GET", "/geonetwork/srv/eng/something");
+        proxy.handleGETRequest(request, httpResponse);
+        assertTrue(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        executed = false;
+        request = new MockHttpServletRequest("GET", "/extractorapp/home");
+        proxy.handleGETRequest(request, httpResponse);
+        assertTrue(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        executed = false;
+        request = new MockHttpServletRequest("GET", "/unmapped/x");
+        proxy.handleGETRequest(request, httpResponse);
+        assertFalse(executed);
+    }
+
+    @Test
+    public void testGetUrlIllegalUrl() throws Exception {
+        proxy.handleUrlGETRequest(request, httpResponse, "http://www.google.com:8080/path");
+        assertFalse(executed);
+    }
+
+    @Test
+    public void testLoadPermissions() throws Exception {
+        proxy = new Proxy();
+        proxy.setProxyPermissionsFile("test-permissions.xml");
+        proxy.init();
+
+        final Permissions proxyPermissions = proxy.getProxyPermissions();
+        assertTrue(proxyPermissions.isAllowByDefault());
+        assertEquals(1, proxyPermissions.getAllowed().size());
+        assertEquals(1, proxyPermissions.getDenied().size());
+
+        assertEquals("localhost", proxyPermissions.getAllowed().get(0).getHost());
+        assertEquals(-1, proxyPermissions.getAllowed().get(0).getPort());
+        assertEquals(null, proxyPermissions.getAllowed().get(0).getPath());
+
+        assertEquals("localhost", proxyPermissions.getDenied().get(0).getHost());
+        assertEquals(433, proxyPermissions.getDenied().get(0).getPort());
+        assertEquals("/geonetwork/", proxyPermissions.getDenied().get(0).getPath());
+
+        assertTrue(proxyPermissions.isInitialized());
+    }
+
+    @Test
+    public void testLoadEmptyPermissions() throws Exception {
+        proxy = new Proxy();
+        proxy.setProxyPermissionsFile("empty-permissions.xml");
+        proxy.init();
+
+        // no exception? good
+    }
+}


### PR DESCRIPTION
Fix for a vulnerability where client could access localhost resources via proxy url.

Added a permissions file so that the urls that are permitted to be proxied can be controlled.  By default all accesses to localhost (server localhost) are denied.

Also any protected services (extractorapp, geonetwork, etc...) are denied because they must be accessed using the path proxy strategy this way the spring security can add extra authorization checks.
