### PR TITLE
security-proxy/health-checker: make database host and port configurable

### DIFF
--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -16,9 +16,8 @@
                 
           <property name="database" value="${psql.db}"/>
 
-<!--  Need to make host and port configurable
           <property name="host" value="${psql.host}"/>
-          <property name="port" value="${psql.port}"/> -->
+          <property name="port" value="${psql.port}"/>
           <property name="user" value="${psql.user}"/>
           <property name="password" value="${psql.pass}"/>
           <property name="proxyPermissionsFile" value="permissions.xml"/>

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -133,6 +133,8 @@ public class Proxy {
     /*  ----------  Required for  DatabaseHealthCenter -------------------- */
     
     private static Boolean checkHealth = false;
+    private String host;
+    private Integer port;
     private String database;
     private String user;
     private String password;
@@ -494,7 +496,7 @@ public class Proxy {
         httpclient.getParams().setBooleanParameter(ClientPNames.HANDLE_REDIRECTS, false);
 
         if( isCheckHealth() ){
-            DatabaseHealthCenter.getInstance(this.database, this.user, this.password, Proxy.class.getSimpleName())
+            DatabaseHealthCenter.getInstance(this.host, this.port, this.database, this.user, this.password, Proxy.class.getSimpleName())
 				.checkConnections(this.maxDatabaseConnections);
         }
 
@@ -1142,6 +1144,14 @@ public class Proxy {
     }
     public void setHeaderManagement(HeadersManagementStrategy headerManagement) {
         this.headerManagement = headerManagement;
+    }
+
+    public void setHost(String host){
+        this.host = host;
+    }
+
+    public void setPort(Integer port){
+        this.port = port;
     }
 
     public void setDatabase(String database){

--- a/security-proxy/src/main/java/org/georchestra/security/healthcenter/CheckPostgresConnections.java
+++ b/security-proxy/src/main/java/org/georchestra/security/healthcenter/CheckPostgresConnections.java
@@ -23,13 +23,13 @@ final class CheckPostgresConnections {
     private static final Log LOGGER = LogFactory.getLog(CheckPostgresConnections.class.getPackage().getName());
     
 
-	public static List<Map<String, Object>> findConnections(String database, String user, String password, String clientName) throws IOException {
+	public static List<Map<String, Object>> findConnections(String host, Integer port, String database, String user, String password, String clientName) throws IOException {
 
 		List<Map<String, Object>> connectionList; 
 		Connection  connection = null;
 		try {
 			
-			DBConnectionProvider connProvider = PostgresConnectionProvider.getInstance(database ,user, password, clientName);
+			DBConnectionProvider connProvider = PostgresConnectionProvider.getInstance(host, port, database ,user, password, clientName);
 			connection = connProvider.getConnection();
 		
 			ConnectionStatsCommand cmd = new ConnectionStatsCommand();

--- a/security-proxy/src/main/java/org/georchestra/security/healthcenter/DatabaseHealthCenter.java
+++ b/security-proxy/src/main/java/org/georchestra/security/healthcenter/DatabaseHealthCenter.java
@@ -20,6 +20,10 @@ public class DatabaseHealthCenter {
 
     private static DatabaseHealthCenter THIS = new DatabaseHealthCenter();
 
+	private String host;
+
+	private Integer port;
+
 	private String user;
 
 	private String password;
@@ -31,8 +35,10 @@ public class DatabaseHealthCenter {
 	private DatabaseHealthCenter(){
 		// singleton
 	}
-	public static synchronized DatabaseHealthCenter getInstance(String database, String user, String password, String clientName){
+	public static synchronized DatabaseHealthCenter getInstance(String host, Integer port, String database, String user, String password, String clientName){
 
+		THIS.host = host;
+		THIS.port = port;
 		THIS.database = database;
 		THIS.user = user;
 		THIS.password = password;
@@ -68,7 +74,7 @@ public class DatabaseHealthCenter {
 		try {
 			long healthLimit = Math.round( maxConnections * 0.8 );
 			
-			List<Map<String,Object>> listConnections = CheckPostgresConnections.findConnections(this.database,  this.user, this.password, this.clientName);
+			List<Map<String,Object>> listConnections = CheckPostgresConnections.findConnections(this.host, this.port, this.database,  this.user, this.password, this.clientName);
 			final int liveConnections = listConnections.size();
 			if( (liveConnections >= healthLimit) && (liveConnections < maxConnections) ){
 				// the configuration is near to the limit, then log the connections status 

--- a/security-proxy/src/main/java/org/georchestra/security/healthcenter/PostgresConnectionProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/healthcenter/PostgresConnectionProvider.java
@@ -23,7 +23,9 @@ final class PostgresConnectionProvider implements DBConnectionProvider {
 	private static final PostgresConnectionProvider THIS = new PostgresConnectionProvider();
 	
 	private Connection connection= null;
-	private String jdbcURL = "jdbc:postgresql://localhost:5432/";//FIXME host:port should be configured (this implementation should be replaced by jndi)
+	private String jdbcURL = "jdbc:postgresql://";
+	private String host;
+	private Integer port;
 	private String database;
 	private String user;
 	private String password;
@@ -34,8 +36,10 @@ final class PostgresConnectionProvider implements DBConnectionProvider {
 		//singleton
 	}
 	
-	public static synchronized DBConnectionProvider getInstance(final String database, final String user, final String password, final String clientApp) {
+	public static synchronized DBConnectionProvider getInstance(final String host, final Integer port, final String database, final String user, final String password, final String clientApp) {
 		
+		THIS.host = host;
+		THIS.port = port;
 		THIS.database = database;
 		THIS.user = user;
 		THIS.password = password;
@@ -68,7 +72,9 @@ final class PostgresConnectionProvider implements DBConnectionProvider {
 					Properties connProp = getConnectionProperties();
 
 					StringBuilder url = new StringBuilder(40);
-					url.append(this.jdbcURL).append(this.database);
+					url.append(this.jdbcURL).append(this.host);
+					url.append(':').append(this.port);
+					url.append('/').append(this.database);
 					this.connection = DriverManager.getConnection(url.toString(), connProp);
  
 					//this.connection.setClientInfo("application_name", this.clientApp); is abstract method in jdbc3 the following is a workaround

--- a/security-proxy/src/test/java/org/georchestra/security/healthcenter/CheckPostgresConnectionsTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/healthcenter/CheckPostgresConnectionsTest.java
@@ -67,7 +67,7 @@ public final class CheckPostgresConnectionsTest {
 	
 	@Ignore // ignored to avoid break the build
 	public void testConnectionsData() throws Exception{
-		List<Map<String, Object>> findConnections = CheckPostgresConnections.findConnections("postgres","postgres", "admin", "testCase");
+		List<Map<String, Object>> findConnections = CheckPostgresConnections.findConnections("localhost", 5432, "postgres","postgres", "admin", "testCase");
 		for (Map<String, Object> conn : findConnections) {
 			LOGGER.info(conn);
 		}

--- a/security-proxy/src/test/java/org/georchestra/security/healthcenter/DatabaseHealthCenterTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/healthcenter/DatabaseHealthCenterTest.java
@@ -37,7 +37,7 @@ public class DatabaseHealthCenterTest {
 	@Test
 	public void testCheckConnectionsUnstable() {
 		
-		DatabaseHealthCenter hc = DatabaseHealthCenter.getInstance("postgres", "postgres", "admin", "testCase");
+		DatabaseHealthCenter hc = DatabaseHealthCenter.getInstance("localhost", 5432, "postgres", "postgres", "admin", "testCase");
 		boolean healthy = hc.checkConnections(2);
 		
 		// TODO assertFalse(healty);
@@ -45,7 +45,7 @@ public class DatabaseHealthCenterTest {
 	@Test
 	public void testCheckConnectionsOnLimits() {
 		
-		DatabaseHealthCenter hc = DatabaseHealthCenter.getInstance("postgres","postgres", "admin", "testCase");
+		DatabaseHealthCenter hc = DatabaseHealthCenter.getInstance("localhost", 5432, "postgres","postgres", "admin", "testCase");
 		boolean healthy = hc.checkConnections(6);
 
 		// TODO assertTrue(healthy);
@@ -54,7 +54,7 @@ public class DatabaseHealthCenterTest {
 	@Test
 	public void testCheckConnectionsOK() {
 		
-		DatabaseHealthCenter hc = DatabaseHealthCenter.getInstance("postgres","postgres", "admin", "testCase");
+		DatabaseHealthCenter hc = DatabaseHealthCenter.getInstance("localhost", 5432, "postgres","postgres", "admin", "testCase");
 		boolean healthy = hc.checkConnections(10);
 
 		// TODO assertTrue(healthy);


### PR DESCRIPTION
Not tested yet in production, but i saw it as a //FIXME, and hardcoding localhost:5432 is so '90...
Not really critical since healthchecker is not enabled by default, and i still fail to see what's the usecase for it....

Based on what was done in https://github.com/georchestra/georchestra/commit/4c0ff764ad2a7c39477c9451eb85eadd0da710e4