### PR TITLE
Don't use isReachable(), it requires root access for icmp raw sockets…

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/AbstractEmailFactory.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/AbstractEmailFactory.java
@@ -45,11 +45,10 @@ public abstract class AbstractEmailFactory {
     public void freeze() {
         this.frozen = true;
         try {
-            if (!InetAddress.getByName(smtpHost).isReachable(3000)) {
-                throw new IllegalStateException(smtpHost + " is not a reachable address");
-            }
+            // just ensure smtpHost resolves to a valid ip
+            InetAddress ip = InetAddress.getByName(smtpHost);
         } catch (IOException e) {
-            throw new IllegalStateException(smtpHost + " is not a reachable address");
+            throw new IllegalStateException(smtpHost + " doesnt resolve");
         }
         if (smtpPort < 0) {
             throw new IllegalStateException(smtpPort + " is not a legal port make sure it is correctly configured");


### PR DESCRIPTION
… (#991)

Just check that smtpHost resolves to a valid IP.

I've tested that InetAddress.getByName() works fine if provided a valid DNS or a valid IP, and throws an exception if provided an invalid DNS.
```
$cat t.java
import java.net.InetAddress;
import java.net.UnknownHostException;

public class t {
    public static void main(String[] args) {
      String smtpHost = "smtp.univ-bpclermont.fr";
      String badSmtpHost = "this.doesnt.resolve";
      String smtpIp = "195.221.122.150";
      try {
          InetAddress ip = InetAddress.getByName(smtpHost);
          System.out.println(smtpHost + " resolves to " + ip.toString());
      } catch (UnknownHostException e) {
           System.out.println(smtpHost + " doesnt resolve");
      }
      try {
          InetAddress ip = InetAddress.getByName(badSmtpHost);
          System.out.println(badSmtpHost + " resolves to " + ip.toString());
      } catch (UnknownHostException e) {
           System.out.println(badSmtpHost + " doesnt resolve");
      }
      try {
          InetAddress ip = InetAddress.getByName(smtpIp);
          System.out.println(smtpIp + " resolves to " + ip.toString());
      } catch (UnknownHostException e) {
           System.out.println(smtpIp + " doesnt resolve");
      }
    }
}
$java t        
smtp.univ-bpclermont.fr resolves to smtp.univ-bpclermont.fr/195.221.122.150
this.doesnt.resolve doesnt resolve
195.221.122.150 resolves to /195.221.122.150
```