### PR TITLE
mapfishapp - reduced functionalities for layergroups

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/de.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/de.js
@@ -194,6 +194,7 @@ OpenLayers.Lang.de = OpenLayers.Util.extend(OpenLayers.Lang.de, {
         " oder nicht ausreichende Zugriffsrechte, " +
         "Datenmenge zu groß...",
     /* GEOR_managelayers.js strings */
+    "layergroup": "Layergruppe",
     "Service": "Service",
     "Protocol": "Protokoll",
     "About this layer": "Über dieser Schicht",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/es.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/es.js
@@ -199,6 +199,7 @@ OpenLayers.Lang.es = OpenLayers.Util.extend(OpenLayers.Lang.es, {
         "invalida. Razones posibles: datos demasiado pesados, derechos insuficientes, " +
         "servidor inalcanzable, etc.",
     /* GEOR_managelayers.js strings */
+    "layergroup": "Capa Grupo",
     "Service": "Service",
     "Protocol": "Servicio",
     "About this layer": "Sobre esta capa",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/fr.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/fr.js
@@ -194,6 +194,7 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
         "serveur. Raisons possibles : droits insuffisants, " +
         "serveur injoignable, trop de données, etc.",
     /* GEOR_managelayers.js strings */
+    "layergroup": "couche composite",
     "Service": "Service",
     "Protocol": "Protocole",
     "About this layer": "A propos de cette couche",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_Lang/ru.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_Lang/ru.js
@@ -155,6 +155,7 @@ OpenLayers.Lang.ru = OpenLayers.Util.extend(OpenLayers.Lang.ru, {
     //"This server does not support HTTP POST": "Ce serveur ne supporte pas HTTP POST",
     "Unreachable server or insufficient rights": "Ответ сервера недействителен. Возможные причины : недостаточные права, сервер недостижим, слишком много данных, и т.д...",
     /* GEOR_managelayers.js strings */
+    //"layergroup": "couche composite",
     //"Service": "Service",
     //"Protocol": "Protocole",
     //"About this layer": "A propos de cette couche",

--- a/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
@@ -845,7 +845,8 @@ GEOR.managelayers = (function() {
                 iconCls: 'geor-btn-layerinfo',
                 text: tr("About this layer"),
                 handler: function() {
-                    var p = GEOR.util.getProtocol(layer),
+                    var isLayergroup = layerRecord.get('layergroup'),
+                    p = GEOR.util.getProtocol(layer),
                     o = OpenLayers.Util.createUrlObject(p.service),
                     port = o.port == "80" ? "" : ":" + o.port,
                     caps = OpenLayers.Util.urlAppend([
@@ -880,15 +881,16 @@ GEOR.managelayers = (function() {
                             items: [{
                                 xtype: 'displayfield',
                                 fieldLabel: tr("Service"),
-                                value: '<a href="'+caps+'">'+caps+'</a>'
+                                value: '<b><a href="'+caps+'">'+caps+'</a></b>'
                             },{
                                 xtype: 'displayfield',
                                 fieldLabel: tr("FeatureType"),
-                                value: p.layer
+                                value: '<b>' + p.layer + '</b>' + 
+                                    (isLayergroup ? " (" + tr("layergroup") + ")" : "")
                             },{
                                 xtype: 'displayfield',
                                 fieldLabel: tr("Protocol"),
-                                value: p.protocol + " " + p.version
+                                value: '<b>' + p.protocol + " " + p.version + '</b>'
                             }]
                         },
                         buttons: [{

--- a/mapfishapp/src/main/webapp/app/js/GEOR_map.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_map.js
@@ -281,15 +281,25 @@ GEOR.map = (function() {
                     GEOR.waiter.show();
                     GEOR.ows.WMSDescribeLayer(r, {
                         success: function(store, records) {
-                            var wfsRecord = GEOR.ows.getWfsInfo(records);
-                            if (wfsRecord) {
-                                r.set("WFS_typeName", wfsRecord.get("typeName"));
-                                r.set("WFS_URL", wfsRecord.get("owsURL"));
-                            }
-                            var wcsRecord = GEOR.ows.getWcsInfo(records);
-                            if (wcsRecord) {
-                                r.set("WCS_typeName", wcsRecord.get("typeName"));
-                                r.set("WCS_URL", wcsRecord.get("owsURL"));
+                            if (records.length > 1) {
+                                // this is a layergroup: no styling, no extractions, no queries
+                                r.set("WFS_typeName", "");
+                                r.set("WFS_URL", "");
+                                r.set("WCS_typeName", "");
+                                r.set("WCS_URL", "");
+                                // specific record field for layergroups:
+                                r.set("layergroup", true);
+                            } else {
+                                var wfsRecord = GEOR.ows.getWfsInfo(records);
+                                if (wfsRecord) {
+                                    r.set("WFS_typeName", wfsRecord.get("typeName"));
+                                    r.set("WFS_URL", wfsRecord.get("owsURL"));
+                                }
+                                var wcsRecord = GEOR.ows.getWcsInfo(records);
+                                if (wcsRecord) {
+                                    r.set("WCS_typeName", wcsRecord.get("typeName"));
+                                    r.set("WCS_URL", wcsRecord.get("owsURL"));
+                                }
                             }
                             r.set("_described", true);
                             // fire event to let the whole app know about it.

--- a/mapfishapp/src/main/webapp/app/js/GEOR_ows.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_ows.js
@@ -66,6 +66,7 @@ GEOR.ows = (function() {
         {name: "WFS_URL", type: "string"},
         {name: "geometryType", type: "string", defaultValue: "unknown"}, // Line, Point, Polygon
         {name: "multiGeometry", type: "boolean"},
+        {name: "layergroup", type: "boolean", defaultValue: false},
         // end geOrchestra use
         {name: "name", type: "string"},
         {name: "title", type: "string"},
@@ -169,6 +170,9 @@ GEOR.ows = (function() {
         store.load();
     };
 
+    /**
+     * Method: getWxsInfo
+     */
     var getWxsInfo = function(records, owsType) {
         var i, len = records.length, r;
         for (i=0; i<len; i++) {


### PR DESCRIPTION
With this PR, WMS layergroups are properly detected and several features based on WFS/WCS availability are deactivated: advanced querying, extractions & styling.

This was requested by CIGALsace.

Layergroup detection is based on DescribeLayer responses.

eg: https://www.cigalsace.org/geoserver/cigal/ows?SERVICE=WMS&&REQUEST=DescribeLayer&LAYERS=CIGAL_BD_ZDH_2008&VERSION=1.1.1&SLD_VERSION=1.0.0&WIDTH=1&HEIGHT=1&SERVICE=WMS&FORMAT=image%2Fpng

```xml
<?xml version="1.0" encoding="UTF-8"?>
<WMS_DescribeLayerResponse version="1.1.1">
    <LayerDescription name="cigal:CIGAL_BdZDH2008_250000_CC48" wfs="https://www.cigalsace.org/geoserver/cigal/wfs?" owsURL="https://www.cigalsace.org/geoserver/cigal/wfs?" owsType="WFS">
        <Query typeName="cigal:CIGAL_BdZDH2008_250000_CC48" />
    </LayerDescription>
    <LayerDescription name="cigal:CIGAL_BdZDH2008_10000_CC48" wfs="https://www.cigalsace.org/geoserver/cigal/wfs?" owsURL="https://www.cigalsace.org/geoserver/cigal/wfs?" owsType="WFS">
        <Query typeName="cigal:CIGAL_BdZDH2008_10000_CC48" />
    </LayerDescription>
</WMS_DescribeLayerResponse>
```