### PR TITLE
ldapadmin - administrators can modify users' uid

### DIFF
--- a/config/defaults/ldapadmin/WEB-INF/templates/account-uid-renamed.txt
+++ b/config/defaults/ldapadmin/WEB-INF/templates/account-uid-renamed.txt
@@ -1,0 +1,9 @@
+Dear {name},
+
+This message is intended to let you know that your identifier on the
+geOrchestra platform has been modified.
+
+Your new login is now: {uid}
+
+---
+Sent by @shared.instance.name@ (@shared.homepage.url@)

--- a/config/defaults/ldapadmin/maven.filter
+++ b/config/defaults/ldapadmin/maven.filter
@@ -36,7 +36,7 @@ smtpPort=@shared.smtp.port@
 replyTo=@shared.email.replyTo@
 from=@shared.email.from@
 emailHtml=@shared.email.html@
-
+warnUserIfUidModified=@shared.ldapadmin.warnifuidmodified@
 # Moderation (enabled by default - we do not want people to be able to gain access to resources without the admin's consent)
 moderatorEmail=@shared.administrator.email@
 
@@ -47,6 +47,7 @@ subject.account.created=
 subject.account.in.process=
 subject.requires.moderation=
 subject.change.password=
+subject.account.uid.renamed=
 moderatedSignup=
 delayInDays=
 requiredFields=

--- a/config/shared.maven.filters
+++ b/config/shared.maven.filters
@@ -61,6 +61,7 @@ shared.download_form.pdfurl=
 shared.ldapadmin.contextpath=/ldapadmin
 shared.ldapadmin.db=georchestra
 shared.ldapadmin.jdbcurl=jdbc:postgresql://@shared.psql.host@:@shared.psql.port@/@shared.ldapadmin.db@
+shared.ldapadmin.warnifuidmodified=true
 
 shared.mapfishapp.db=georchestra
 shared.mapfishapp.jdbcurl=jdbc:postgresql://@shared.psql.host@:@shared.psql.port@/@shared.mapfishapp.db@

--- a/ldapadmin/src/deb/resources/etc/georchestra/ldapadmin/ldapadmin.properties
+++ b/ldapadmin/src/deb/resources/etc/georchestra/ldapadmin/ldapadmin.properties
@@ -39,6 +39,8 @@ subject.account.created=[geOrchestra] Your account has been created
 subject.account.in.process=[geOrchestra] Your new account is waiting for validation
 subject.requires.moderation=[geOrchestra] New account waiting for validation
 subject.change.password=[geOrchestra] Update your password
+subject.account.uid.renamed=[geOrchestra] New login for your account
+warnUserIfUidModified=true
 
 # Used in header*.jsp (size in px)
 headerHeight=90

--- a/ldapadmin/src/deb/resources/etc/georchestra/ldapadmin/templates/account-uid-renamed.txt
+++ b/ldapadmin/src/deb/resources/etc/georchestra/ldapadmin/templates/account-uid-renamed.txt
@@ -1,0 +1,9 @@
+Dear {name}, 
+
+This message is intended to let you know that your identifier on the
+geOrchestra platform has been modified.
+
+Your new login is now: {uid}
+
+---
+Sent by geOrchestra (http://georchestra.mydomain.org/)

--- a/ldapadmin/src/main/filtered-resources/WEB-INF/spring/ldapadmin.properties
+++ b/ldapadmin/src/main/filtered-resources/WEB-INF/spring/ldapadmin.properties
@@ -38,4 +38,5 @@ subject.account.created=${subject.account.created}
 subject.account.in.process=${subject.account.in.process}
 subject.requires.moderation=${subject.requires.moderation}
 subject.change.password=${subject.change.password}
-
+subject.account.uid.renamed=${subject.account.uid.renamed}
+warnUserIfUidModified=${warnUserIfUidModified}

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDao.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDao.java
@@ -59,6 +59,19 @@ public interface AccountDao {
 	void update(final Account account) throws DataServiceException, DuplicatedEmailException;
 
 	/**
+	 * Updates the user account, given the old and the new state of the account
+	 * Needed if a DN update is required (modifying the uid).
+	 *
+	 * @param account
+	 * @param modified
+	 *
+	 * @throws DuplicatedEmailException
+	 * @throws DataServiceException
+	 * @throws NotFoundException
+	 */
+	void update(Account account, Account modified) throws DataServiceException, DuplicatedEmailException, NotFoundException;
+
+	/**
 	 * Changes the user password
 	 * 
 	 * @param uid
@@ -123,8 +136,4 @@ public interface AccountDao {
 	 */
 	String generateUid(String uid) throws DataServiceException;
 
-	
-
-
-	
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/AccountDaoImpl.java
@@ -191,7 +191,7 @@ public final class AccountDaoImpl implements AccountDao {
      * @see {@link AccountDao#update(Account)}
      */
     @Override
-    public void update(final Account account) throws DataServiceException, DuplicatedEmailException {
+    public synchronized void update(final Account account) throws DataServiceException, DuplicatedEmailException {
 
         // checks mandatory fields
         if (account.getUid().length() == 0) {
@@ -238,7 +238,7 @@ public final class AccountDaoImpl implements AccountDao {
      * @see {@link AccountDao#update(Account, Account)}
      */
     @Override
-    public void update(Account account, Account modified) throws DataServiceException, DuplicatedEmailException, NotFoundException {
+    public synchronized void update(Account account, Account modified) throws DataServiceException, DuplicatedEmailException, NotFoundException {
        if (! account.getUid().equals(modified.getUid())) {
            ldapTemplate.rename(buildDn(account.getUid()), buildDn(modified.getUid()));
            for (Group g : groupDao.findAllForUser(account.getUid())) {
@@ -254,7 +254,7 @@ public final class AccountDaoImpl implements AccountDao {
      * @see {@link AccountDao#delete(Account)}
      */
     @Override
-    public void delete(final String uid) throws DataServiceException, NotFoundException {
+    public synchronized void delete(final String uid) throws DataServiceException, NotFoundException {
         this.ldapTemplate.unbind(buildDn(uid), true);
 
         this.groupDao.deleteUser(uid);

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/GroupDao.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/GroupDao.java
@@ -64,15 +64,15 @@ public interface GroupDao {
 	 */
 	void deleteUser(String groupName, String uid) throws DataServiceException;
 
-    /**
-     * Modifies the user (e.g. rename) from the group
-     *
-     * @param groupName
-     * @param oldUid
-     * @param newUid
-     * @throws DataServiceException
-     */
-    void modifyUser(String groupName, String oldUid, String newUid) throws DataServiceException;
+	/**
+	 * Modifies the user (e.g. rename) from the group
+	 *
+	 * @param groupName
+	 * @param oldUid
+	 * @param newUid
+	 * @throws DataServiceException
+	 */
+	void modifyUser(String groupName, String oldUid, String newUid) throws DataServiceException;
 
 	/**
 	 * Adds the group

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/GroupDao.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ds/GroupDao.java
@@ -30,7 +30,14 @@ public interface GroupDao {
 	 * @return list of {@link Group}
 	 */
 	List<Group> findAll() throws DataServiceException;
-	
+
+	/**
+	 * Returns all groups for a given uid.
+	 *
+	 * @return list of {@link Group}
+	 */
+	List<Group> findAllForUser(String userId) throws DataServiceException;
+
 	/**
 	 * Returns the group's users
 	 * 
@@ -38,25 +45,34 @@ public interface GroupDao {
 	 */
 	List<String> findUsers(final String groupName) throws DataServiceException;
 
-
 	/**
 	 * Deletes the user from all groups 
-	 * 
+	 *
 	 * @param uid
 	 * @throws DataServiceException
 	 */
 	void deleteUser(String uid) throws DataServiceException;
-	
+
 	void deleteUsers(String cn, List<String> deleteList) throws DataServiceException, NotFoundException;
-	
+
 	/**
-	 * Deletes the user from the user
+	 * Deletes the user from the group
 	 * 
 	 * @param groupName
 	 * @param uid
 	 * @throws DataServiceException
 	 */
 	void deleteUser(String groupName, String uid) throws DataServiceException;
+
+    /**
+     * Modifies the user (e.g. rename) from the group
+     *
+     * @param groupName
+     * @param oldUid
+     * @param newUid
+     * @throws DataServiceException
+     */
+    void modifyUser(String groupName, String oldUid, String newUid) throws DataServiceException;
 
 	/**
 	 * Adds the group

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/dto/AccountFactory.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/dto/AccountFactory.java
@@ -184,4 +184,38 @@ public class AccountFactory {
 		return a;
 	}
 
+	/**
+	 * Creates an account object from another one, given as argument.
+	 *
+	 * @param o other account to copy
+	 */
+	public static Account create(Account o) {
+		Account a = new AccountImpl();
+		a.setUid(o.getUid());
+		a.setCommonName(o.getCommonName());
+		a.setSurname(o.getSurname());
+		a.setOrg(o.getOrg());
+		a.setEmail(o.getEmail());
+		a.setPhone(o.getPhone());
+		a.setDescription(o.getDescription());
+		// passwords / new passwords fields voluntarily omitted:
+		// the password update process should not go through this.
+		a.setGivenName(o.getGivenName());
+		a.setTitle(o.getTitle());
+		a.setPostalAddress(o.getPostalAddress());
+		a.setPostalCode(o.getPostalCode());
+		a.setRegisteredAddress(o.getRegisteredAddress());
+		a.setPostOfficeBox(o.getPostOfficeBox());
+		a.setPhysicalDeliveryOfficeName(o.getPhysicalDeliveryOfficeName());
+		a.setStreet(o.getStreet());
+		a.setLocality(o.getLocality());
+		a.setFacsimile(o.getFacsimile());
+		a.setMobile(o.getMobile());
+		a.setRoomNumber(o.getRoomNumber());
+		a.setStateOrProvince(o.getStateOrProvince());
+		a.setOrganizationalUnit(o.getOrganizationalUnit());
+		a.setHomePostalAddress(o.getHomePostalAddress());
+		return a;
+	}
+
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/AccountUidRenamedEmail.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/AccountUidRenamedEmail.java
@@ -1,0 +1,51 @@
+package org.georchestra.ldapadmin.mailservice;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
+import javax.servlet.ServletContext;
+
+import org.georchestra.commons.configuration.GeorchestraConfiguration;
+
+public class AccountUidRenamedEmail extends Email {
+	
+	private ServletContext context;
+
+	public AccountUidRenamedEmail(String[] recipients,
+			String emailSubject,
+			String smtpHost,
+			int smtpPort,
+			String emailHtml,
+			String replyTo,
+			String from,
+			String bodyEncoding,
+			String subjectEncoding,
+			String[] languages,
+			String fileTemplate,
+			ServletContext ctx,
+			GeorchestraConfiguration georConfig) {
+		super(recipients, emailSubject, smtpHost, smtpPort, emailHtml, replyTo,
+				from, bodyEncoding, subjectEncoding, languages,
+				fileTemplate, georConfig);
+		
+		context = ctx;
+	}
+
+	@Override
+	protected String toAbsolutePath(String fileTemplate) {
+    	return this.context.getRealPath(fileTemplate);
+	}
+	
+	public void sendMsg(final String userName, final String uid)
+			throws AddressException, MessagingException {
+		String body = getBodyTemplate();
+		body = body.replace("{uid}", uid);
+		body = body.replace("{name}", userName);
+
+		if(LOG.isDebugEnabled() ){
+			LOG.debug("built email: "+ body);
+		}
+
+		super.sendMsg(body);
+	}
+
+}

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/Email.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/Email.java
@@ -83,8 +83,7 @@ public abstract class Email {
 
 	/**
      * Read the body from template
-     * @param servletContext
-     * @return
+     * @return String the formatted message
      */
     protected String getBodyTemplate() {
 

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/EmailFactoryImpl.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/EmailFactoryImpl.java
@@ -23,6 +23,17 @@ public class EmailFactoryImpl extends AbstractEmailFactory {
 
 	private String changePasswordEmailFile;
 	private String changePasswordEmailSubject;
+	
+	private String accountUidRenamedEmailFile;
+	private String accountUidRenamedEmailSubject;
+	
+	public void setAccountUidRenamedEmailSubject(String accountUidRenamedEmailSubject) {
+		this.accountUidRenamedEmailSubject = accountUidRenamedEmailSubject;
+	}
+
+	public void setAccountUidRenamedEmailFile(String accountUidRenamedEmailFile) {
+		this.accountUidRenamedEmailFile = accountUidRenamedEmailFile;
+	}
 
 	public void setAccountWasCreatedEmailFile(String accountWasCreatedEmailFile) {
 		this.accountWasCreatedEmailFile = accountWasCreatedEmailFile;
@@ -159,5 +170,28 @@ public class EmailFactoryImpl extends AbstractEmailFactory {
 
 		return mail;
 
+	}
+	
+	public AccountUidRenamedEmail createAccountUidRenamedEmail(ServletContext servletContext, String[] recipients) {
+
+		super.emailSubject = this.accountUidRenamedEmailSubject;
+
+		AccountUidRenamedEmail mail = new AccountUidRenamedEmail(
+				recipients,
+				super.emailSubject,
+				this.smtpHost,
+				this.smtpPort,
+				this.emailHtml,
+				this.replyTo,
+				this.from,
+				this.bodyEncoding,
+				this.subjectEncoding,
+				this.languages,
+				this.accountUidRenamedEmailFile,
+				servletContext,
+				this.georConfig
+				);
+
+		return mail;
 	}
 }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/MailService.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/mailservice/MailService.java
@@ -64,6 +64,21 @@ public final class MailService {
 		
 	}
 	
+	public void sendAccountUidRenamed(final ServletContext servletContext, final String newUid, final String commonName, final String userEmail) {
+		if(LOG.isDebugEnabled()){
+			LOG.debug("Send mail to warn user [email: " + userEmail + "] for its new identifier: " + newUid);
+		}
+		try{
+			AccountUidRenamedEmail email = this.emailFactory.createAccountUidRenamedEmail(servletContext, new String[]{userEmail});
+			
+			email.sendMsg(commonName, newUid );
+			
+		} catch (Exception e) {
+			
+			LOG.error(e);
+		} 
+	}
+	
 
 	public void sendAccountWasCreated(final ServletContext servletContext, final String uid, final String commonName, final String userEmail) {
 

--- a/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -155,6 +155,8 @@
     <property name="newAccountRequiresModerationEmailSubject" value="${subject.requires.moderation}"/>
     <property name="changePasswordEmailFile" value="/WEB-INF/templates/changepassword-email-template.txt"/>
     <property name="changePasswordEmailSubject" value="${subject.change.password}"/>
+    <property name="accountUidRenamedEmailFile" value="/WEB-INF/templates/account-uid-renamed.txt" />
+    <property name="accountUidRenamedEmailSubject" value="${subject.account.uid.renamed}" />    
   </bean>
 
   <bean id="mailService" class="org.georchestra.ldapadmin.mailservice.MailService">
@@ -172,6 +174,10 @@
 
   <bean id="validation" class="org.georchestra.ldapadmin.ws.utils.Validation">
     <property name="requiredFields" value="${requiredFields}"/>
+  </bean>
+
+  <bean id="warnUserIfUidModified" class="java.lang.Boolean">
+    <constructor-arg value="${warnUserIfUidModified}" />
   </bean>
 
   <bean id="georchestraConfiguration" class="org.georchestra.commons.configuration.GeorchestraConfiguration">

--- a/ldapadmin/src/main/webapp/privateui/js/controllers.js
+++ b/ldapadmin/src/main/webapp/privateui/js/controllers.js
@@ -259,11 +259,28 @@ angular.module('ldapadmin.controllers', [])
       $scope.save = function() {
         $scope.user.put().then(function() {
           flash.success = 'User correctly updated';
-          var index = findByAttr($scope.users, 'uid', $routeParams.userId);
+          var prevUserId = $routeParams.userId;
+          var newUserId = $scope.user.uid;
+          var index = findByAttr($scope.users, 'uid', prevUserId);
 
           if (index !== false) {
             $scope.users[index] = angular.copy($scope.user);
             remote = angular.copy($scope.user);
+
+            // uid modified
+            if (newUserId != prevUserId) {
+                window.location = '#/users/' + newUserId;
+
+                // Update the groups the user belongs to
+                var i,
+                    len = $scope.groups.length;
+                for (i=0; i < len; i++) {
+                  var index2 = _.indexOf($scope.groups[i].users, prevUserId);
+                  if (index2 != -1) {
+                      $scope.groups[i].users[index2] = newUserId;
+                  }
+                }
+            }
           }
         }, function(args) {
           flash.error = 'User could not be updated';

--- a/ldapadmin/src/main/webapp/privateui/js/controllers.js
+++ b/ldapadmin/src/main/webapp/privateui/js/controllers.js
@@ -269,17 +269,17 @@ angular.module('ldapadmin.controllers', [])
 
             // uid modified
             if (newUserId != prevUserId) {
-                window.location = '#/users/' + newUserId;
+              window.location = '#/users/' + newUserId;
 
-                // Update the groups the user belongs to
-                var i,
-                    len = $scope.groups.length;
-                for (i=0; i < len; i++) {
-                  var index2 = _.indexOf($scope.groups[i].users, prevUserId);
-                  if (index2 != -1) {
-                      $scope.groups[i].users[index2] = newUserId;
-                  }
+              // Update the groups the user belongs to
+              var i,
+                  len = $scope.groups.length;
+              for (i=0; i < len; i++) {
+                var index2 = _.indexOf($scope.groups[i].users, prevUserId);
+                if (index2 != -1) {
+                  $scope.groups[i].users[index2] = newUserId;
                 }
+              }
             }
           }
         }, function(args) {

--- a/ldapadmin/src/main/webapp/privateui/partials/user-edit.html
+++ b/ldapadmin/src/main/webapp/privateui/partials/user-edit.html
@@ -25,7 +25,7 @@
     <div class="span6">
       <div class="control-group">
         <label for="mail">Login</label>
-        <input type="text" name="uid" ng-model="user.uid" ng-readonly="true" placeholder="Login" class="span12"/>
+        <input type="text" name="uid" ng-model="user.uid" placeholder="Login" class="span12"/>
       </div>
     </div>
     <div class="span6">

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ds/AccountDaoTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ds/AccountDaoTest.java
@@ -24,15 +24,15 @@ public class AccountDaoTest {
     
     @Before
     public void setUp() throws Exception {
-        assumeTrue(System.getProperty("ldapadmin.test.ldapUrl") != null
-                && System.getProperty("ldapadmin.test.ldapBaseDn") != null
-                && System.getProperty("ldapadmin.test.ldapAdminDn") != null
-                && System.getProperty("ldapadmin.test.ldapAdminDnPw") != null);
+        assumeTrue(System.getProperty("ldapadmin.test.openldap.ldapurl") != null
+                && System.getProperty("ldapadmin.test.openldap.basedn") != null
+                && System.getProperty("ldapadmin.test.openldap.binddn") != null
+                && System.getProperty("ldapadmin.test.openldap.password") != null);
 
-        String ldapUrl = System.getProperty("ldapadmin.test.ldapUrl");
-        String baseDn = System.getProperty("ldapadmin.test.ldapBaseDn");
-        String ldapAdminDn = System.getProperty("ldapadmin.test.ldapAdminDn");
-        String ldapAdminDnPw = System.getProperty("ldapadmin.test.ldapAdminDnPw");
+        String ldapUrl = System.getProperty("ldapadmin.test.openldap.ldapurl");
+        String baseDn = System.getProperty("ldapadmin.test.openldap.basedn");
+        String ldapAdminDn = System.getProperty("ldapadmin.test.openldap.binddn");
+        String ldapAdminDnPw = System.getProperty("ldapadmin.test.openldap.password");
 
         contextSource = new LdapContextSource();
         contextSource.setBase(baseDn);

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersControllerTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersControllerTest.java
@@ -414,7 +414,9 @@ public class UsersControllerTest {
     public void testUpdateBadJSON() throws Exception {
         request.setRequestURI("/ldapadmin/users/pmauduit");
         request.setContent("{[this is ] } not valid JSON obviously ....".getBytes());
-
+        Mockito.when(ldapTemplate.lookup(Mockito.any(Name.class), Mockito.any(ContextMapper.class))).thenReturn(
+              AccountFactory.createBrief("pmauduit", "monkey123", "Pierre", "Mauduit",
+              "pmt@c2c.com", "+123", "+456", "developer", "developer"));
         try {
             usersCtrl.update(request, response);
         } catch (Throwable e) {

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersExportTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/backoffice/users/UsersExportTest.java
@@ -46,11 +46,11 @@ public class UsersExportTest {
     }
 
     private void setUpAgainstRealLdap() {
-        assumeTrue(System.getProperty("ldapadmin.test.ldapUrl") != null
-                && System.getProperty("ldapadmin.test.ldapBaseDn") != null);
+        assumeTrue(System.getProperty("ldapadmin.test.openldap.ldapurl") != null
+                && System.getProperty("ldapadmin.test.openldap.basedn") != null);
 
-        String ldapUrl = System.getProperty("ldapadmin.test.ldapUrl");
-        String baseDn = System.getProperty("ldapadmin.test.ldapBaseDn");
+        String ldapUrl = System.getProperty("ldapadmin.test.openldap.ldapurl");
+        String baseDn = System.getProperty("ldapadmin.test.openldap.basedn");
 
         DefaultSpringSecurityContextSource contextSource = new DefaultSpringSecurityContextSource(ldapUrl + baseDn);
         contextSource.setBase(baseDn);


### PR DESCRIPTION
Evolution funded by CIGALsace (https://github.com/camptocamp/georchestra-cigalsace-configuration/issues/531).

Enables the ability for LDAP administrators (members of MOD_LDAPADMIN) to modify the user id (uid) of the users LDAP entries.

The uid field is not like the others attributes and need extra work to implement the ability to modify it, since it is part of the DN qualification ; it requires to "move" the LDAP entry, which is not the same as updating a regular attribute.

It also requires to get the users groups and update the member entry (server-side but also client-side in the js objects).

Tests: 
- [x] Utests + tests against a real ldap adapted / OK
- [x] Runtime tests OK
- [x] No added tests though, might deserve a one, at least onto a regular LDAP.
- [x] Adding the "Warn by mail" feature