### PR TITLE
Add configuration to run georchestra with multiple jetty instances

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -171,17 +171,15 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.18</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-              <maxIdleTime>10000</maxIdleTime>
-            </connector>
-          </connectors>
+          <webApp><contextPath>/analytics/</contextPath></webApp>
           <scanIntervalSeconds>5</scanIntervalSeconds>
+          <httpConnector>
+            <port>8280</port>
+          </httpConnector>
         </configuration>
       </plugin>
     </plugins>

--- a/catalogapp/pom.xml
+++ b/catalogapp/pom.xml
@@ -76,6 +76,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
+        <configuration>
+          <webApp><contextPath>/catalogapp/</contextPath></webApp>
+          <scanIntervalSeconds>5</scanIntervalSeconds>
+          <httpConnector>
+            <port>8281</port>
+          </httpConnector>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>

--- a/downloadform/pom.xml
+++ b/downloadform/pom.xml
@@ -138,17 +138,15 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.18</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8083</port>
-              <maxIdleTime>10000</maxIdleTime>
-            </connector>
-          </connectors>
+          <webApp><contextPath>/downloadform/</contextPath></webApp>
           <scanIntervalSeconds>5</scanIntervalSeconds>
+          <httpConnector>
+            <port>8282</port>
+          </httpConnector>
         </configuration>
       </plugin>
     </plugins>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -356,16 +356,14 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
-          <webApp>${basedir}/target/extractorapp.war</webApp>
-          <scanIntervalSeconds>5</scanIntervalSeconds>
-          <scanTargets>
-            <scanTarget>src/main/java</scanTarget>
-            <scanTarget>src/main/resources</scanTarget>
-          </scanTargets>
+          <!--<webApp>${basedir}/target/extractorapp.war</webApp>-->
+          <httpConnector>
+            <port>8283</port>
+          </httpConnector>
           <systemProperties>
             <systemProperty>
               <name>org.geotools.referencing.forceXY</name>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -361,6 +361,11 @@
         <version>9.2.11.v20150529</version>
         <configuration>
           <webApp><contextPath>/extractorapp/</contextPath></webApp>
+          <scanIntervalSeconds>5</scanIntervalSeconds>
+          <scanTargets>
+            <scanTarget>src/main/java</scanTarget>
+            <scanTarget>src/main/resources</scanTarget>
+          </scanTargets>
           <!--<webApp>${basedir}/target/extractorapp.war</webApp>-->
           <httpConnector>
             <port>8283</port>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -360,6 +360,7 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>9.2.11.v20150529</version>
         <configuration>
+          <webApp><contextPath>/extractorapp/</contextPath></webApp>
           <!--<webApp>${basedir}/target/extractorapp.war</webApp>-->
           <httpConnector>
             <port>8283</port>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -82,6 +82,7 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>9.2.11.v20150529</version>
         <configuration>
+          <webApp><contextPath>/header/</contextPath></webApp>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java</scanTarget>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -78,13 +78,18 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.10</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
           <scanIntervalSeconds>10</scanIntervalSeconds>
-          <stopKey>foo</stopKey>
-          <stopPort>9999</stopPort>
+          <scanTargets>
+            <scanTarget>src/main/java</scanTarget>
+            <scanTarget>src/main/resources</scanTarget>
+          </scanTargets>
+          <httpConnector>
+            <port>8285</port>
+          </httpConnector>
         </configuration>
       </plugin>
       <plugin>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -83,7 +83,7 @@
         <version>9.2.11.v20150529</version>
         <configuration>
           <webApp><contextPath>/header/</contextPath></webApp>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <scanIntervalSeconds>5</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java</scanTarget>
             <scanTarget>src/main/resources</scanTarget>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -542,16 +542,26 @@
         <version>1.1</version>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
+          <webApp><contextPath>/ldapadmin/</contextPath></webApp>
           <scanIntervalSeconds>5</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java/</scanTarget>
             <scanTarget>src/main/resources/</scanTarget>
             <scanTarget>src/main/webapp/</scanTarget>
           </scanTargets>
+          <httpConnector>
+            <port>8286</port>
+          </httpConnector>
+          <systemProperties>
+            <systemProperty>
+              <name>org.geotools.referencing.forceXY</name>
+              <value>true</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -266,16 +266,20 @@
           <packagingExcludes>**/ext/examples/**,**/ext/pkgs/**,**/docs/**,**/openlayers/examples/**,**/openlayers/tests/**,PostTreatment.groovy</packagingExcludes>
         </configuration>
       </plugin>
+      <!-- needed for jetty:run maven target -->
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
-          <scanIntervalSeconds>5</scanIntervalSeconds>
+          <scanIntervalSeconds>10</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java</scanTarget>
             <scanTarget>src/main/resources</scanTarget>
           </scanTargets>
+          <httpConnector>
+            <port>8287</port>
+          </httpConnector>
           <systemProperties>
             <systemProperty>
               <name>org.geotools.referencing.forceXY</name>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -273,7 +273,7 @@
         <version>9.2.11.v20150529</version>
         <configuration>
           <webApp><contextPath>/mapfishapp/</contextPath></webApp>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <scanIntervalSeconds>5</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java</scanTarget>
             <scanTarget>src/main/resources</scanTarget>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -272,6 +272,7 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>9.2.11.v20150529</version>
         <configuration>
+          <webApp><contextPath>/mapfishapp/</contextPath></webApp>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java</scanTarget>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -252,20 +252,24 @@
           <target>1.6</target>
         </configuration>
       </plugin>
+
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.18</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.11.v20150529</version>
         <configuration>
-          <webAppConfig>
+          <webApp>
             <contextPath>/</contextPath>
-            <baseResource implementation="org.mortbay.resource.ResourceCollection">
+            <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
               <resourcesAsCSV>${basedir}/src/main/webapp,${basedir}/target/generated-configs/</resourcesAsCSV>
             </baseResource>
-          </webAppConfig>
+          </webApp>
           <stopKey>JETTY_TOP</stopKey>
           <stopPort>8090</stopPort>
           <reload>manual</reload>
+          <httpConnector>
+            <port>8180</port>
+          </httpConnector>
         </configuration>
       </plugin>
     </plugins>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -264,6 +264,7 @@
               <resourcesAsCSV>${basedir}/src/main/webapp,${basedir}/target/generated-configs/</resourcesAsCSV>
             </baseResource>
           </webApp>
+          <scanIntervalSeconds>5</scanIntervalSeconds>
           <stopKey>JETTY_TOP</stopKey>
           <stopPort>8090</stopPort>
           <reload>manual</reload>


### PR DESCRIPTION
Currently, jetty was configured for following modules : 

* Security proxy
* Cas
* mapfishapp
* extractorapp
* header
