### PR TITLE
Fix for Proxy URL parameter vulnerability for 14.01

### DIFF
--- a/config/defaults/security-proxy/WEB-INF/classes/permissions.xml
+++ b/config/defaults/security-proxy/WEB-INF/classes/permissions.xml
@@ -1,0 +1,8 @@
+<permissions>
+    <allowByDefault>true</allowByDefault>
+    <denied>
+        <urimatcher>
+            <host>localhost</host> <!-- All ips for local host irregardless of name will be checked -->
+        </urimatcher>
+    </denied>
+</permissions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.georchestra</groupId>
-	<artifactId>root</artifactId>
-	<packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.georchestra</groupId>
+  <artifactId>root</artifactId>
+  <packaging>pom</packaging>
 	<version>14.01</version>
-	<name>Root project of the geOrchestra project</name>
-	<url>http://maven.apache.org</url>
-	<organization>
-		<name>geOrchestra</name>
-	</organization>
-	<properties>
+  <name>Root project of the geOrchestra project</name>
+  <url>http://maven.apache.org</url>
+  <organization>
+    <name>geOrchestra</name>
+  </organization>
+  <properties>
 		<gt.version>9.2</gt.version>
-		<spring.version>2.5.6.SEC01</spring.version>
-		<security.version>2.0.5.RELEASE</security.version>
-		<spring.ldap.version>1.3.0.RELEASE</spring.ldap.version>
+    <spring.version>2.5.6.SEC01</spring.version>
+    <security.version>2.0.5.RELEASE</security.version>
+    <spring.ldap.version>1.3.0.RELEASE</spring.ldap.version>
                 <gmaven.version>1.0</gmaven.version>
                 <gmaven.runtime.version>1.5</gmaven.runtime.version>
-		<server>template</server>
-		<sub.target>dev</sub.target>
-		<!-- default when building without a profile specified -->
-		<confdir>${project.build.directory}/conf</confdir>
-		<encoding>UTF-8</encoding>
-		<georchestra.version>${project.version}</georchestra.version>
-		<postTreatmentScript><![CDATA[
+    <server>template</server>
+    <sub.target>dev</sub.target>
+    <!-- default when building without a profile specified -->
+    <confdir>${project.build.directory}/conf</confdir>
+    <encoding>UTF-8</encoding>
+    <georchestra.version>${project.version}</georchestra.version>
+ <!--    <postTreatmentScript><![CDATA[
 def server=project.properties['server']
 def subTarget=project.properties['subTarget']
 						
 def params = new Parameters(
-	project: project,
+    project: project,
 	target: server,
 	subTarget: subTarget,
 	log: log,
@@ -37,57 +37,57 @@ def params = new Parameters(
 params.init(false)
 
 new PostTreatment().run(this, log, ant, project.basedir, params.projectDir, server, subTarget, project.build.directory)
-]]></postTreatmentScript>
-	</properties>
-	<modules>
+]]></postTreatmentScript> -->
+  </properties>
+  <modules>
 		<module>geotools</module>
-		<module>config</module>
+    <module>config</module>
 		<module>header</module>
-		<module>epsg-extension</module>
-		<module>ogc-server-statistics</module>
-		<module>server-deploy-support</module>
-	</modules>
-	<build>
-		<plugins>
-			 <!-- initialize git revision info -->
-			 <plugin>
-				 <groupId>pl.project13.maven</groupId>
-				 <artifactId>git-commit-id-plugin</artifactId>
-				 <version>2.1.4</version>
-				 <executions>
-					 <execution>
-						 <goals>
-							 <goal>revision</goal>
-						 </goals>
-					 </execution>
-				 </executions>
-				 <configuration>
-					 <prefix>build</prefix>
-					 <failOnNoGitDirectory>false</failOnNoGitDirectory>
-					 <skipPoms>false</skipPoms>
-					 <verbose>false</verbose>
+    <module>epsg-extension</module>
+    <module>ogc-server-statistics</module>
+    <module>server-deploy-support</module>
+  </modules>
+  <build>
+    <plugins>
+       <!-- initialize git revision info -->
+       <plugin>
+         <groupId>pl.project13.maven</groupId>
+         <artifactId>git-commit-id-plugin</artifactId>
+         <version>2.1.10</version>
+         <executions>
+           <execution>
+             <goals>
+               <goal>revision</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <prefix>build</prefix>
+           <failOnNoGitDirectory>false</failOnNoGitDirectory>
+           <skipPoms>false</skipPoms>
+           <verbose>false</verbose>
 					 <!-- see https://github.com/ktoso/maven-git-commit-id-plugin/issues/61#issuecomment-27995746 -->
 					 <gitDescribe>
 					 <skip>true</skip>
 					 </gitDescribe>
-				 </configuration>
-			 </plugin>
-		</plugins>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.codehaus.groovy.maven</groupId>
-					<artifactId>gmaven-plugin</artifactId>
+         </configuration>
+       </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+<!-- 		<plugin>
+			<groupId>org.codehaus.groovy.maven</groupId>
+			<artifactId>gmaven-plugin</artifactId>
                                         <version>${gmaven.version}</version>
-					<executions>
-						<execution>
-							<id>create-missingpost-treatment</id>
-							<phase>prepare-package</phase>
-							<goals>
-								<goal>execute</goal>
-							</goals>
-							<configuration>
-								<source><![CDATA[
+			<executions>
+				<execution>
+					<id>create-missingpost-treatment</id>
+					<phase>prepare-package</phase>
+					<goals>
+						<goal>execute</goal>
+					</goals>
+					<configuration>
+						<source><![CDATA[
 def confDir = new File(project.build.directory, "conf")
 def treatmentFile = new File(confDir, project.artifactId+"/PostTreatment.groovy")
 if(confDir.exists() && !treatmentFile.exists()){
@@ -101,302 +101,302 @@ class PostTreatment {
 }
 """
 }
-]]></source>
+						]]></source>
 
-							</configuration>
-						</execution>
-						<execution>
-							<id>post-treatment-script</id>
-							<phase>prepare-package</phase>
-							<goals>
-								<goal>execute</goal>
-							</goals>
-							<configuration>
-								<scriptpath>
-									<element>${project.build.directory}/conf/${project.artifactId}</element>
-									<element>${project.build.directory}/conf/scripts</element>
-								</scriptpath>
-								<source>${postTreatmentScript}</source>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-
-
-
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.5</version>
-					<configuration>
-						<nonFilteredFileExtensions>
-							<nonFilteredFileExtension>pdf</nonFilteredFileExtension>
-							<nonFilteredFileExtension>swf</nonFilteredFileExtension>
-							<nonFilteredFileExtension>gif</nonFilteredFileExtension>
-							<nonFilteredFileExtension>ico</nonFilteredFileExtension>
-							<nonFilteredFileExtension>bmp</nonFilteredFileExtension>
-							<nonFilteredFileExtension>jpg</nonFilteredFileExtension>
-							<nonFilteredFileExtension>odg</nonFilteredFileExtension>
-						</nonFilteredFileExtensions>
 					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-dependency-plugin</artifactId>
-					<version>2.3</version>
-					<executions>
-						<execution>
-							<id>unpack-config</id>
-							<goals>
-								<goal>unpack</goal>
-							</goals>
-							<phase>initialize</phase>
-							<configuration>
-								<artifactItems>
-									<artifactItem>
-										<groupId>org.georchestra</groupId>
-										<artifactId>config</artifactId>
-										<version>${georchestra.version}</version>
-										<classifier>${server}</classifier>
-									</artifactItem>
-								</artifactItems>
-								<overWriteSnapshots>true</overWriteSnapshots>
-								<overWriteReleases>true</overWriteReleases>
-								<outputDirectory>${confdir}</outputDirectory>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.mortbay.jetty</groupId>
-					<artifactId>maven-jetty-plugin</artifactId>
-					<version>6.1.26</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-war-plugin</artifactId>
-					<version>2.1.1</version>
+				</execution>
+				<execution>
+					<id>post-treatment-script</id>
+					<phase>prepare-package</phase>
+					<goals>
+						<goal>execute</goal>
+					</goals>
 					<configuration>
-						<classifier>${server}</classifier>
+						<scriptpath>
+							<element>${project.build.directory}/conf/${project.artifactId}</element>
+							<element>${project.build.directory}/conf/scripts</element>
+						</scriptpath>
+						<source>${postTreatmentScript}</source>
 					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.3.2</version>
-					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
-						<encoding>UTF-8</encoding>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.3.2</version>
-				</plugin>
-				<plugin>
-					<groupId>com.c2c</groupId>
-					<artifactId>maven-resources-plugin</artifactId>
-					<version>1.3</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
-	<profiles>
+				</execution>
+			</executions>
+        </plugin> -->
 
-		<profile>
-			<id>localhost</id>
-			<properties>
-				<server>localhost</server>
-			</properties>
-		</profile>
 
-		<!-- template profile -->
-		<profile>
-			<id>template</id>
-			<properties>
-				<server>template</server>
-			</properties>
-		</profile>
 
-		<profile>
-			<id>all</id>
-			<activation>
-				<file>
-					<!-- this is added so that all will be the default profile -->
-					<!-- one can build only a specific project by doing -->
-					<!-- -P-all,extractorapp -->
-					<missing>hack_to_make_all_enabled_by_default</missing>
-				</file>
-			</activation>
-			<modules>
-				<module>cas-server-webapp</module>
-				<module>catalogapp</module>
-				<module>extractorapp</module>
-				<module>geoserver</module>
-				<module>ldapadmin</module>
-				<module>mapfishapp</module>
-				<module>security-proxy</module>
-				<module>geonetwork</module>
-				<module>downloadform</module>
-				<module>analytics</module>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.5</version>
+          <configuration>
+            <nonFilteredFileExtensions>
+              <nonFilteredFileExtension>pdf</nonFilteredFileExtension>
+              <nonFilteredFileExtension>swf</nonFilteredFileExtension>
+              <nonFilteredFileExtension>gif</nonFilteredFileExtension>
+              <nonFilteredFileExtension>ico</nonFilteredFileExtension>
+              <nonFilteredFileExtension>bmp</nonFilteredFileExtension>
+              <nonFilteredFileExtension>jpg</nonFilteredFileExtension>
+              <nonFilteredFileExtension>odg</nonFilteredFileExtension>
+            </nonFilteredFileExtensions>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.3</version>
+          <executions>
+            <execution>
+              <id>unpack-config</id>
+              <goals>
+                <goal>unpack</goal>
+              </goals>
+              <phase>initialize</phase>
+              <configuration>
+                <artifactItems>
+                  <artifactItem>
+                    <groupId>org.georchestra</groupId>
+                    <artifactId>config</artifactId>
+                    <version>${georchestra.version}</version>
+                    <classifier>${server}</classifier>
+                  </artifactItem>
+                </artifactItems>
+                <overWriteSnapshots>true</overWriteSnapshots>
+                <overWriteReleases>true</overWriteReleases>
+                <outputDirectory>${confdir}</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>maven-jetty-plugin</artifactId>
+          <version>6.1.26</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.1.1</version>
+          <configuration>
+            <classifier>${server}</classifier>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.3.2</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+            <encoding>UTF-8</encoding>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.3.2</version>
+        </plugin>
+        <plugin>
+          <groupId>com.c2c</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>1.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  <profiles>
+
+    <profile>
+      <id>localhost</id>
+      <properties>
+        <server>localhost</server>
+      </properties>
+    </profile>
+
+    <!-- template profile -->
+    <profile>
+      <id>template</id>
+      <properties>
+        <server>template</server>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>all</id>
+      <activation>
+        <file>
+          <!-- this is added so that all will be the default profile -->
+          <!-- one can build only a specific project by doing -->
+          <!-- -P-all,extractorapp -->
+          <missing>hack_to_make_all_enabled_by_default</missing>
+        </file>
+      </activation>
+      <modules>
+        <module>cas-server-webapp</module>
+        <module>catalogapp</module>
+        <module>extractorapp</module>
+        <module>geoserver</module>
+        <module>ldapadmin</module>
+        <module>mapfishapp</module>
+        <module>security-proxy</module>
+        <module>geonetwork</module>
+        <module>downloadform</module>
+        <module>analytics</module>
 				<module>header</module>
-			</modules>
-		</profile>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>cas-server-webapp</id>
-			<modules>
-				<module>cas-server-webapp</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>cas-server-webapp</id>
+      <modules>
+        <module>cas-server-webapp</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>cas</id>
-			<modules>
-				<module>cas-server-webapp</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>cas</id>
+      <modules>
+        <module>cas-server-webapp</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>catalogapp</id>
-			<modules>
-				<module>catalogapp</module>
-			</modules>
-		</profile>
-
-		<profile>
+    <profile>
+      <id>catalogapp</id>
+      <modules>
+        <module>catalogapp</module>
+      </modules>
+    </profile>  
+    
+    <profile>
 			<id>header</id>
-			<modules>
+      <modules>
 				<module>header</module>
-			</modules>
-		</profile>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>extractorapp</id>
-			<modules>
-				<module>extractorapp</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>extractorapp</id>
+      <modules>
+        <module>extractorapp</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>geoserver</id>
-			<modules>
-				<module>geoserver</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>geoserver</id>
+      <modules>
+        <module>geoserver</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>ldapadmin</id>
-			<modules>
-				<module>ldapadmin</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>ldapadmin</id>
+      <modules>
+        <module>ldapadmin</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>mapfishapp</id>
-			<modules>
-				<module>mapfishapp</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>mapfishapp</id>
+      <modules>
+        <module>mapfishapp</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>security-proxy</id>
-			<modules>
-				<module>security-proxy</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>security-proxy</id>
+      <modules>
+        <module>security-proxy</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>proxy</id>
-			<modules>
-				<module>security-proxy</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>proxy</id>
+      <modules>
+        <module>security-proxy</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>geonetwork</id>
-			<modules>
-				<module>geonetwork</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>geonetwork</id>
+      <modules>
+        <module>geonetwork</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>downloadform</id>
-			<modules>
-				<module>downloadform</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>downloadform</id>
+      <modules>
+        <module>downloadform</module>
+      </modules>
+    </profile>
 
-		<profile>
-			<id>analytics</id>
-			<modules>
-				<module>analytics</module>
-			</modules>
-		</profile>
+    <profile>
+      <id>analytics</id>
+      <modules>
+        <module>analytics</module>
+      </modules>
+    </profile>
 
-	</profiles>
-	<repositories>
-		<repository>
-			<snapshots>
-				<enabled>true</enabled>
-				<checksumPolicy>ignore</checksumPolicy>
-			</snapshots>
-			<id>mapfish</id>
-			<url>http://dev.mapfish.org/maven/repository</url>
-		</repository>
+  </profiles>
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
+      </snapshots>
+      <id>mapfish</id>
+      <url>http://dev.mapfish.org/maven/repository</url>
+    </repository>
 		<!-- geotools -->
-		<repository>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>osgeo</id>
-			<name>Open Source Geospatial Foundation Repository</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
-		</repository>
-		<repository>
-			<id>opengeo</id>
-			<name>OpenGeo Maven Repository</name>
-			<url>http://repo.opengeo.org/</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>jetty-repository</id>
-			<name>Jetty Maven2 Repository</name>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>http://download.osgeo.org/webdav/geotools/</url>
+    </repository>
+    <repository>
+      <id>opengeo</id>
+      <name>OpenGeo Maven Repository</name>
+      <url>http://repo.opengeo.org/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>jetty-repository</id>
+      <name>Jetty Maven2 Repository</name>
 			<url>https://oss.sonatype.org/content/groups/jetty/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>codehaus-snapshot-plugins</id>
-			<name>codehaus-shapshot-plugins</name>
-			<url>http://snapshots.repository.codehaus.org/</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-		<pluginRepository>
-			<id>opengeo</id>
-			<name>OpenGeo Maven Repository</name>
-			<url>http://repo.opengeo.org/</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<snapshots>
-				<enabled>true</enabled>
-				<checksumPolicy>ignore</checksumPolicy>
-			</snapshots>
-			<id>mapfish</id>
-			<url>http://dev.mapfish.org/maven/repository</url>
-		</pluginRepository>
-	</pluginRepositories>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>codehaus-snapshot-plugins</id>
+      <name>codehaus-shapshot-plugins</name>
+      <url>http://snapshots.repository.codehaus.org/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </pluginRepository>
+    <pluginRepository>
+      <id>opengeo</id>
+      <name>OpenGeo Maven Repository</name>
+      <url>http://repo.opengeo.org/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <snapshots>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
+      </snapshots>
+      <id>mapfish</id>
+      <url>http://dev.mapfish.org/maven/repository</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -13,16 +13,15 @@
 	<properties>
 		<spring.version>3.0.7.RELEASE</spring.version>
 		<security.version>3.0.5.RELEASE</security.version>
-		<maven.test.skip>true</maven.test.skip>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+	    <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
 			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-        <dependency>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
@@ -56,10 +55,26 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.7</version>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-oxm</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 			<version>${spring.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-aop</artifactId>
@@ -144,6 +159,12 @@
 			<version>2.1</version>
 			<scope>provided</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>17.0</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<resources>
@@ -164,9 +185,9 @@
 				<artifactId>gmaven-plugin</artifactId>
 				<dependencies>
 					<dependency>
-						<groupId>org.georchestra</groupId>
-						<artifactId>config</artifactId>
-						<version>${project.version}</version>
+							<groupId>org.georchestra</groupId>
+							<artifactId>config</artifactId>
+							<version>${project.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -185,11 +206,11 @@
 			</plugin>
 			<plugin>
 				<!--
-					Copy du fichier default.wmc.example si il n'existe
-					pas de fichier default.wmc dans le repertoire src/main/webapp.
-					Ce fichier n'est pas écrasé si le packageur de l'application
-					a placé son propre fichier default.wmc
-				-->
+                      Copy du fichier default.wmc.example si il n'existe
+                      pas de fichier default.wmc dans le repertoire src/main/webapp.
+                      Ce fichier n'est pas écrasé si le packageur de l'application
+                      a placé son propre fichier default.wmc
+                -->
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>

--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans 
 						http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-    <bean id="proxy" 
+    <bean id="proxy"  init-method="init"
           class="org.georchestra.security.Proxy">
 <!--          <property name="defaultTarget" value="${proxy.defaultTarget}/sec/"/>-->
           <property name="headerManagement" ref="headerManagementBean"/>
@@ -21,7 +21,8 @@
           <property name="port" value="${psql.port}"/> -->
           <property name="user" value="${psql.user}"/>
           <property name="password" value="${psql.pass}"/>
-          
+          <property name="proxyPermissionsFile" value="permissions.xml"/>
+
           <property name="targets">
                <map>
 ${proxy.mapping}

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -1,36 +1,8 @@
 package org.georchestra.security;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.ProxySelector;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.DeflaterInputStream;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.google.common.io.Closer;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -54,7 +26,11 @@ import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
 import org.apache.http.message.BasicNameValuePair;
+import org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter;
 import org.georchestra.security.healthcenter.DatabaseHealthCenter;
+import org.georchestra.security.permissions.Permissions;
+import org.georchestra.security.permissions.UriMatcher;
+import org.springframework.oxm.xstream.XStreamMarshaller;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.DefaultRedirectStrategy;
@@ -64,8 +40,38 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter;
-import org.georchestra.security.healthcenter.DatabaseHealthCenter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.DeflaterInputStream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.stream.StreamSource;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 
 /**
@@ -120,15 +126,41 @@ public class Proxy {
 
     private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 
+    private Permissions proxyPermissions = new Permissions();
+    private String proxyPermissionsFile;
+
     
     /*  ----------  Required for  DatabaseHealthCenter -------------------- */
     
-    private static Boolean checkHealth;
+    private static Boolean checkHealth = false;
 	private String database;
     private String user;
     private String password;
 	private Integer maxDatabaseConnections;
-    
+
+    public void init() throws IOException, ClassNotFoundException {
+        if (targets != null) {
+            for (String url : targets.values()) {
+                new URL(url); // test that it is a valid URL
+            }
+        }
+        if (proxyPermissionsFile != null) {
+            Closer closer = Closer.create();
+            try {
+                final ClassLoader classLoader = Proxy.class.getClassLoader();
+                InputStream inStream = closer.register(classLoader.getResourceAsStream(proxyPermissionsFile));
+                Map<String, Class<?>> aliases = Maps.newHashMap();
+                aliases.put(Permissions.class.getSimpleName().toLowerCase(), Permissions.class);
+                aliases.put(UriMatcher.class.getSimpleName().toLowerCase(), UriMatcher.class);
+                XStreamMarshaller unmarshaller = new XStreamMarshaller();
+                unmarshaller.setAliasesByType(aliases);
+                setProxyPermissions((Permissions) unmarshaller.unmarshal(new StreamSource(inStream)));
+            } finally {
+                closer.close();
+            }
+        }
+    }
+
     /*  ----------  start work around for no gateway option  -------------- */
     private Gateway gateway = new Gateway();
     
@@ -176,42 +208,94 @@ public class Proxy {
     
     // ----------------- Method calls where request is encoded in a url parameter of request ----------------- //
     @RequestMapping(params={"url","!login"}, method=RequestMethod.POST)
-    public void handleUrlPOSTRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {
+    public void handleUrlPOSTRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws
+            IOException {
         handleUrlParamRequest(request, response, RequestType.POST, sURL);
     }
 
     @RequestMapping(params={"url","!login"}, method=RequestMethod.GET)
-    public void handleUrlGETRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {   
+    public void handleUrlGETRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws
+            IOException {
         handleUrlParamRequest(request, response, RequestType.GET, sURL);
     }
     @RequestMapping(params={"url","!login"}, method=RequestMethod.DELETE)
-    public void handleUrlDELETERequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {   
+    public void handleUrlDELETERequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws IOException {
         handleUrlParamRequest(request, response, RequestType.DELETE, sURL);
     }
     @RequestMapping(params={"url","!login"}, method=RequestMethod.HEAD)
-    public void handleUrlHEADRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {   
+    public void handleUrlHEADRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws
+            IOException {
         handleUrlParamRequest(request, response, RequestType.HEAD, sURL);
     }
     @RequestMapping(params={"url","!login"}, method=RequestMethod.OPTIONS)
-    public void handleUrlOPTIONSRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {   
+    public void handleUrlOPTIONSRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws IOException {
         handleUrlParamRequest(request, response, RequestType.OPTIONS, sURL);
     }
     @RequestMapping(params={"url","!login"}, method=RequestMethod.PUT)
-    public void handleUrlPUTRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {   
+    public void handleUrlPUTRequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws
+            IOException {
         handleUrlParamRequest(request, response, RequestType.PUT, sURL);
     }
     @RequestMapping(params={"url","!login"}, method=RequestMethod.TRACE)
-    public void handleUrlTRACERequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) {   
+    public void handleUrlTRACERequest(HttpServletRequest request, HttpServletResponse response, @RequestParam("url") String sURL) throws IOException {
         handleUrlParamRequest(request, response, RequestType.TRACE, sURL);
     }
 
-    private void handleUrlParamRequest(HttpServletRequest request, HttpServletResponse response, RequestType type, String sURL) {
+    private void handleUrlParamRequest(HttpServletRequest request, HttpServletResponse response, RequestType type, String sURL) throws
+            IOException {
         if(request.getRequestURI().startsWith("/sec/proxy/")){
             testLegalContentType(request);
+            URL url;
+            try {
+                url = new URL(sURL);
+            } catch (MalformedURLException e) { // not an url
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+                return;
+            }
+            if (proxyPermissions.isDenied(url) || urlIsProtected(request, url)) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "URL is not allowed.");
+                return;
+            }
+            handleRequest(request, response, type, sURL, false);
             handleRequest(request, response, type, sURL, false);
         } else {
             handlePathEncodedRequests(request, response, type);
         }
+    }
+
+    private boolean urlIsProtected(HttpServletRequest request, URL url) throws IOException {
+        if (isSameServer(request, url)) {
+            String requestURI = url.getPath();
+            String[] requestSegments = splitRequestPath(requestURI);
+            for (String target : targets.values()) {
+                if (samePathPrefix(requestSegments, target)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    private boolean isSameServer(HttpServletRequest request, URL url) throws UnknownHostException {
+        return InetAddress.getByName(request.getServerName()).equals(InetAddress.getByName(url.getHost()));
+    }
+    private boolean samePathPrefix(String[] requestSegments, String target) throws MalformedURLException {
+        String[] targetSegments = splitRequestPath(new URL(target).getPath());
+        for (int i = 0; i < targetSegments.length; i++) {
+            String targetSegment = targetSegments[i];
+            if (!targetSegment.equals(requestSegments[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    private String[] splitRequestPath(String requestURI) {
+        String[] requestSegments;
+        if(requestURI.charAt(0) == '/') {
+            requestSegments = StringUtils.split(requestURI.substring(1), '/');
+        } else {
+            requestSegments = StringUtils.split(requestURI, '/');
+        }
+        return requestSegments;
     }
 
     /**
@@ -335,8 +419,7 @@ public class Proxy {
     }
 
     private boolean isSameHostAndPort(HttpServletRequest request, URL url) throws IOException {
-        boolean sameserver = InetAddress.getByName(request.getServerName()).equals(InetAddress.getByName(url.getHost()));
-        return sameserver && url.getPort() == request.getServerPort();
+        return isSameServer(request, url) && url.getPort() == request.getServerPort();
     }
 
     private String findTarget(String requestURI) {
@@ -392,13 +475,7 @@ public class Proxy {
     }
     
     private String findMatchingTarget(String requestURI) {
-    	
-        String[] segments;
-        if(requestURI.charAt(0) == '/') {
-            segments = StringUtils.split(requestURI.substring(1), '/');
-        } else {
-            segments = StringUtils.split(requestURI, '/');
-        }
+        String[] segments = splitRequestPath(requestURI);
         
         if(segments.length == 0){
         	return null;
@@ -484,7 +561,8 @@ public class Proxy {
 		        	logger.debug("Host header set to: " + proxyingRequest.getFirstHeader("Host").getValue() + " for proxy request.");
 		        }
             }
-            HttpResponse proxiedResponse = httpclient.execute(proxyingRequest);
+
+            HttpResponse proxiedResponse = executeHttpRequest(httpclient, proxyingRequest);
 
             org.apache.http.StatusLine statusLine = proxiedResponse
                     .getStatusLine();
@@ -543,6 +621,11 @@ public class Proxy {
         } finally {
             httpclient.getConnectionManager().shutdown();
         }
+    }
+
+    @VisibleForTesting
+    protected HttpResponse executeHttpRequest(HttpClient httpclient, HttpRequestBase proxyingRequest) throws IOException {
+        return httpclient.execute(proxyingRequest);
     }
 
     private void copyLocationHeaders(HttpResponse proxiedResponse, HttpServletResponse finalResponse) {
@@ -1112,5 +1195,16 @@ public class Proxy {
      */
 	public void setRedirectStrategy(RedirectStrategy redirectStrategy) {
     	this.redirectStrategy = redirectStrategy;
+    }
+
+    public void setProxyPermissionsFile(String proxyPermissionsFile) {
+        this.proxyPermissionsFile = proxyPermissionsFile;
+    }
+    public void setProxyPermissions(Permissions proxyPermissions) throws UnknownHostException {
+        this.proxyPermissions = proxyPermissions;
+        this.proxyPermissions.init();
+    }
+    public Permissions getProxyPermissions() {
+        return proxyPermissions;
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/permissions/Permissions.java
+++ b/security-proxy/src/main/java/org/georchestra/security/permissions/Permissions.java
@@ -1,0 +1,98 @@
+package org.georchestra.security.permissions;
+
+import com.google.common.collect.Lists;
+
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+
+/**
+ * @author Jesse on 8/15/2014.
+ */
+public class Permissions {
+    private List<UriMatcher> allowed = Lists.newArrayList();
+    private List<UriMatcher> denied = Lists.newArrayList();
+    private boolean allowByDefault = false;
+    private boolean initialized = false;
+
+    public Permissions setAllowed(List<UriMatcher> allowed) {
+        this.allowed = allowed;
+        return this;
+    }
+
+    public Permissions setDenied(List<UriMatcher> denied) {
+        this.denied = denied;
+        return this;
+    }
+
+    public boolean isDenied(URL url) {
+        if (allowByDefault) {
+            if (checkIfAllowed(url)) return false;
+            if (checkIfDenied(url)) return true;
+        } else {
+            if (checkIfDenied(url)) return true;
+            if (checkIfAllowed(url)) return false;
+        }
+        return !allowByDefault;
+    }
+
+    private boolean checkIfDenied(URL url) {
+        for (UriMatcher uriMatcher : denied) {
+            if (uriMatcher.matches(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkIfAllowed(URL url) {
+        for (UriMatcher uriMatcher : allowed) {
+            if (uriMatcher.matches(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<UriMatcher> getAllowed() {
+        return allowed;
+    }
+
+    public List<UriMatcher> getDenied() {
+        return denied;
+    }
+
+    public boolean isAllowByDefault() {
+        return allowByDefault;
+    }
+
+    public void setAllowByDefault(boolean allowByDefault) {
+        this.allowByDefault = allowByDefault;
+    }
+
+    public synchronized void init() throws UnknownHostException {
+        for (UriMatcher uriMatcher : allowed) {
+            uriMatcher.init();
+        }
+
+        for (UriMatcher uriMatcher : denied) {
+            uriMatcher.init();
+        }
+        initialized = true;
+    }
+
+    public synchronized boolean isInitialized() {
+        return this.initialized;
+    }
+
+
+    private Object readResolve() {
+        if (this.denied == null) {
+            this.denied = Lists.newArrayList();
+        }
+        if (this.allowed == null) {
+            this.allowed = Lists.newArrayList();
+        }
+        return this;
+    }
+}

--- a/security-proxy/src/main/java/org/georchestra/security/permissions/UriMatcher.java
+++ b/security-proxy/src/main/java/org/georchestra/security/permissions/UriMatcher.java
@@ -1,0 +1,108 @@
+package org.georchestra.security.permissions;
+
+import com.google.common.collect.Sets;
+
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.regex.Pattern;
+
+/**
+ * @author Jesse on 8/15/2014.
+ */
+public class UriMatcher {
+    private int port = -1;
+    private String path;
+    private Pattern pathPattern;
+    private HashSet<InetAddress> hostNames;
+    private String host;
+
+    public synchronized void init() throws UnknownHostException {
+        this.hostNames = null;
+        if (this.host != null) {
+            this.hostNames = Sets.newHashSet(InetAddress.getAllByName(this.host));
+        }
+        this.pathPattern = null;
+        if (this.path != null) {
+            if (!this.path.startsWith("/")) {
+                this.path = "(/" + this.path + ")|(" + this.path + ")";
+            }
+            this.pathPattern = Pattern.compile(this.path);
+        }
+    }
+
+    public boolean matches(URL url) {
+        if (hostNames != null && !matchesHost(url)) {
+            return false;
+        }
+        if (port != -1 && !matchesPort(url)) {
+            return false;
+        }
+        return !(pathPattern != null && !matchesPath(url));
+    }
+
+    private boolean matchesPath(URL url) {
+        return this.pathPattern.matcher(url.getPath()).matches();
+    }
+
+    private boolean matchesPort(URL url) {
+        if (url.getPort() == this.port) {
+            return true;
+        }
+        return url.getPort() == -1 && url.getDefaultPort() == this.port;
+    }
+
+    private boolean matchesHost(URL url) {
+        final InetAddress[] allByName;
+        try {
+            allByName = InetAddress.getAllByName(url.getHost());
+        } catch (UnknownHostException e) {
+            return false;
+        }
+
+        for (InetAddress inetAddress : allByName) {
+            if (this.hostNames.contains(inetAddress)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public UriMatcher setHost(String host) throws UnknownHostException {
+        this.host = host;
+        return this;
+    }
+
+    public UriMatcher setPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public UriMatcher setPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    private Object readResolve() {
+        // The Xml unmarshaller will set port to 0 if the port element is missing
+        // so I will assume that this means the port is missing and set to -1 which
+        // is the correct ignore port number
+        if (this.port == 0) {
+            this.port = -1;
+        }
+        return this;
+    }
+}

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -1,0 +1,145 @@
+package org.georchestra.security;
+
+import com.google.common.collect.Maps;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.message.BasicHttpResponse;
+import org.georchestra.security.permissions.Permissions;
+import org.georchestra.security.permissions.UriMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProxyTest {
+    private Proxy proxy;
+    private BasicHttpResponse response;
+    private boolean executed = true;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse httpResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        response = null;
+        executed = false;
+        proxy = new Proxy() {
+            @Override
+            protected HttpResponse executeHttpRequest(HttpClient httpclient, HttpRequestBase proxyingRequest) throws IOException {
+                executed = true;
+                return response;
+            }
+        };
+        proxy.setProxyPermissions(new Permissions().
+                setAllowed(Collections.singletonList(new UriMatcher().setHost("localhost"))).
+                setDenied(Collections.singletonList(new UriMatcher().setHost("google.com"))));
+
+        response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+        this.request = new MockHttpServletRequest("GET", "/sec/proxy/");
+        this.request.setServerName("localhost");
+        this.request.setServerPort(80);
+        this.httpResponse = new MockHttpServletResponse();
+
+        Map<String, String> targets = Maps.newHashMap();
+        targets.put("geonetwork", "http://www.google.com/geonetwork-private");
+        targets.put("extractorapp", "http://localhost/extractorapp-private");
+        proxy.setTargets(targets);
+
+    }
+
+    @Test
+    public void testGetUrlLegalUrl() throws Exception {
+        proxy.handleUrlGETRequest(request, httpResponse, "http://localhost:8080/path");
+        assertTrue(executed);
+    }
+
+    /**
+     * All url proxy requests (http://server/sec/proxy?url=...) that try to directly access protected services like extractorapp should
+     * be rejected.  In the cases where the protected services are required, the url parameter should be the public url of the
+     * protected service (not the private one).
+     */
+    @Test
+    public void testGetUrlTarget() throws Exception {
+        proxy.handleUrlGETRequest(request, httpResponse, "http://localhost:8080/geonetwork-private");
+        assertFalse(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+        proxy.handleUrlGETRequest(request, httpResponse, "http://localhost:8080/extractorapp");
+        assertTrue(executed);
+    }
+
+    /**
+     * Ensure that when the proxy form: http://server.com/sec/geonetwork/srv/eng/home is used to access a protected service,
+     * the request should always be allowed no matter the proxy permissions.
+     */
+    @Test
+    public void testGetUrlLegalUrlButTarget() throws Exception {
+        request = new MockHttpServletRequest("GET", "http://localhost:8080/geonetwork-private");
+        proxy.handleGETRequest(request, httpResponse);
+        assertFalse(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        request = new MockHttpServletRequest("GET", "/geonetwork/srv/eng/something");
+        proxy.handleGETRequest(request, httpResponse);
+        assertTrue(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        executed = false;
+        request = new MockHttpServletRequest("GET", "/extractorapp/home");
+        proxy.handleGETRequest(request, httpResponse);
+        assertTrue(executed);
+
+        this.httpResponse = new MockHttpServletResponse();
+        executed = false;
+        request = new MockHttpServletRequest("GET", "/unmapped/x");
+        proxy.handleGETRequest(request, httpResponse);
+        assertFalse(executed);
+    }
+
+    @Test
+    public void testGetUrlIllegalUrl() throws Exception {
+        proxy.handleUrlGETRequest(request, httpResponse, "http://www.google.com:8080/path");
+        assertFalse(executed);
+    }
+
+    @Test
+    public void testLoadPermissions() throws Exception {
+        proxy = new Proxy();
+        proxy.setProxyPermissionsFile("test-permissions.xml");
+        proxy.init();
+
+        final Permissions proxyPermissions = proxy.getProxyPermissions();
+        assertTrue(proxyPermissions.isAllowByDefault());
+        assertEquals(1, proxyPermissions.getAllowed().size());
+        assertEquals(1, proxyPermissions.getDenied().size());
+
+        assertEquals("localhost", proxyPermissions.getAllowed().get(0).getHost());
+        assertEquals(-1, proxyPermissions.getAllowed().get(0).getPort());
+        assertEquals(null, proxyPermissions.getAllowed().get(0).getPath());
+
+        assertEquals("localhost", proxyPermissions.getDenied().get(0).getHost());
+        assertEquals(433, proxyPermissions.getDenied().get(0).getPort());
+        assertEquals("/geonetwork/", proxyPermissions.getDenied().get(0).getPath());
+
+        assertTrue(proxyPermissions.isInitialized());
+    }
+
+    @Test
+    public void testLoadEmptyPermissions() throws Exception {
+        proxy = new Proxy();
+        proxy.setProxyPermissionsFile("empty-permissions.xml");
+        proxy.init();
+
+        // no exception? good
+    }
+}


### PR DESCRIPTION
Fix for Proxy URL parameter vulnerability.

Fix for a vulnerability where client could access localhost resources via proxy url.

Added a permissions file so that the urls that are permitted to be proxied can be controlled.  By default all accesses to localhost (server localhost) are denied.

Also any protected services (extractorapp, geonetwork, etc...) are denied because they must be accessed using the path proxy strategy this way the spring security can add extra authorization checks.
