### PR TITLE
Add filter button to querier

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/de.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/de.js
@@ -316,6 +316,7 @@ OpenLayers.Lang.de = OpenLayers.Util.extend(OpenLayers.Lang.de, {
     "Request on NAME": "Sucher auf ${NAME}",
     "WFS GetFeature on filter": "GetFeature WFS auf einem Filter",
     "Search": "Suchen",
+    "Filter": "Filter",
     "querier.layer.no.geom":
         "Geometrische Spalte nicht vorhanden." +
         "<br />Sucher nicht verfügbar.",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/es.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/es.js
@@ -320,6 +320,7 @@ OpenLayers.Lang.es = OpenLayers.Util.extend(OpenLayers.Lang.es, {
     "Request on NAME": "Consultas sobre ${NAME}",
     "WFS GetFeature on filter": "GetFeature WFS sobre un filtro",
     "Search": "Búsqueda",
+    "Filter": "Filtro",
     "querier.layer.no.geom":
         "La capa no contiene ninguna columna geométrica." +
         "<br />El módulo de consultas geométricas no funcionará.",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/fr.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/fr.js
@@ -319,6 +319,7 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
     "Request on NAME": "Requêteur sur ${NAME}",
     "WFS GetFeature on filter": "GetFeature WFS sur un filtre",
     "Search": "Rechercher",
+    "Filter": "Filtrer",
     "querier.layer.no.geom":
         "La couche ne possède pas de colonne géométrique." +
         "<br />Le requêteur géométrique ne sera pas fonctionnel.",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/ru.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/ru.js
@@ -258,6 +258,7 @@ OpenLayers.Lang.ru = OpenLayers.Util.extend(OpenLayers.Lang.ru, {
     "Fields of filters with a red mark are mandatory": "Поля фильтров, помеченные красным цветом, являются обязательными для заполнения.",
     "Request on NAME": "Сделать запрос о ${NAME}",
     "Search": "Искать",
+    "Filter": "фильтр",
     "querier.layer.no.geom": "Слой не имеет геометрического столбца.<br />Геометрический запросчик не будет работать.",
     "querier.layer.error": "получить характеристику запрошенного слоя.<br />Запросчик не будет доступен.",
     /* GEOR_referentials.js strings */

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -29,6 +29,7 @@
  * @requires OpenLayers/Filter/Comparison.js
  * @requires OpenLayers/Filter/Spatial.js
  * @include OpenLayers/Filter/Logical.js
+ * @include OpenLayers/Format/CQL.js
  * @include OpenLayers/Format/Filter.js
  * @include OpenLayers/Format/XML.js
  // see https://github.com/georchestra/georchestra/issues/482 :
@@ -258,10 +259,16 @@ GEOR.querier = (function() {
             deactivable: true,
             cookieProvider: cp,
             autoScroll: true,
-            buttons: [{
-                text: tr("Search"),
-                handler: search
-            }],
+            buttons: [
+                {
+                    text: tr("Search"),
+                    handler: search
+                },
+                {
+                    text: tr("Filter"),
+                    handler: filterLayer
+                }
+            ],
             map: map,
             attributes: attStore,
             allowSpatial: true,
@@ -271,6 +278,24 @@ GEOR.querier = (function() {
             })
         });
     };
+    
+    var filterLayer = function() {
+        var filterbuilder = this.findParentByType("gx_filterbuilder");
+        var filter = filterbuilder.getFilter();
+        if (!checkFilter(filter)) {
+            return;
+        }
+        
+        var layers = map.getLayersBy('id',record.id);
+        
+        if( layers.length > 0 ) {
+            if( filter.CLASS_NAME == "OpenLayers.Filter.Spatial" || filter.CLASS_NAME == "OpenLayers.Filter.Comparison" || ('filters' in filter && filter.filters.length > 0) ) {
+                layers[0].mergeNewParams({'CQL_FILTER': (new OpenLayers.Format.CQL()).write(filter)});
+            } else {
+                layers[0].mergeNewParams({'CQL_FILTER': null});
+            }
+        }
+    }
 
     return {
     

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -29,7 +29,6 @@
  * @requires OpenLayers/Filter/Comparison.js
  * @requires OpenLayers/Filter/Spatial.js
  * @include OpenLayers/Filter/Logical.js
- * @include OpenLayers/Format/CQL.js
  * @include OpenLayers/Format/Filter.js
  * @include OpenLayers/Format/XML.js
  // see https://github.com/georchestra/georchestra/issues/482 :
@@ -289,10 +288,19 @@ GEOR.querier = (function() {
         var layers = map.getLayersBy('id',record.id);
         
         if( layers.length > 0 ) {
-            if( filter.CLASS_NAME == "OpenLayers.Filter.Spatial" || filter.CLASS_NAME == "OpenLayers.Filter.Comparison" || ('filters' in filter && filter.filters.length > 0) ) {
-                layers[0].mergeNewParams({'CQL_FILTER': (new OpenLayers.Format.CQL()).write(filter)});
-            } else {
-                layers[0].mergeNewParams({'CQL_FILTER': null});
+            if( layers[0].CLASS_NAME == "OpenLayers.Layer.WMS" ) {
+                if( filter.CLASS_NAME == "OpenLayers.Filter.Spatial" || filter.CLASS_NAME == "OpenLayers.Filter.Comparison" || ('filters' in filter && filter.filters.length > 0) ) {
+                    layers[0].params["FILTER"] = (new OpenLayers.Format.XML()).write((new OpenLayers.Format.Filter()).write(filter));
+                } else {
+                    layers[0].params["FILTER"] = null;
+                }
+                
+                layers[0].mergeNewParams({
+                    nocache: new Date().valueOf()
+                });
+            } else if( layers[0].CLASS_NAME == "OpenLayers.Layer.Vector" ) {
+                layers[0].filter = filter;
+                layers[0].refresh();
             }
         }
     }

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -285,7 +285,7 @@ GEOR.querier = (function() {
             return;
         }
         
-        var layers = map.getLayersBy('id',record.id);
+        var layer = record.getLayer();
         
         if( layers.length > 0 ) {
             if( layers[0].CLASS_NAME == "OpenLayers.Layer.WMS" ) {


### PR DESCRIPTION
Add a filter button to the querier in order to add CQL filters to the layer and refresh it.

Actually doesn't work with geometry because filter returned reference a null geometry attribute : 

```
var filterbuilder = this.findParentByType("gx_filterbuilder");
var filter = filterbuilder.getFilter();
```