### PR TITLE
introduced shared.url.scheme in configuration, see #747

### DIFF
--- a/catalogapp/src/main/webapp/app/js/GEOR_where.js
+++ b/catalogapp/src/main/webapp/app/js/GEOR_where.js
@@ -122,7 +122,7 @@ GEOR.where = (function() {
             theme: null,
             projection: epsg900913,
             layers: [
-                new OpenLayers.Layer.OSM('OSM', 'http://tile.openstreetmap.org/${z}/${x}/${y}.png', {
+                new OpenLayers.Layer.OSM('OSM', 'https://tile.openstreetmap.org/${z}/${x}/${y}.png', {
                     buffer: 0,
                     attribution: "Carte CC-By-SA <a href='http://openstreetmap.org/' target='_blank'>OpenStreetMap</a>"
                 })

--- a/config/defaults/extractorapp/maven.filter
+++ b/config/defaults/extractorapp/maven.filter
@@ -6,7 +6,7 @@ instance=@shared.instance.name@
 language=@shared.language@
 
 # The base url of the extractorapp as accessible from outside the intranet
-servletUrl=http://@shared.server.name@:@shared.server.port@/extractorapp
+servletUrl=@shared.url.scheme@://@shared.server.name@:@shared.server.port@/extractorapp
 
 # Hostname of the geoserver that is secured for geOrchestra.
 secureHost=@shared.server.name@

--- a/config/defaults/geonetwork-main/webapp/WEB-INF/config-overrides-georchestra.xml
+++ b/config/defaults/geonetwork-main/webapp/WEB-INF/config-overrides-georchestra.xml
@@ -70,7 +70,7 @@
     </file>
     <file name=".*/WEB-INF/config-gui.xml">
         <addXml xpath="">
-            <geoserver.url>http://${wfs.host}:${wfs.port}/geoserver/</geoserver.url>
+            <geoserver.url>@shared.url.scheme@://${wfs.host}:${wfs.port}/geoserver/</geoserver.url>
         </addXml>
         <replaceAtt xpath="client" attName="widget" value="true"/>
         <replaceAtt xpath="client" attName="url" value="../../apps/georchestra/"/>

--- a/config/defaults/geowebcache-webapp/WEB-INF/classes/gwc.properties
+++ b/config/defaults/geowebcache-webapp/WEB-INF/classes/gwc.properties
@@ -1,2 +1,2 @@
-baseUrl=http://@shared.server.name@:@shared.server.port@
+baseUrl=@shared.url.scheme@://@shared.server.name@:@shared.server.port@
 contextPath=/geowebcache

--- a/config/defaults/ldapadmin/WEB-INF/templates/newaccount-requires-moderation-template.txt
+++ b/config/defaults/ldapadmin/WEB-INF/templates/newaccount-requires-moderation-template.txt
@@ -5,7 +5,7 @@ A new account has been created on @shared.homepage.url@ and is waiting for valid
 User name: {name}
 User ID: {uid}
 
-Visit https://@shared.server.name@/ldapadmin/privateui/#/groups/PENDING_USERS to review the pending users.
+Visit @shared.url.scheme@://@shared.server.name@/ldapadmin/privateui/#/groups/PENDING_USERS to review the pending users.
 
 ---
 Sent by @shared.instance.name@ (@shared.homepage.url@)

--- a/config/shared.maven.filters
+++ b/config/shared.maven.filters
@@ -2,7 +2,8 @@
 
 shared.instance.name=geOrchestra
 
-shared.homepage.url=http://@shared.server.name@/
+shared.url.scheme=http
+shared.homepage.url=@shared.url.scheme@://@shared.server.name@/
 shared.server.port=80
 
 shared.header.height=90


### PR DESCRIPTION
By default `shared.url.scheme` is http (see config/shared.maven.filters), which will match most of the setups.

People having an SDI configured for full HTTPS will take advantage of the newly introduced `shared.url.scheme` variable.

Note: this setting is only relevant for the SDI external URL.
For now, we always assume that it internally uses HTTP.
