### PR TITLE
SP - session invalidation

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -217,7 +217,6 @@ public class HeadersManagementStrategy {
      */
     public synchronized void copyResponseHeaders(HttpServletRequest originalRequest, String originalRequestURI, HttpResponse proxyResponse, HttpServletResponse finalResponse, Map<String,String> proxyTargets) {
         HttpSession session = originalRequest.getSession(true);
-        session.setMaxInactiveInterval(Integer.MAX_VALUE);
 
         StringBuilder headersLog = new StringBuilder("Response Headers:\n");
         headersLog


### PR DESCRIPTION
Removing `setMaxInactiveInterval(Integer.MAX_VALUE)`, related to https://github.com/georchestra/georchestra/issues/1069

This modification has been tested and does not break the normal behaviour at runtime. Should be good to be merged into master to test it more thoroughly.