### PR TITLE
[Mapfish] Enable CQL Filter by JSON POST

### DIFF
--- a/mapfishapp/README.md
+++ b/mapfishapp/README.md
@@ -40,7 +40,8 @@ It is also possible to POST a JSON string to the home controller, for instance :
         "layers": [{
             "layername": "ign:ign_bdtopo_departement",
             "owstype": "WMS",
-            "owsurl": "http://ids.pigma.org/geoserver/ign/wms"
+            "owsurl": "http://ids.pigma.org/geoserver/ign/wms",
+            "cql_filter": "id_dept = 47"
         }, {
             "layername": "ign:ign_bdtopo_region",
             "owstype": "WMS",
@@ -48,7 +49,7 @@ It is also possible to POST a JSON string to the home controller, for instance :
         }]
     }
 
-In response, the viewer will add the above two layers to the map, and display a dialog window showing the layers from the http://ids.pigma.org/geoserver/ign_r/wms WMS server.
+In response, the viewer will add the above two layers to the map, and display a dialog window showing the layers from the http://ids.pigma.org/geoserver/ign_r/wms WMS server. The department will only display features which have id_dept equals to 47.
 
 
 CSWquerier

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -22,6 +22,7 @@
  * @include OpenLayers/Projection.js
  * @include OpenLayers/Format/JSON.js
  * @include OpenLayers/Format/GeoJSON.js
+ * @include OpenLayers/Format/CQL.js
  * @include GeoExt/data/LayerRecord.js
  * @include GeoExt/data/LayerStore.js
  * @include GeoExt/data/WMSCapabilitiesReader.js

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -318,6 +318,18 @@ GEOR.mapinit = (function() {
                     return (r.get('name') == item.name);
                 }).first();
                 if (record) {
+                    // handle cql_filter param in JSON POST
+                    if( type == "WFS" ) {
+                        if ( !(typeof item.cql_filter === 'undefined') ) {
+                            var format = new OpenLayers.Format.CQL();
+                            record.data.layer.filter = format.read(item.cql_filter);
+                        }
+                    } else {
+                        if ( !(typeof item.cql_filter === 'undefined') ) {
+                            record.data.layer.params.CQL_FILTER = item.cql_filter;
+                        }
+                    }
+                    
                     // set metadataURLs in record, data comes from GeoNetwork
                     if (item.metadataURL) {
                         record.set("metadataURLs", [item.metadataURL]);

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -320,13 +320,13 @@ GEOR.mapinit = (function() {
                 if (record) {
                     // handle cql_filter param in JSON POST
                     if( type == "WFS" ) {
-                        if ( !(typeof item.cql_filter === 'undefined') ) {
+                        if ( item.hasOwnProperty("cql_filter") ) {
                             var format = new OpenLayers.Format.CQL();
-                            record.data.layer.filter = format.read(item.cql_filter);
+                            record.getLayer().filter = format.read(item.cql_filter);
                         }
                     } else {
-                        if ( !(typeof item.cql_filter === 'undefined') ) {
-                            record.data.layer.params.CQL_FILTER = item.cql_filter;
+                        if ( item.hasOwnProperty("cql_filter") ) {
+                            record.getLayer().params.CQL_FILTER = item.cql_filter;
                         }
                     }
                     

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -313,7 +313,7 @@ GEOR.mapinit = (function() {
         var records = [], record;
         var errors = [], count = 0;
         Ext.each(initState, function(item) {
-            if (item.type == "WMSLayer" || item.type == "WFSLayer") {
+            if ( (item.type == "WMSLayer" || item.type == "WFSLayer") && item.type == type+'Layer' ) {
                 record = stores[item.url].queryBy(function(r) {
                     return (r.get('name') == item.name);
                 }).first();

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -322,8 +322,7 @@ GEOR.mapinit = (function() {
                     // handle cql_filter param in JSON POST
                     if( type == "WFS" ) {
                         if ( item.hasOwnProperty("cql_filter") ) {
-                            var format = new OpenLayers.Format.CQL();
-                            record.getLayer().filter = format.read(item.cql_filter);
+                            record.getLayer().filter = (new OpenLayers.Format.CQL()).read(item.cql_filter);
                         }
                     } else {
                         if ( item.hasOwnProperty("cql_filter") ) {


### PR DESCRIPTION
This patch enable to send POST JSON data to mapfihapp with a cql_filter parameter.

Tested with : 

```
{
    "layers": [{
        "layername": "geo_commune",
        "owstype": "WFS",
        "owsurl": "https://opendata.agglo-lepuyenvelay.fr/geoserver/cadastre/wfs",
		"cql_filter": "idu = 157"
    }, {
        "layername": "lepuy:secteurs_elus",
        "owstype": "WMS",
        "owsurl": "https://opendata.agglo-lepuyenvelay.fr/geoserver/wms",
		"cql_filter": "numsecteur = 8"
    }]
}
```

When I tested it, I can't load WMS and WFS servers simultaneously, so I added a condition over the layer Type in updateStoreFromWxSLayer().

This allow the javascipt to not crash. There still a lot of bugs with WFS protocol, but not related to this patch...
