### PR TITLE
[Mapfish] Fix bug on editing feature

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_edit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_edit.js
@@ -139,7 +139,6 @@ GEOR.edit = (function() {
                 hover: true,
                 click: false,
                 single: true,
-                maxFeatures: 1,
                 clickTolerance: 7,
                 eventListeners: {
                     "hoverfeature": function(e) {

--- a/mapfishapp/src/main/webapp/app/js/GEOR_edit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_edit.js
@@ -139,6 +139,7 @@ GEOR.edit = (function() {
                 hover: true,
                 click: false,
                 single: true,
+                maxFeatures: 5,
                 clickTolerance: 7,
                 eventListeners: {
                     "hoverfeature": function(e) {


### PR DESCRIPTION
When editing a feature (observed on close lines and points), sometimes the hovered feature is not the good one.

This problem is due to : 
```
maxFeatures: 1,
```

Because the wfs protocol requests a BBOX where more than one feature can be included, and as said in the OL doc, set maxFeatures to more than one allows wfs to return more than one feature. The returned set of features is then used to determine the best match client-side.

http://dev.openlayers.org/apidocs/files/OpenLayers/Control/GetFeature-js.html

I remove the line because by default, maxFeatures is set to 10, the good value to set there depends on the distance between features in the edited layer, so the default value seems to be a good average.

After doing that, the edit function is repaired.