### PR TITLE
extractorapp - Removing useless bean definition

### DIFF
--- a/extractorapp/src/main/filtered-resources/WEB-INF/ws-servlet.xml
+++ b/extractorapp/src/main/filtered-resources/WEB-INF/ws-servlet.xml
@@ -84,11 +84,6 @@
         <property name="suffix" value=".jsp"/>
     </bean>
 
-    <!-- File upload controller -->
-    <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-      <property name="maxUploadSize" value="1000000"/>
-    </bean>
-
     <bean id="georchestraConfiguration" class="org.georchestra.commons.configuration.GeorchestraConfiguration">
         <constructor-arg value="extractorapp" />
     </bean>


### PR DESCRIPTION
Fixes #1174.

Tests:
- suite OK (but this modification could not be revealed by the unit tests)
- runtime OK (in dockerization)
