### PR TITLE
ldapadmin,mapfishapp,extractorapp - commons-fileupload bump

### DIFF
--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -57,11 +57,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.3.1</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.4</version>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -250,7 +250,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.2.2</version>
+      <version>1.3.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -248,11 +248,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.3.1</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.4</version>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
the current version of commons-fileupload is vulnerable to a known vulnerability, which might cause a deny-of-service[1].

Tests: Compilation time, would require runtime tests (once merged and the VM is regenerated on the CI)

Note: I am wondering why this dependency is necessary in extractorapp / ldapadmin ? From what I'm aware of, sending file from the browser is only possible from mapfishapp.

[1] https://www.cvedetails.com/cve/CVE-2014-0050/