### PR TITLE
Update how_to_upgrade.md

### DIFF
--- a/doc/how_to_upgrade.md
+++ b/doc/how_to_upgrade.md
@@ -10,13 +10,16 @@ We suppose that your configuration is versioned with git, and that it has two re
 
 When typing ```git remote -v``` in your config folder, you should see something like this:
 ```
-origin	git@gitlab.com:user/myprofile.git (fetch)
-origin	git@gitlab.com:user/myprofile.git (push)
-upstream	git@github.com:georchestra/template.git (fetch)
-upstream	git@github.com:georchestra/template.git (push)
+cd ~/myprofile
+origin  git://github.com/georchestra/template.git (fetch)
+origin  git://github.com/georchestra/template.git (push)
+upstream        git://github.com/georchestra/template.git (fetch)
+upstream        git://github.com/georchestra/template.git (push)
+
 ```
 
-If one remote is missing, you may add it with, eg ```git remote add upstream git@github.com:georchestra/template.git```.
+If one remote is missing, you may add it with the command: 
+```git remote add upstream git://github.com/georchestra/template.git```.
 
 
 ## Upgrade your configuration directory


### PR DESCRIPTION
plusieurs problèmes :
- le dépôt est sur github et non gitlab
- l'utilisation de git en ssh ou en http. on a évoqué ce sujet ici : https://groups.google.com/forum/#!msg/georchestra/ZSbhDMKgUwY/B0WqM1C6n-4J
seuls les développeurs possèdent la clé ssh et peuvet utiliser la syntaxe git@github. mais un utilisateur non référencé ne passe pas :
```
ernest@georchestra:~/myprofile$ git remote add upstream git@github.com:georchestra/template.git
ernest@georchestra:~/myprofile$ git fetch upstream
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
```
la solution, c'est celle-ci :
```
ernest@georchestra:~/myprofile$ git remote add upstream git://github.com/georchestra/template.git
```