### PR TITLE
Introducing a new module commons

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.georchestra</groupId>
+    <artifactId>root</artifactId>
+    <version>15.12-SNAPSHOT</version>
+  </parent>
+  <artifactId>georchestra-commons</artifactId>
+  <packaging>jar</packaging>
+  <name>geOrchestra Commons</name>
+  <url>http://www.georchestra.org</url>
+  <description>Common classes shared across geOrchestra apps</description>
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.16</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/commons/src/main/java/org/georchestra/commons/configuration/GeorchestraConfiguration.java
+++ b/commons/src/main/java/org/georchestra/commons/configuration/GeorchestraConfiguration.java
@@ -1,0 +1,151 @@
+package org.georchestra.commons.configuration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.PropertyConfigurator;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.ServletContextAware;
+
+@Controller
+public class GeorchestraConfiguration implements ServletContextAware {
+
+    protected String globalDatadir;
+    protected String contextDataDir;
+
+    protected String contextName;
+    protected ServletContext ctx;
+
+    protected Properties applicationSpecificProperties = new Properties();
+
+    public String getContextDataDir() {
+        return contextDataDir;
+    }
+
+    private boolean activated = false;
+
+    public void init() {}
+
+    public GeorchestraConfiguration(String context) {
+
+        this.contextName = context;
+        globalDatadir = System.getProperty("georchestra.datadir");
+        if (globalDatadir != null) {
+            contextDataDir = new File(String.format("%s%s%s%s", globalDatadir, File.separator, context, File.separator)).getAbsolutePath();
+
+            // Simple check that the path exists
+            if (new File(contextDataDir).exists() == false) {
+                contextDataDir = null;
+                return;
+            }
+            // loads the application context property file
+            FileInputStream propsFis = null;
+            try {
+                try {
+                    // application-context
+                    propsFis = new FileInputStream(new File(contextDataDir, context + ".properties"));
+                    InputStreamReader isr = new InputStreamReader(propsFis, "UTF8");
+                    applicationSpecificProperties.load(isr);
+                } finally {
+                    if (propsFis != null) {
+                        propsFis.close();
+                    }
+                }
+            } catch (Exception e) {
+                activated = false;
+                return;
+            }
+
+            // log4j configuration
+            File log4jProperties = new File(contextDataDir, "log4j" + File.separator + "log4j.properties");
+            File log4jXml = new File(contextDataDir, "log4j" + File.separator + "log4j.xml");
+            String log4jConfigurationFile = null;
+            if (log4jProperties.exists()) {
+                log4jConfigurationFile = log4jProperties.getAbsolutePath();
+            } else if (log4jXml.exists()) {
+                log4jConfigurationFile = log4jXml.getAbsolutePath();
+            }
+            if (log4jConfigurationFile != null) {
+                PropertyConfigurator.configure(log4jConfigurationFile);
+            }
+            // everything went well
+            activated = true;
+        }
+    }
+
+    /**
+     * Loads a property file from the context directory
+     *
+     * @param key the key file identifier in the context datadir
+     * @return Properties a properties map from the given key.properties file
+     * @throws IOException
+     */
+    public Properties loadCustomPropertiesFile(String key) throws IOException {
+        Properties prop = new Properties();
+        FileInputStream fisProp = null;
+        try {
+            fisProp = new FileInputStream(new File(contextDataDir, key + ".properties"));
+            InputStreamReader isrProp = new InputStreamReader(fisProp, "UTF8");
+            prop.load(isrProp);
+        } finally {
+            if (fisProp != null) {
+                fisProp.close();
+            }
+        }
+        return prop;
+    }
+
+    public String getProperty(String key) {
+        if ((applicationSpecificProperties == null) || (activated == false))
+            return null;
+        return applicationSpecificProperties.getProperty(key);
+    }
+
+    public boolean activated() {
+        return activated;
+    }
+
+    /**
+     * This controller allows to intercept GEOR_custom.js used
+     * in Mapfishapp and Extractorapp.
+     * @param request
+     * @param response
+     * @throws Exception
+     */
+    @RequestMapping(value= "/app/js/GEOR_custom.js")
+    public void getGeorCustom(HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+        response.setContentType("application/javascript; charset=UTF-8");
+        // we could get extra infos from the DB or elsewhere, and
+        // add them to the variables provided by the js file :-)
+        if (contextDataDir != null) {
+            File georCustom = new File(contextDataDir, "js" + File.separator + "GEOR_custom.js");
+            if (georCustom.exists()) {
+                response.getOutputStream().write(FileUtils.readFileToByteArray(georCustom));
+                return;
+            }
+        }
+        // Fallback on the default one provided by the webapp
+        InputStream is = this.ctx.getResourceAsStream("/app/js/GEOR_custom.js");
+        byte[] content = IOUtils.toByteArray(is);
+        response.getOutputStream().write(content);
+        return;
+    }
+
+    @Override
+    public void setServletContext(ServletContext servletContext) {
+        this.ctx = servletContext;
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <module>epsg-extension</module>
     <module>ogc-server-statistics</module>
     <module>server-deploy-support</module>
+    <module>commons</module>
   </modules>
   <build>
     <plugins>
@@ -408,6 +409,12 @@
         <module>downloadform</module>
         <module>analytics</module>
         <module>header</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>commons</id>
+      <modules>
+        <module>commons</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
This is meant to share some common code across modules.

It also provides a new controller to get the GEOR_Custom.js file used in some modules (mapfishapp, extractorapp, ...) directly into a custom directory (defined by the `georchestra.datadir` env variable).

There are several concepts introduced by this module (which compiles into a jar, and that should be added across the modules as a new spring bean):

- georchestra.datadir is the configuration placeholder for georchestra
- the context.datadir is constructed as {georchestra.datadir}/{modulename}/
- A properties file is sourced considering the content as UTF-8 (instead of default Java behaviour which considers .properties file as ISO-8859-1)
- since the log4j configuration does not simply allow to be configured against a config file outside of the webapp, the class is responsible of reconfiguring log4j java-side at runtime

If the setup is well (needs the georchestra.datadir env variables, plus the files explained above), the boolean activated is set to true. Otherwise, the "old" geOrchestra behaviour is kept.

