### PR TITLE
Fixing log4j configuration for analytics (#731)

### DIFF
--- a/config/defaults/analytics/WEB-INF/classes/log4j.properties
+++ b/config/defaults/analytics/WEB-INF/classes/log4j.properties
@@ -1,6 +1,6 @@
 log4j.rootLogger=@shared.default.log.level@, R
 
-log4j.logger.org.georchestra.analytics=DEBUG, console
+log4j.logger.org.georchestra.analytics=@shared.default.log.level@, R
 
 log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.R.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
@@ -10,6 +10,3 @@ log4j.appender.R.Append = true
 log4j.appender.R.layout = org.apache.log4j.PatternLayout
 log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
 
-log4j.appender.console        = org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout = org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%c] - %m%n


### PR DESCRIPTION
- removes useless console appender
- WARN debug level by default

Manually tested at compilation & runtime level on my dev instance
