### PR TITLE
[Mapfish] Correct line return in context list

### DIFF
--- a/mapfishapp/src/main/webapp/app/css/main.css
+++ b/mapfishapp/src/main/webapp/app/css/main.css
@@ -381,6 +381,7 @@ div.olMapViewport {
     margin-right: 0;
     padding: 5px;
     cursor: pointer;
+    width: 116px;
 }
 
 .context-selector .thumb-wrap span {


### PR DESCRIPTION
When the context title is too long, there is no line return and the context is larger than others and it shift all next contexts. That's ugly.

With this css rule, the width of each context is fixed so it prevent that shift.