### PR TITLE
security-proxy - Fix tomcat7 incompatibilities

### DIFF
--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -135,7 +135,6 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>
 			<version>1.1.2</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -143,8 +142,12 @@
 			<version>2.4</version>
 			<scope>provided</scope>
 		</dependency>
-
-        <dependency>
+		<dependency>
+			<groupId>taglibs</groupId>
+			<artifactId>standard</artifactId>
+			<version>1.1.2</version>
+			</dependency>
+		<dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>17.0</version>

--- a/security-proxy/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -44,11 +44,7 @@
         <to type="forward" last="true">/$1</to>
     </rule>
     <rule>
-        <from>^/(jquery-min.js|empty|cas-logout.jsp|casfailed.jsp|favicon.ico|receptor|j_spring_security_logout|j_spring_cas_security_check|_static/.*)$</from>
-        <to type="forward" last="true">/$1</to>
-    </rule>
-    <rule>
-        <from>^/(?!sec/)(.+)</from>
+        <from>^/(?!sec/|favicon.ico|receptor|j_spring_security_logout|j_spring_cas_security_check|header.jsp|_static/|cas-logout.jsp|403.jsp|404.jsp|casfailed.jsp)(.*)$</from>
         <to type="forward" last="true">/sec/$1</to>
     </rule>
 

--- a/security-proxy/src/main/webapp/WEB-INF/web.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/web.xml
@@ -104,13 +104,9 @@
     </servlet>
     <!-- url mapping -->
     <servlet-mapping>
-        <servlet-name>default</servlet-name>
-        <url-pattern>/_static/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
         <servlet-name>proxy</servlet-name>
         <url-pattern>/sec/*</url-pattern>
-    </servlet-mapping>  
+    </servlet-mapping>
     <session-config>
         <session-timeout>60</session-timeout>
     </session-config>


### PR DESCRIPTION
This is a backport of my current branch (georchestra_datadir), which
allows the use of tomcat > 6 for the security-proxy.

Main issues were the following:
- Redirect loops due to the Tuckeys' urlrewrite configuration ;
- useless default servlet mapping which was messing up somehow with
tomcat default servlet configuration

Also seems to fix a bug with jsp compilation.

Tests:
- Runtime tested on tomcat 6 and tomcat 7, no regression encountered
- Unit tests OK.