### PR TITLE
Allow to cluster ldapadmin

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/edituserdetails/EditUserDetailsFormBean.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/edituserdetails/EditUserDetailsFormBean.java
@@ -7,7 +7,7 @@ package org.georchestra.ldapadmin.ws.edituserdetails;
  * @author Mauricio Pazos
  *
  */
-public class EditUserDetailsFormBean {
+public class EditUserDetailsFormBean implements java.io.Serializable {
 	
 	private String uid; 
 	private String surname; 


### PR DESCRIPTION
This way, ldapadmin can be clusterized between several tomcat instances, adding
<distributable/> to web.xml. Otherwise, account/userdetails was complaining
that EditUserDetailsFormBean wasn't serializable in a session, which is a
requirement for tomcat clustering.

```
java.lang.IllegalArgumentException: setAttribute: Non-serializable attribute editUserDetailsFormBean
```