### PR TITLE
removes attributes in LDAPAdmin (implement #1086)

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
@@ -11,6 +11,7 @@ import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.georchestra.ldapadmin.dto.Account;
@@ -446,6 +447,16 @@ public final class AccountDaoImpl implements AccountDao {
 
         if (!isNullValue(value)) {
             context.setAttributeValue(fieldName, value);
+        } else {
+            Object[] values = context.getObjectAttributes(fieldName);
+            if (values != null) {
+                if (values.length == 1) {
+                    LOG.info("Removing attribue " + fieldName);
+                    context.removeAttributeValue(fieldName, values[0]);
+                } else {
+                    LOG.error("Multiple values encountered for field " + fieldName + ", expected a single value");
+                }
+            }
         }
     }
 
@@ -533,7 +544,7 @@ public final class AccountDaoImpl implements AccountDao {
         if (value == null)
             return true;
 
-        if (value instanceof String && (((String) value).length() == 0)) {
+        if (value instanceof String && (StringUtils.isEmpty(value.toString()))) {
             return true;
         }
 

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersControllerTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersControllerTest.java
@@ -290,7 +290,7 @@ public class UsersControllerTest {
 
 
         Mockito.when(ldapTemplate.search((Name) Mockito.any(), Mockito.anyString(),(ContextMapper) Mockito.any()))
-            .thenReturn(new ArrayList());
+            .thenReturn(new ArrayList<Object>());
         Mockito.when(ldapTemplate.lookupContext(new DistinguishedName("cn=SV_USER,ou=groups")))
             .thenReturn(Mockito.mock(DirContextOperations.class));
 
@@ -454,6 +454,45 @@ public class UsersControllerTest {
         Mockito.doReturn(listFakedAccount).when(ldapTemplate).search(eq(DistinguishedName.EMPTY_PATH),
                 eq(mFilter), (ContextMapper) Mockito.any());
         Mockito.doReturn(Mockito.mock(DirContextOperations.class)).when(ldapTemplate).lookupContext((Name) Mockito.any());
+
+        usersCtrl.update(request, response);
+
+        JSONObject ret = new JSONObject(response.getContentAsString());
+        assertTrue(response.getStatus() == HttpServletResponse.SC_OK);
+        assertTrue(ret.getBoolean("success"));
+
+    }
+
+    @Test
+    public void testUpdateEmptyTelephoneNumber() throws Exception {
+        request.setRequestURI("/ldapadmin/users/pmauduit");
+        JSONObject reqUsr = new JSONObject().put("sn","newPmauduit")
+                .put("postalAddress", "newAddress")
+                .put("postOfficeBox", "newPOBox")
+                .put("postalCode", "73000")
+                .put("street", "newStreet")
+                .put("l", "newLocality") // locality
+                .put("telephoneNumber", "")
+                .put("facsimileTelephoneNumber", "+339182736745")
+                .put("o", "newgeOrchestra") // organization
+                .put("title", "CEO")
+                .put("description", "CEO geOrchestra Corporation")
+                .put("givenName", "newPierre");
+        request.setContent(reqUsr.toString().getBytes());
+        Account fakedAccount = AccountFactory.createBrief("pmauduit", "monkey123", "Pierre",
+                "pmauduit", "pmauduit@georchestra.org", "+33123456789", "geOrchestra",
+                "developer & sysadmin", "dev&ops");
+        Mockito.doReturn(fakedAccount).when(ldapTemplate).
+            lookup((Name) Mockito.any(), (ContextMapper) Mockito.any());
+        // Returns the same account when searching it back
+        String mFilter = "(&(objectClass=inetOrgPerson)(objectClass=organizationalPerson)"
+                + "(objectClass=person)(mail=tomcat2@localhost))";
+        List<Account> listFakedAccount = new ArrayList<Account>();
+        listFakedAccount.add(fakedAccount);
+        Mockito.doReturn(listFakedAccount).when(ldapTemplate).search(eq(DistinguishedName.EMPTY_PATH),
+                eq(mFilter), (ContextMapper) Mockito.any());
+        Mockito.doReturn(Mockito.mock(DirContextOperations.class)).
+            when(ldapTemplate).lookupContext((Name) Mockito.any());
 
         usersCtrl.update(request, response);
 


### PR DESCRIPTION
Backport for 14.12 of PR  #1093 ;

14.12 is the first version where the fix could be easily backported.