### PR TITLE
Update tomcat.md

### DIFF
--- a/doc/setup/tomcat.md
+++ b/doc/setup/tomcat.md
@@ -158,7 +158,7 @@ In ```/var/lib/tomcat-proxycas/conf/server.xml```, find the place where the HTTP
 
 Finally, we make the instance start by default with the OS, and check it works:
 ```
-sudo update-rc.d tomcat-proxycas defaults 90
+sudo insserv tomcat-proxycas
 sudo service tomcat-proxycas start
 ```
 
@@ -253,7 +253,7 @@ In ```/var/lib/tomcat-georchestra/conf/server.xml```:
 ### Start the instance
 
 ```
-sudo update-rc.d tomcat-georchestra defaults 90
+sudo insserv tomcat-georchestra
 sudo service tomcat-georchestra start
 ```
 
@@ -356,7 +356,7 @@ In ```/var/lib/tomcat-geoserver0/conf/server.xml```:
 ### Start the instance
 
 ```
-sudo update-rc.d tomcat-geoserver0 defaults 90
+sudo insserv tomcat-geoserver0
 sudo service tomcat-geoserver0 start
 ```
 


### PR DESCRIPTION
Sous Debian, les scripts de démarrage sont gérés différement à partir de Debian 6. La commande update-rc.d a été abandonnée au profit de insserv pour ajouter une gestion des dépendances de service.
Cette nouvelle méthode est inscrite dans les scripts de lancement Linux Standard Base (LSB). 
http://wiki.ouieuhtoutca.org/doku.php?id=insserv