### PR TITLE
basic-auth filter enhancement

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -58,6 +58,12 @@
                 <value>.*Apache-HttpClient.*</value> <!-- Extractorapp client -->
             </list>
         </property>
+        <!-- List of hosts for which the filter will be discarded -->
+        <property name="blacklistedHosts">
+            <list>
+                <value>217.108.210.153</value> <!-- IP address of the géocatalogue -->
+            </list>
+        </property>
         <property name="ignoreHttps" value="true" />
         <property name="ignoreFailure" value="false"/>
         <property name="credentialsCharset" value="UTF-8"/>


### PR DESCRIPTION
We need to avoid in certain cases to trigger the filter ; currently,
the géocatalogue is triggering this filter, because using a user-agent
activated by default (Jakarta, also used by GeoFence).

This commit provides a basic way of disabling the filter for certain
hosts. It makes use of the "x-forwarded-for" HTTP header.

Related issue:
https://github.com/camptocamp/georchestra-cigalsace-configuration/issues/482