### PR TITLE
mapfishapp: addons can escape the tools menu - see #132

### DIFF
--- a/mapfishapp/src/main/webapp/WEB-INF/jsp/debug-includes.jsp
+++ b/mapfishapp/src/main/webapp/WEB-INF/jsp/debug-includes.jsp
@@ -51,6 +51,7 @@
     <script type="text/javascript" src="<%= context %>/app/js/GEOR_Lang/<%= lang %>.js"></script>
     <script type="text/javascript" src="<%= context %>/app/js/GEOR_querier.js"></script>
     <script type="text/javascript" src="<%= context %>/app/js/GEOR_styler.js"></script>
+    <script type="text/javascript" src="<%= context %>/app/js/GEOR_addons.js"></script>
     <script type="text/javascript" src="<%= context %>/app/js/GEOR_getfeatureinfo.js"></script>
     <script type="text/javascript" src="<%= context %>/app/js/GEOR_ResultsPanel.js"></script>
     <script type="text/javascript" src="<%= context %>/app/js/GEOR_util.js"></script>

--- a/mapfishapp/src/main/webapp/app/addons/README.md
+++ b/mapfishapp/src/main/webapp/app/addons/README.md
@@ -71,11 +71,12 @@ Ext.namespace("GEOR.Addons");
 GEOR.Addons.Test = function(map, options) {
     this.map = map;
     this.options = options;
-    this.cmps = null;
-    this.parent = null;
 };
 
 GEOR.Addons.Test.prototype = {
+    cmps: null,
+    parent: null,
+
     /**
      * Method: init
      *

--- a/mapfishapp/src/main/webapp/app/addons/README.md
+++ b/mapfishapp/src/main/webapp/app/addons/README.md
@@ -49,23 +49,25 @@ Starting from geOrchestra 14.12, addons are able to escape the "tools" menu to w
 This is achieved through the use of the optional ```target``` property in their configuration options.
 
 Example ```init``` method taking into account the target property:
-```
+```js
     init: function(record) {
         if (this.target) {
             // addon placed in toolbar
             this.components = this.target.insertButton(this.position, {
                 xtype: 'button',
-                tooltip: this.getTooltip(record),
+                tooltip: this.getTooltip(record), // method provided by GEOR.Addons.Base
                 iconCls: 'addon-xxx',
-                handler: ...
+                handler: ...,
+                scope: this
             });
             this.target.doLayout();
         } else {
             // addon placed in "tools menu"
             this.item = new Ext.menu.Item({
-                text: this.getText(record),
-                qtip: this.getQtip(record),
-                handler: this.showWindow,
+                text: this.getText(record), // method provided by GEOR.Addons.Base
+                qtip: this.getQtip(record), // method provided by GEOR.Addons.Base
+                iconCls: 'addon-xxx',
+                handler: ...,
                 scope: this
             });
         }
@@ -89,7 +91,7 @@ Example configuration:
     }
 ```
 With the above configuration (```"target": "tbar_11"```), the addon button will be inserted in the top toolbar, at position 11.
-At the moment, the target can be one of ```tbar```, ```bbar``` for the bottom tollbar, ```tabs``` for the tabpanel in the lower right corner of the screen.
+At the moment, the target can be one of ```tbar```, ```bbar``` for the bottom toolbar, ```tabs``` for the tabpanel in the lower right corner of the screen.
 
 If no target is specified, the addon will have the default behavior (as before) and it's component will be placed inside the "tools" menu.
 

--- a/mapfishapp/src/main/webapp/app/addons/README.md
+++ b/mapfishapp/src/main/webapp/app/addons/README.md
@@ -61,3 +61,57 @@ If the addon instance exposes a public property named ```item```, the referenced
 
 
 If developing a new addon, you might want to start from a simple example, eg the [magnifier](magnifier/README.md) addon.
+
+### How to create an addon which adds its own components into an existing component ?
+
+Here's an example which inserts a textfield into the top toolbar:
+```js
+Ext.namespace("GEOR.Addons");
+
+GEOR.Addons.Test = function(map, options) {
+    this.map = map;
+    this.options = options;
+    this.cmps = null;
+    this.parent = null;
+};
+
+GEOR.Addons.Test.prototype = {
+    /**
+     * Method: init
+     *
+     * Parameters:
+     * record - {Ext.data.record} a record with the addon parameters
+     */
+    init: function(record) {
+        // attach to top toolbar:
+        this.parent = GeoExt.MapPanel.guess().getTopToolbar();
+        this.cmps = this.parent.insertButton(11, ['-', {
+            xtype: 'textfield',
+            value: "inserted"
+        }]);
+        this.parent.doLayout();
+    },
+
+    /**
+     * Method: destroy
+     * Called by GEOR_tools when deselecting this addon
+     */
+    destroy: function() {
+        if (Ext.isArray(this.cmps)) {
+            var p = this.parent;
+            Ext.each(this.cmps, function(cmp) {
+                p.remove(cmp);
+            });
+        } else {
+            this.parent.remove(this.cmps);
+        }
+        this.cmp = null;
+        this.map = null;
+    }
+};
+```
+
+For the bottom toolbar, you would use:
+```
+this.parent = GeoExt.MapPanel.guess().getBottomToolbar();
+```

--- a/mapfishapp/src/main/webapp/app/addons/annotation/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/annotation/js/main.js
@@ -1,16 +1,11 @@
 Ext.namespace("GEOR.Addons");
 
-GEOR.Addons.Annotation = function(map, options) {
-    this.map = map;
-    this.options = options;
-    this.control = null;
-    this.item = null;
-    this.window = null;
-};
+GEOR.Addons.Annotation = Ext.extend(GEOR.Addons.Base, {
 
-// If required, may extend or compose with Ext.util.Observable
-//Ext.extend(GEOR.Addons.Annotation, Ext.util.Observable, {
-GEOR.Addons.Annotation.prototype = {
+    control: null,
+
+    window: null,
+
     /**
      * Method: init
      *
@@ -18,7 +13,6 @@ GEOR.Addons.Annotation.prototype = {
      * record - {Ext.data.record} a record with the addon parameters
      */
     init: function(record) {
-
         var annotation = new GEOR.Annotation({
             map: this.map,
             popupOptions: {unpinnable: false, draggable: true}
@@ -38,32 +32,46 @@ GEOR.Addons.Annotation.prototype = {
             }],
             listeners: {
                 "hide": function() {
-                    item.setChecked(false);
+                    this.item && this.item.setChecked(false);
+                    this.components && this.components.toggle(false);
                 },
                 scope: this
             }
         });
-
-        var lang = OpenLayers.Lang.getCode(),
-            item = new Ext.menu.CheckItem({
-                text: record.get("title")[lang] || record.get("title")["en"],
-                qtip: record.get("description")[lang] || record.get("description")["en"],
+  
+        if (this.target) {
+            // create a button to be inserted in toolbar:
+            this.components = this.target.insertButton(this.position, {
+                xtype: 'button',
+                enableToggle: true,
+                tooltip: this.getTooltip(record),
                 iconCls: "addon-annotation",
-                checked: false,
                 listeners: {
-                    "checkchange": this.onCheckchange,
+                    "checkchange": this._onCheckchange,
                     scope: this
                 }
             });
-        this.item = item;
-        return item;
+            this.target.doLayout();
+        } else {
+            // create a menu item for the "tools" menu:
+            this.item =  new Ext.menu.CheckItem({
+                text: this.getText(record),
+                qtip: this.getQtip(record),
+                iconCls: "addon-annotation",
+                checked: false,
+                listeners: {
+                    "checkchange": this._onCheckchange,
+                    scope: this
+                }
+            });
+        }
     },
 
     /**
-     * Method: onCheckchange
+     * Method: _onCheckchange
      * Callback on checkbox state changed
      */
-    onCheckchange: function(item, checked) {
+    _onCheckchange: function(item, checked) {
         if (checked) {
             this.window.show();
             this.window.alignTo(
@@ -84,6 +92,7 @@ GEOR.Addons.Annotation.prototype = {
     destroy: function() {
         this.window.hide();
         this.control = null;
-        this.map = null;
+
+        GEOR.Addons.Base.prototype.destroy.call(this);
     }
-};
+});

--- a/mapfishapp/src/main/webapp/app/addons/annotation/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/annotation/js/main.js
@@ -43,13 +43,10 @@ GEOR.Addons.Annotation = Ext.extend(GEOR.Addons.Base, {
             // create a button to be inserted in toolbar:
             this.components = this.target.insertButton(this.position, {
                 xtype: 'button',
-                enableToggle: true,
                 tooltip: this.getTooltip(record),
                 iconCls: "addon-annotation",
-                listeners: {
-                    "checkchange": this._onCheckchange,
-                    scope: this
-                }
+                handler: this._onCheckchange,
+                scope: this
             });
             this.target.doLayout();
         } else {

--- a/mapfishapp/src/main/webapp/app/addons/cadastre/README.md
+++ b/mapfishapp/src/main/webapp/app/addons/cadastre/README.md
@@ -31,15 +31,15 @@ Typical configuration to include in your GEOR_custom.js file:
             "tab1": {
                 "field1": {
                     "file": "cities.json",
-                    "valuefield": "code_insee",
-                    "displayfield": "nom_com",
-                    "template": "<b>{nom_com}</b> ({code_dep})"
+                    "valuefield": "INSE",
+                    "displayfield": "COMMUNE",
+                    "template": "<b>{COMMUNE}</b> ({INSE})"
                 },
                 "field2": {
                     "wfs": "http://ids.pigma.org/geoserver/ign/wfs",
                     "typename": "ign:ign_bdparcellaire_sections",
                     "matchingproperties": {
-                        "field1": "code_insee"
+                        "field1": "INSE"
                     },
                     "valuefield": "section",
                     "displayfield": "section",
@@ -59,7 +59,7 @@ Typical configuration to include in your GEOR_custom.js file:
             },
             "tab2": {
                 "field2": {
-                    "wfs": "http://ids.pigma.org/geoserver/cadastre/wfs",
+                    "wfs": "https://ids.pigma.org/geoserver/cadastre/wfs",
                     "typename": "cadastre:localisants_bdparc_majic2012",
                     "matchingproperties": {
                         "field1": "code_insee"

--- a/mapfishapp/src/main/webapp/app/addons/cadastre/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/cadastre/js/main.js
@@ -81,7 +81,7 @@ GEOR.Addons.Cadastre = Ext.extend(GEOR.Addons.Base, {
             this.target.doLayout();
         } else {
             // return menu item:
-            this.item = new Ext.menu.Item({
+            this.item = new Ext.menu.CheckItem({
                 text: this.getText(record),
                 qtip: this.getQtip(record),
                 iconCls: 'cadastre-icon',
@@ -167,6 +167,8 @@ GEOR.Addons.Cadastre = Ext.extend(GEOR.Addons.Base, {
                 listeners: {
                     "hide": function() {
                         this.map.removeLayer(this.layer);
+                        this.item && this.item.setChecked(false);
+                        this.components && this.components.toggle(false);
                     },
                     scope: this
                 }

--- a/mapfishapp/src/main/webapp/app/addons/cadastre/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/cadastre/js/main.js
@@ -18,7 +18,6 @@ GEOR.Addons.Cadastre = Ext.extend(GEOR.Addons.Base, {
      * record - {Ext.data.record} a record with the addon parameters
      */
     init: function(record) {
-        var lang = OpenLayers.Lang.getCode();
         Ext.iterate(this.options.tab1, function(k, v) {
             this.fieldNames.push(k);
         }, this);

--- a/mapfishapp/src/main/webapp/app/addons/cadastre/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/cadastre/js/main.js
@@ -1,23 +1,6 @@
 Ext.namespace("GEOR.Addons");
 
-GEOR.Addons.Cadastre = function(map, options) {
-    this.map = map;
-    this.options = options;
-};
-
-GEOR.Addons.Cadastre.BaseComboConfig = {
-    forceSelection: false,
-    width: 190,
-    itemSelector: '.x-combo-list-item'
-};
-GEOR.Addons.Cadastre.BaseFormConfig = {
-    labelWidth: 80,
-    labelSeparator: OpenLayers.i18n("labelSeparator"),
-    bodyStyle: 'padding: 10px',
-    height: 110
-};
-
-GEOR.Addons.Cadastre.prototype = {
+GEOR.Addons.Cadastre = Ext.extend(GEOR.Addons.Base, {
     item: null,
     stores: {},
     layer: null,
@@ -87,15 +70,26 @@ GEOR.Addons.Cadastre.prototype = {
                 fields: fields
             });
         }, this);
-        // return menu item:
-        this.item = new Ext.menu.Item({
-            text: record.get("title")[lang] || record.get("title")["en"],
-            qtip: record.get("description")[lang] || record.get("description")["en"],
-            iconCls: 'cadastre-icon',
-            handler: this.showWindow,
-            scope: this
-        });
-        return this.item;
+        
+        if (this.target) {
+            this.components = this.target.insertButton(this.position, {
+                xtype: 'button',
+                iconCls: 'cadastre-icon',
+                tooltip: this.getTooltip(record),
+                handler: this.showWindow,
+                scope: this
+            });
+            this.target.doLayout();
+        } else {
+            // return menu item:
+            this.item = new Ext.menu.Item({
+                text: this.getText(record),
+                qtip: this.getQtip(record),
+                iconCls: 'cadastre-icon',
+                handler: this.showWindow,
+                scope: this
+            });
+        }
     },
 
 
@@ -537,10 +531,22 @@ GEOR.Addons.Cadastre.prototype = {
         }, GEOR.Addons.Cadastre.BaseFormConfig));
     },
 
-
     destroy: function() {
-        this.win.hide();
+        this.win && this.win.hide();
         this.layer = null;
-        this.map = null;
+
+        GEOR.Addons.Base.prototype.destroy.call(this);
     }
+});
+
+GEOR.Addons.Cadastre.BaseComboConfig = {
+    forceSelection: false,
+    width: 190,
+    itemSelector: '.x-combo-list-item'
+};
+GEOR.Addons.Cadastre.BaseFormConfig = {
+    labelWidth: 80,
+    labelSeparator: OpenLayers.i18n("labelSeparator"),
+    bodyStyle: 'padding: 10px',
+    height: 110
 };

--- a/mapfishapp/src/main/webapp/app/addons/extractor/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/extractor/js/main.js
@@ -1,10 +1,5 @@
 Ext.namespace("GEOR.Addons");
 
-GEOR.Addons.Extractor = function(map, options) {
-    this.map = map;
-    this.options = options;
-};
-
 /*
  * TODO: 
  * - handle dlform
@@ -12,7 +7,7 @@ GEOR.Addons.Extractor = function(map, options) {
  * - wizard (1 choose layers (NOK report here) 2 choose extent 3 choose formats 4 enter email )
  * - modifyFeature control improved: non symetrical mode when OpenLayers.Control.ModifyFeature.RESIZE
  */
-GEOR.Addons.Extractor.prototype = {
+GEOR.Addons.Extractor = Ext.extend(GEOR.Addons.Base, {
     win: null,
     jsonFormat: null,
     layer: null,
@@ -23,6 +18,7 @@ GEOR.Addons.Extractor.prototype = {
     rasterFormatField: null,
     resField: null,
     emailField: null,
+
     /**
      * Method: init
      *
@@ -30,7 +26,6 @@ GEOR.Addons.Extractor.prototype = {
      * record - {Ext.data.record} a record with the addon parameters
      */
     init: function(record) {
-        var lang = OpenLayers.Lang.getCode();
         this.jsonFormat = new OpenLayers.Format.JSON();
         var style = {
             externalGraphic: GEOR.config.PATHNAME + "/app/addons/extractor/img/shading.png",
@@ -59,14 +54,27 @@ GEOR.Addons.Extractor.prototype = {
                 OpenLayers.Control.ModifyFeature.DRAG,
             autoActivate: true
         });
-        this.item = new Ext.menu.Item({
-            text: record.get("title")[lang] || record.get("title")["en"],
-            qtip: record.get("description")[lang] || record.get("description")["en"],
-            iconCls: 'extractor-icon',
-            handler: this.showWindow,
-            scope: this
-        });
-        return this.item;
+
+        if (this.target) {
+            // create a button to be inserted in toolbar:
+            this.components = this.target.insertButton(this.position, {
+                xtype: 'button',
+                tooltip: this.getTooltip(record),
+                iconCls: 'extractor-icon',
+                handler: this.showWindow,
+                scope: this
+            });
+            this.target.doLayout();
+        } else {
+            // create a menu item for the "tools" menu:
+            this.item =  new Ext.menu.CheckItem({
+                text: this.getText(record),
+                qtip: this.getQtip(record),
+                iconCls: 'extractor-icon',
+                handler: this.showWindow,
+                scope: this
+            });
+        }
     },
     
     createWindow: function() {
@@ -178,6 +186,8 @@ GEOR.Addons.Extractor.prototype = {
                     this.map.removeLayer(this.layer);
                     this.modifyControl.unselectFeature(this.layer.features[0]);
                     this.map.removeControl(this.modifyControl);
+                    this.item && this.item.setChecked(false);
+                    this.components && this.components.toggle(false);
                 },
                 scope: this
             }
@@ -286,8 +296,9 @@ GEOR.Addons.Extractor.prototype = {
     destroy: function() {
         this.win.hide();
         this.layer = null;
-        this.map = null;
         this.jsonFormat = null;
         this.modifyControl = null;
+        
+        GEOR.Addons.Base.prototype.destroy.call(this);
     }
-};
+});

--- a/mapfishapp/src/main/webapp/app/addons/extractor/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/extractor/js/main.js
@@ -294,7 +294,7 @@ GEOR.Addons.Extractor = Ext.extend(GEOR.Addons.Base, {
     },
 
     destroy: function() {
-        this.win.hide();
+        this.win && this.win.hide();
         this.layer = null;
         this.jsonFormat = null;
         this.modifyControl = null;

--- a/mapfishapp/src/main/webapp/app/addons/magnifier/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/magnifier/js/main.js
@@ -16,7 +16,7 @@ GEOR.Addons.Magnifier = Ext.extend(GEOR.Addons.Base, {
      */
     init: function(record) {
         if (this.target) {
-            // create button to be inserted in toolbar:
+            // create a button to be inserted in toolbar:
             this.components = this.target.insertButton(this.position, {
                 xtype: 'button',
                 enableToggle: true,
@@ -29,7 +29,7 @@ GEOR.Addons.Magnifier = Ext.extend(GEOR.Addons.Base, {
             });
             this.target.doLayout();
         } else {
-            // create menu item for the "tools" menu:
+            // create a menu item for the "tools" menu:
             this.item =  new Ext.menu.CheckItem({
                 text: this.getText(record),
                 qtip: this.getQtip(record),

--- a/mapfishapp/src/main/webapp/app/addons/magnifier/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/magnifier/js/main.js
@@ -1,15 +1,13 @@
 Ext.namespace("GEOR.Addons");
 
-GEOR.Addons.Magnifier = function(map, options) {
-    this.map = map;
-    this.options = options;
-    this.control = null;
-    this.item = null;
-};
+GEOR.Addons.Magnifier = Ext.extend(GEOR.Addons.Base, {
 
-// If required, may extend or compose with Ext.util.Observable
-//Ext.extend(GEOR.Addons.Magnifier, Ext.util.Observable, { 
-GEOR.Addons.Magnifier.prototype = {
+    /**
+     * Property: control
+     * {OpenLayers.Control.Magnifier}
+     */
+    control: null,
+
     /**
      * Method: init
      *
@@ -17,19 +15,31 @@ GEOR.Addons.Magnifier.prototype = {
      * record - {Ext.data.record} a record with the addon parameters
      */
     init: function(record) {
-        var lang = OpenLayers.Lang.getCode(),
-            item = new Ext.menu.CheckItem({
-                text: record.get("title")[lang] || record.get("title")["en"],
-                qtip: record.get("description")[lang] || record.get("description")["en"],
-                //iconCls: "addon-magnifier",
+        if (this.target) {
+            // create button to be inserted in toolbar:
+            this.components = this.target.insertButton(this.position, {
+                xtype: 'button',
+                enableToggle: true,
+                tooltip: this.getTooltip(record),
+                iconCls: 'addon-magnifier',
+                listeners: {
+                    "toggle": this.onCheckchange,
+                    scope: this
+                }
+            });
+            this.target.doLayout();
+        } else {
+            // create menu item for the "tools" menu:
+            this.item =  new Ext.menu.CheckItem({
+                text: this.getText(record),
+                qtip: this.getQtip(record),
                 checked: false,
                 listeners: {
                     "checkchange": this.onCheckchange,
                     scope: this
                 }
             });
-        this.item = item;
-        return item;
+        }
     },
 
     /**
@@ -54,6 +64,7 @@ GEOR.Addons.Magnifier.prototype = {
     destroy: function() {
         this.control && this.control.destroy();
         this.control = null;
-        this.map = null;
+
+        GEOR.Addons.Base.prototype.destroy.call(this);
     }
-};
+});

--- a/mapfishapp/src/main/webapp/app/addons/magnifier/manifest.json
+++ b/mapfishapp/src/main/webapp/app/addons/magnifier/manifest.json
@@ -9,10 +9,10 @@
     "default_options": {
         "mode": "static",
         "baseLayerConfig": {
-            "wmsurl": "http://tile.geobretagne.fr/gwc02/service/wms",
-            "layer": "satellite",
+            "wmsurl": "http://sdi.georchestra.org/geoserver/wms",
+            "layer": "unearthedoutdoors:truemarble",
             "format": "image/jpeg",
-            "buffer": 8
+            "buffer": 1
         }
     },
     "i18n": {

--- a/mapfishapp/src/main/webapp/app/addons/openls/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/openls/js/main.js
@@ -1,11 +1,6 @@
 Ext.namespace("GEOR.Addons");
 
-GEOR.Addons.OpenLS = function(map, options) {
-    this.map = map;
-    this.options = options;
-};
-
-GEOR.Addons.OpenLS.prototype = {
+GEOR.Addons.OpenLS = Ext.extend(GEOR.Addons.Base, {
     win: null,
     addressField: null,
     layer: null,
@@ -56,6 +51,8 @@ GEOR.Addons.OpenLS.prototype = {
                     this.popup && this.popup.hide();
                     this.layer.destroyFeatures();
                     this.map.removeLayer(this.layer);
+                    this.item && this.item.setChecked(false);
+                    this.components && this.components.toggle(false);
                 },
                 "show": function() {
                     this.map.addLayer(this.layer);
@@ -63,16 +60,27 @@ GEOR.Addons.OpenLS.prototype = {
                 scope: this
             }
         });
-        var lang = OpenLayers.Lang.getCode(),
-            item = new Ext.menu.Item({
-                text: record.get("title")[lang] || record.get("title")["en"],
-                qtip: record.get("description")[lang] || record.get("description")["en"],
+
+        if (this.target) {
+            // create a button to be inserted in toolbar:
+            this.components = this.target.insertButton(this.position, {
+                xtype: 'button',
+                tooltip: this.getTooltip(record),
+                iconCls: 'addon-openls',
+                handler: this.showWindow,
+                scope: this
+            });
+            this.target.doLayout();
+        } else {
+            // create a menu item for the "tools" menu:
+            this.item =  new Ext.menu.CheckItem({
+                text: this.getText(record),
+                qtip: this.getQtip(record),
                 iconCls: "addon-openls",
                 handler: this.showWindow,
                 scope: this
             });
-        this.item = item;
-        return item;
+        }
     },
 
     /**
@@ -265,6 +273,7 @@ GEOR.Addons.OpenLS.prototype = {
         this.popup.destroy();
         this.popup = null;
         this.layer = null;
-        this.map = null;
+        
+        GEOR.Addons.Base.prototype.destroy.call(this);
     }
-};
+});

--- a/mapfishapp/src/main/webapp/app/addons/openls/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/openls/js/main.js
@@ -270,7 +270,7 @@ GEOR.Addons.OpenLS = Ext.extend(GEOR.Addons.Base, {
      */
     destroy: function() {
         this.win.hide();
-        this.popup.destroy();
+        this.popup && this.popup.destroy();
         this.popup = null;
         this.layer = null;
         

--- a/mapfishapp/src/main/webapp/app/addons/streetview/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/streetview/js/main.js
@@ -361,8 +361,8 @@ GEOR.Addons.Streetview = Ext.extend(GEOR.Addons.Base, {
         this._drawControl = null;
         this._modifyControl && this._modifyControl.destroy();
         this._modifyControl = null;
-        this.map.removeLayer(this._layer);
-        this.map.removeLayer(this._fovLayer);
+        this._layer.map && this.map.removeLayer(this._layer);
+        this._fovLayer.map && this.map.removeLayer(this._fovLayer);
         this._window.destroy();
         this._window = null;
         this._layer = null;

--- a/mapfishapp/src/main/webapp/app/addons/streetview/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/streetview/js/main.js
@@ -1,11 +1,6 @@
 Ext.namespace("GEOR.Addons");
 
-GEOR.Addons.Streetview = function(map, options) {
-    this.map = map;
-    this.options = options;
-};
-
-GEOR.Addons.Streetview.prototype = {
+GEOR.Addons.Streetview = Ext.extend(GEOR.Addons.Base, {
     _layer: null,
     _fovLayer: null,
     _modifyControl: null,
@@ -120,7 +115,8 @@ GEOR.Addons.Streetview.prototype = {
             }],
             listeners: {
                 "hide": function() {
-                    item.setChecked(false);
+                    this.item && this.item.setChecked(false);
+                    this.components && this.components.toggle(false);
                 },
                 "resize": this._updateView,
                 "show": {
@@ -133,10 +129,25 @@ GEOR.Addons.Streetview.prototype = {
                 scope: this
             }
         });
-        var lang = OpenLayers.Lang.getCode(),
-            item = new Ext.menu.CheckItem({
-                text: record.get("title")[lang] || record.get("title")["en"],
-                qtip: record.get("description")[lang] || record.get("description")["en"],
+
+        if (this.target) {
+            // create a button to be inserted in toolbar:
+            this.components = this.target.insertButton(this.position, {
+                xtype: 'button',
+                enableToggle: true,
+                tooltip: this.getTooltip(record),
+                iconCls: "addon-streetview",
+                listeners: {
+                    "toggle": this._onCheckchange,
+                    scope: this
+                }
+            });
+            this.target.doLayout();
+        } else {
+            // create a menu item for the "tools" menu:
+            this.item =  new Ext.menu.CheckItem({
+                text: this.getText(record),
+                qtip: this.getQtip(record),
                 iconCls: "addon-streetview",
                 checked: false,
                 listeners: {
@@ -144,8 +155,7 @@ GEOR.Addons.Streetview.prototype = {
                     scope: this
                 }
             });
-        this.item = item;
-        return item;
+        }
     },
 
     /**
@@ -357,6 +367,7 @@ GEOR.Addons.Streetview.prototype = {
         this._window = null;
         this._layer = null;
         this._fovLayer = null;
-        this.map = null;
+        
+        GEOR.Addons.Base.prototype.destroy.call(this);
     }
-};
+});

--- a/mapfishapp/src/main/webapp/app/addons/streetview/js/main.js
+++ b/mapfishapp/src/main/webapp/app/addons/streetview/js/main.js
@@ -77,7 +77,7 @@ GEOR.Addons.Streetview = Ext.extend(GEOR.Addons.Base, {
             title: OpenLayers.i18n("StreetView"),
             closable: true,
             x: 0,
-            y: 0,
+            y: 120,
             minHeight: 200,
             minWidth: 200,
             boxMaxHeight: 640,

--- a/mapfishapp/src/main/webapp/app/js/GEOR.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR.js
@@ -191,6 +191,7 @@ Ext.namespace("GEOR");
                 // this panel contains the components for
                 // recentering the map
                 region: "south",
+                id: "tabs",
                 collapseMode: "mini",
                 collapsible: true,
                 deferredRender: false,

--- a/mapfishapp/src/main/webapp/app/js/GEOR_addons.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_addons.js
@@ -1,0 +1,73 @@
+Ext.namespace("GEOR.Addons");
+
+GEOR.Addons.Base = Ext.extend(Object, {
+
+    constructor: function(map, options) {
+        this.map = map;
+        this.options = options;
+        this.components = null;
+        this.lang = OpenLayers.Lang.getCode();
+        if (this.options.target) {
+            var t = this.options.target.split("_"),
+                target = t[0];
+            this.position = parseInt(t[1]) || 0;
+            this.target = null;
+            switch (target) {
+                // top toolbar:
+                case "tbar":
+                    this.target = GeoExt.MapPanel.guess().getTopToolbar();
+                    break;
+                // bottom toolbar:
+                case "bbar":
+                    this.target = GeoExt.MapPanel.guess().getBottomToolbar();
+                    break;
+                // mini tabpanel in lower right corner:
+                case "tabs":
+                    this.target = Ext.getCmp("tabs");
+                    break;
+            }
+        }
+    },
+
+    /**
+     * Method: getTooltip
+     */
+    getTooltip: function(record) {
+        return [
+            "<b>",
+            this.getText(record),
+            "</b><br>",
+            this.getQtip(record)
+        ].join('');
+    },
+
+    /**
+     * Method: getText
+     */
+    getText: function(record) {
+        return record.get("title")[this.lang]
+            || record.get("title")["en"];
+    },
+
+    /**
+     * Method: getQtip
+     */
+    getQtip: function(record) {
+        return record.get("description")[this.lang]
+            || record.get("description")["en"];
+    },
+
+    /**
+     * Method: destroy
+     * Called by GEOR_tools when deselecting this addon
+     */
+    destroy: function() {
+        if (this.target) {
+            Ext.each(this.components, function(cmp) {
+                this.target.remove(cmp);
+            }, this);
+            this.components = null;
+        }
+        this.map = null;
+    }
+});

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mappanel.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mappanel.js
@@ -159,6 +159,7 @@ GEOR.mappanel = (function() {
         map.addControl(mpControl);
 
         return {
+            id: "bbar",
             items: items
         };
     };

--- a/mapfishapp/src/main/webapp/app/js/GEOR_toolbar.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_toolbar.js
@@ -62,7 +62,7 @@ GEOR.toolbar = (function() {
      * {Ext.Toolbar} The toolbar.
      */
     var createTbar = function(layerStore) {
-        var map = layerStore.map, tbar = new Ext.Toolbar(), ctrl, items = [];
+        var map = layerStore.map, tbar = new Ext.Toolbar({id: "tbar"}), ctrl, items = [];
 
         ctrl = new OpenLayers.Control.ZoomToMaxExtent();
         items.push(new GeoExt.Action({

--- a/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
@@ -231,8 +231,10 @@ GEOR.tools = (function() {
         Ext.each(outgoing, function(r) {
             var addon = addonsCache[r.id],
                 item = addon.item;
-            menu.remove(item, true);
-            addon.destroy();
+            if (item) {
+                menu.remove(item, true);
+            }
+            addon.destroy(); // will be used by the addon to remove its component
             delete addonsCache[r.id];
             r.set("_loaded", false);
         });
@@ -273,7 +275,8 @@ GEOR.tools = (function() {
                     var js = [], 
                         o = (new OpenLayers.Format.JSON()).read(
                             response.responseText
-                        );
+                        ),
+                        popmsg = false; // no message popping down by default
                     // handle i18n
                     if (o.i18n) {
                         Ext.iterate(o.i18n, function(k, v) {
@@ -312,14 +315,23 @@ GEOR.tools = (function() {
                                     break;
                                 }
                             }
-                            // handle menuitem qtip:
-                            addon.item.on('afterrender', GEOR.util.registerTip);
-                            // here we know it should be inserted at position i from the beginning
-                            menu.insert(i + 2, addon.item);
+                            if (addon.item) {
+                                // "one addon hidden in the tools menu" means
+                                // that the popping down message has to be displayed:
+                                popmsg = true;
+                                // handle menuitem qtip:
+                                addon.item.on('afterrender', GEOR.util.registerTip);
+                                // here we know it should be inserted at position i from the beginning
+                                menu.insert(i + 2, addon.item);
+                            } else {
+                                // if there is no addon.item, it means the addon takes care of 
+                                // inserting his own component into the viewport
+                                // and calling doLayout on the parent component.
+                            }
                         }, this, true);
                     }
                     // inform user:
-                    if (count == 0 && !silent) {
+                    if (popmsg && count == 0 && !silent) {
                         GEOR.helper.msg(tr("Tools"), 
                             tr("Your new tools are now available in the tools menu."));
                     }

--- a/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
@@ -23,6 +23,7 @@
  * @include GEOR_waiter.js
  * @include GEOR_config.js
  * @include GEOR_localStorage.js
+ * @include GEOR_addons.js
  * @include GEOR_util.js
  */
 

--- a/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
@@ -323,7 +323,7 @@ GEOR.tools = (function() {
                                 // handle menuitem qtip:
                                 addon.item.on('afterrender', GEOR.util.registerTip);
                                 // here we know it should be inserted at position i from the beginning
-                                menu.insert(i + 2, addon.item);
+                                menu.insert(i + 5, addon.item);
                             } else {
                                 // if there is no addon.item, it means the addon takes care of 
                                 // inserting his own component into the viewport
@@ -575,6 +575,12 @@ GEOR.tools = (function() {
             menu = new Ext.menu.Menu({
                 defaultAlign: "tr-br",
                 items: [
+                    {
+                        text: tr("Manage tools"),
+                        hideOnClick: false,
+                        iconCls: "add",
+                        handler: showToolSelection
+                    }, '-',
                     new Ext.menu.CheckItem(
                         new GeoExt.Action({
                             text: tr("distance measure"),
@@ -591,12 +597,7 @@ GEOR.tools = (function() {
                             group: "_measure",
                             iconCls: "measure_area"
                         })
-                    ), '-', {
-                        text: tr("Manage tools"),
-                        hideOnClick: false,
-                        iconCls: "add",
-                        handler: showToolSelection
-                    }
+                    ), '-'
                 ]
             });
             return new Ext.Button({


### PR DESCRIPTION
This improvement gives more freedom when developing addons.

Addons had to expose a public "item" property (a menu item), which was added to the "tools" menu.
This not mandatory anymore. An example is provided in the addons/README.md file.