### PR TITLE
Fix missing session's attributes in LDAPAdmin forms [TC7]

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/changepassword/ChangePasswordFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/changepassword/ChangePasswordFormController.java
@@ -135,7 +135,9 @@ public class ChangePasswordFormController {
 
 		}
 	}
-
-
-
+	
+	@ModelAttribute("changePasswordFormBean")
+	public ChangePasswordFormBean getChangePasswordFormBean() {
+		return new ChangePasswordFormBean();
+	}
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/edituserdetails/EditUserDetailsFormController.java
@@ -220,4 +220,9 @@ public class EditUserDetailsFormController {
 	public void setAccountBackup(Account a) {
 	    this.accountBackup = a;
 	}
+	
+	@ModelAttribute("editUserDetailsFormBean")
+	public EditUserDetailsFormBean getEditUserDetailsFormBean() {
+		return new EditUserDetailsFormBean();
+	}
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/newaccount/NewAccountFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/newaccount/NewAccountFormController.java
@@ -193,4 +193,9 @@ public final class NewAccountFormController {
 			throw new IOException(e);
 		}
 	}
+	
+	@ModelAttribute("accountFormBean")
+	public AccountFormBean getAccountFormBean() {
+		return new AccountFormBean();
+	}
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/passwordrecovery/NewPasswordFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/passwordrecovery/NewPasswordFormController.java
@@ -143,5 +143,9 @@ public class NewPasswordFormController {
 			
 		} 
 	}
-
+	
+	@ModelAttribute("newPasswordFormBean")
+	public NewPasswordFormBean getNewPasswordFormBean() {
+		return new NewPasswordFormBean();
+	}
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/passwordrecovery/PasswordRecoveryFormController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/passwordrecovery/PasswordRecoveryFormController.java
@@ -189,4 +189,9 @@ public class PasswordRecoveryFormController  {
 		
 		return url;
 	}
+	
+	@ModelAttribute("passwordRecoveryFormBean")
+	public PasswordRecoveryFormBean getPasswordRecoveryFormBean() {
+		return new PasswordRecoveryFormBean();
+	}
 }


### PR DESCRIPTION
When I try to submit new account creation form in LDAPadmin, I get this exception : 

org.springframework.web.HttpSessionRequiredException: Expected session attribute 'accountFormBean'

I found how to solve it in this thread : http://stackoverflow.com/questions/17737913/http-status-500-expected-session-attribute-userobject

The solution is to add a ModelAttribute method at the end of the NewAccountFormController class, cf. changes in file.

I don't know why I'm the only one to get this error and why this block of code correct it...