### PR TITLE
security-proxy - Intercept "connection refused" errors

### DIFF
--- a/config/defaults/security-proxy/503.jsp
+++ b/config/defaults/security-proxy/503.jsp
@@ -1,0 +1,26 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="s" %>
+
+<!DOCTYPE html>
+<!--TODO: set appropriate lang-->
+<!--TODO: favicon-->
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title><s:message code="503.title"/></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href='/_static/bootstrap_3.0.0/css/bootstrap.min.css' rel="stylesheet" />
+</head>
+
+<body>
+  <%@ include file="header.jsp" %>
+  <div class="container">
+    <div class="page-header">
+      <h1><s:message code="503.title"/></h1>
+    </div>
+    <p class="lead"><s:message code="503.body"/></p>
+  </div>
+</body>
+</html>

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -612,7 +612,13 @@ public class Proxy {
             }
         } catch (IOException e) {
             // connection problem with the host
-            e.printStackTrace();
+            logger.error("Exception occured when trying to connect to the remote host: ", e);
+            try {
+                finalResponse.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            } catch (IOException e2) {
+                // error occured while trying to return the "service unavailable status"
+                finalResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
         } finally {
             httpclient.getConnectionManager().shutdown();
         }

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application.properties
@@ -4,3 +4,6 @@
 403.title=Forbidden
 404.body=Resource not found.
 404.title=404 error
+503.title=503 - Service unavailable
+503.body=The remote server did not answer (Connection refused).
+

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -4,3 +4,5 @@
 403.title=Geschützter Bereich
 404.body=Ressource wurde nicht gefunden.
 404.title=Fehler 404
+503.body=Service nicht verfügbar
+503.title=503 - Nicht verfügbar

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -4,3 +4,5 @@
 403.title=Prohibido
 404.body=Recurso no encontrado.
 404.title=Error 404
+503.title=Service unavailable
+503.body=El servidor no ha respondido

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -4,3 +4,5 @@
 403.title=Accès interdit
 404.body=Ressource introuvable.
 404.title=Erreur 404
+503.title=Erreur 503 - Service non disponible
+503.body=Le serveur distant n'a pas répondu.

--- a/security-proxy/src/main/webapp/WEB-INF/web.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/web.xml
@@ -119,5 +119,10 @@
         <error-code>403</error-code>
         <location>/403.jsp</location>
     </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/503.jsp</location>
+    </error-page>
+
 </web-app>
 


### PR DESCRIPTION
This PR is related to the issue #961.

If underlying webapps are unavailable, an empty webpage is produced
(Content-length: 0), no log traces are produced (a printStackTrace() is
done anyway), and a 200 OK status code is returned.

This commit provides:
- A 503 "service unavailable" status code is returned instead
- A default status page for 503 (as it is currently done for 403 and 404
  statuses) is produced,
- A log trace is correctly (in the correct log file, not on stdout) is
  printed.

Note that the 503 error code can also be intercepted by the frontend
server, so that a custom error page is returned.