### PR TITLE
ogc server statistics - do not log if request made onto the /proxy endpoint

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -296,7 +296,6 @@ public class Proxy {
                 return;
             }
             handleRequest(request, response, type, sURL, false);
-            handleRequest(request, response, type, sURL, false);
         } else {
             handlePathEncodedRequests(request, response, type);
         }

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -635,7 +635,10 @@ public class Proxy {
                 for (Header originalHeader : originalHeaders) {
                     org = originalHeader.getValue();
                 }
-                statsLogger.info(OGCServiceMessageFormatter.format(authentication.getName(), sURL, org));
+                // no OGC SERVICE log if request going through /proxy/?url=
+                if (!request.getRequestURI().startsWith("/sec/proxy/")) {
+                    statsLogger.info(OGCServiceMessageFormatter.format(authentication.getName(), sURL, org));
+                }
             } catch (Exception e) {
                 logger.error("Unable to log the request into the statistics logger", e);
             }


### PR DESCRIPTION
See #1058 
Also addresses an useless extra call to handleRequest()

Tests: runtime tested
