### PR TITLE
Ldapadmin remove fields - bugfix for #1097

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
@@ -256,29 +256,6 @@ public final class AccountDaoImpl implements AccountDao {
         return ldapTemplate.search(DistinguishedName.EMPTY_PATH, filter.encode(), new AccountContextMapper());
     }
 
-    // TODO Note: this implementation use the SortControlDirContextProcessor but
-    // it don't work
-    // @Override
-    // public List<Account> findAll() throws DataServiceException {
-    //
-    // UserAttributesMapper mapper = new UserAttributesMapper();
-    //
-    // final EqualsFilter filter = new EqualsFilter("objectClass", "Person");
-    //
-    // final SearchControls searchControl = new SearchControls();
-    // searchControl.setSearchScope(SearchControls.SUBTREE_SCOPE);
-    // searchControl.setDerefLinkFlag(false);
-    //
-    //
-    // final SortControlDirContextProcessor sortControl = new
-    // SortControlDirContextProcessor("cn");
-    //
-    // List<Account> list = ldapTemplate.search( DistinguishedName.EMPTY_PATH,
-    // filter.encode(), searchControl, mapper, sortControl);
-    //
-    // return list;
-    // }
-
     @Override
     public List<Account> findFilterBy(final ProtectedUserFilter filterProtected) throws DataServiceException {
 
@@ -497,46 +474,6 @@ public final class AccountDaoImpl implements AccountDao {
 
             return account;
         }
-    }
-
-    private static class UserAttributesMapper implements AttributesMapper {
-
-        @Override
-        public Object mapFromAttributes(Attributes attributes) throws NamingException {
-
-            // set the group name
-            Account a = AccountFactory.createFull((String) attributes.get(UserSchema.UUID_KEY).get(),
-                    (String) attributes.get(UserSchema.COMMON_NAME_KEY).get(),
-                    (String) attributes.get((UserSchema.SURNAME_KEY)).get(),
-                    (String) attributes.get((UserSchema.GIVEN_NAME_KEY)).get(),
-                    (String) attributes.get(UserSchema.MAIL_KEY).get(),
-
-                    (String) attributes.get(UserSchema.ORG_KEY).get(), (String) attributes.get(UserSchema.TITLE_KEY)
-                            .get(),
-
-                    (String) attributes.get(UserSchema.TELEPHONE_KEY).get(),
-                    (String) attributes.get(UserSchema.DESCRIPTION_KEY).get(),
-
-                    (String) attributes.get(UserSchema.POSTAL_ADDRESS_KEY).get(),
-                    (String) attributes.get(UserSchema.POSTAL_CODE_KEY).get(),
-                    (String) attributes.get(UserSchema.REGISTERED_ADDRESS_KEY).get(),
-                    (String) attributes.get(UserSchema.POST_OFFICE_BOX_KEY).get(),
-                    (String) attributes.get(UserSchema.PHYSICAL_DELIVERY_OFFICE_NAME_KEY).get(),
-
-                    (String) attributes.get(UserSchema.STREET_KEY).get(),
-                    (String) attributes.get(UserSchema.LOCALITY_KEY).get(),
-
-                    (String) attributes.get(UserSchema.FACSIMILE_KEY).get(),
-                    (String) attributes.get(UserSchema.ORG_UNIT_KEY).get(),
-
-                    (String) attributes.get(UserSchema.HOME_POSTAL_ADDRESS_KEY).get(),
-                    (String) attributes.get(UserSchema.MOBILE_KEY).get(),
-                    (String) attributes.get(UserSchema.ROOM_NUMBER_KEY).get(),
-                    (String) attributes.get(UserSchema.STATE_OR_PROVINCE_KEY).get());
-
-            return a;
-        }
-
     }
 
     private boolean isNullValue(Object value) {

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
@@ -380,8 +380,6 @@ public final class AccountDaoImpl implements AccountDao {
 
         setAccountField(context, UserSchema.TELEPHONE_KEY, account.getPhone());
 
-        setAccountField(context, UserSchema.USER_PASSWORD_KEY, account.getPassword());
-
         setAccountField(context, UserSchema.MOBILE_KEY, account.getMobile());
 
         // organizationalPerson attributes
@@ -418,6 +416,8 @@ public final class AccountDaoImpl implements AccountDao {
         setAccountField(context, UserSchema.STATE_OR_PROVINCE_KEY, account.getStateOrProvince());
 
         setAccountField(context, UserSchema.ORG_UNIT_KEY, account.getOrganizationalUnit());
+        
+        setAccountField(context, UserSchema.HOME_POSTAL_ADDRESS_KEY, account.getHomePostalAddress());
     }
 
     private void setAccountField(DirContextOperations context, String fieldName, Object value) {

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/dto/AccountImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/dto/AccountImpl.java
@@ -14,7 +14,7 @@ import org.springframework.security.authentication.encoding.LdapShaPasswordEncod
  * @author Mauricio Pazos
  *
  */
-class AccountImpl implements Serializable, Account, Comparable<Account>{
+public class AccountImpl implements Serializable, Account, Comparable<Account>{
 
 	private static final long serialVersionUID = -8022496448991887664L;
 

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ds/AccountDaoTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ds/AccountDaoTest.java
@@ -1,0 +1,79 @@
+package org.georchestra.ldapadmin.ds;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.HashMap;
+
+import javax.naming.directory.Attributes;
+import javax.naming.ldap.LdapName;
+
+import org.georchestra.ldapadmin.dto.Account;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.ldap.core.AuthenticationSource;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+
+
+public class AccountDaoTest {
+
+    private AccountDao us;
+    private LdapContextSource contextSource;
+    
+    @Before
+    public void setUp() throws Exception {
+        assumeTrue(System.getProperty("ldapadmin.test.ldapUrl") != null
+                && System.getProperty("ldapadmin.test.ldapBaseDn") != null
+                && System.getProperty("ldapadmin.test.ldapAdminDn") != null
+                && System.getProperty("ldapadmin.test.ldapAdminDnPw") != null);
+
+        String ldapUrl = System.getProperty("ldapadmin.test.ldapUrl");
+        String baseDn = System.getProperty("ldapadmin.test.ldapBaseDn");
+        String ldapAdminDn = System.getProperty("ldapadmin.test.ldapAdminDn");
+        String ldapAdminDnPw = System.getProperty("ldapadmin.test.ldapAdminDnPw");
+
+        contextSource = new LdapContextSource();
+        contextSource.setBase(baseDn);
+        contextSource.setUrl(ldapUrl);
+        contextSource.setBaseEnvironmentProperties(new HashMap<String, Object>());
+        contextSource.setUserDn(ldapAdminDn);
+        contextSource.setPassword(ldapAdminDnPw);
+        contextSource.setAnonymousReadOnly(true);
+        contextSource.setCacheEnvironmentProperties(false);
+        AuthenticationSource authsrc =  Mockito.mock(AuthenticationSource.class);
+        Mockito.when(authsrc.getPrincipal()).thenReturn(ldapAdminDn);
+        Mockito.when(authsrc.getCredentials()).thenReturn(ldapAdminDnPw);
+        contextSource.setAuthenticationSource(authsrc);
+
+        LdapTemplate ldapTemplate = new LdapTemplate(contextSource);
+
+        us = new AccountDaoImpl(ldapTemplate, null);
+        ((AccountDaoImpl) us).setUserSearchBaseDN("ou=users");
+    }
+
+    @Test
+    public void testBlankFields_issues_1086_1096() throws Exception {
+        Account testadminAc  = us.findByUID("testadmin");
+        String org = testadminAc.getOrg();
+        
+        testadminAc.setOrg(null);
+        
+        us.update(testadminAc);
+        
+        Attributes attrs = contextSource.getReadWriteContext().getAttributes(new LdapName("uid=testadmin,ou=users"));
+            
+        boolean hasStillUserPassword = attrs.get("userPassword") != null;
+        boolean noOrgAnymore = attrs.get("o") == null;
+        
+        // restoring 'o' attribute before assertions, to keep original state
+        testadminAc.setOrg(org);
+        us.update(testadminAc);
+
+        assertTrue("No userPassword found for testadmin, expected one", hasStillUserPassword);
+        assertTrue("Found a 'o' attribute, expeceted none", noOrgAnymore);
+        
+    }
+ 
+}


### PR DESCRIPTION
Remove the userPassword of the maping + add test with real LDAP
fixes #1097

Tests:
- runtime: ok
- Integration test (against real LDAP with default geOr base): ok