### PR TITLE
Reset the _userAgents list if an user-agents.properties file is found…

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/BasicAuthChallengeByUserAgent.java
+++ b/security-proxy/src/main/java/org/georchestra/security/BasicAuthChallengeByUserAgent.java
@@ -56,6 +56,7 @@ public class BasicAuthChallengeByUserAgent extends BasicAuthenticationFilter {
             try {
                 fisProp = new FileInputStream(new File(contextDatadir, "user-agents.properties"));
                 InputStreamReader isrProp = new InputStreamReader(fisProp, "UTF8");
+                _userAgents.clear();
                 uaProps.load(isrProp);
             } finally {
                 if (fisProp != null) {
@@ -66,7 +67,6 @@ public class BasicAuthChallengeByUserAgent extends BasicAuthenticationFilter {
         if (! uaProps.isEmpty()) {
             int i = 0;
             String ua;
-            _userAgents.clear();
             while ((ua = uaProps.getProperty("useragent" + i + ".value")) != null) {
                 _userAgents.add(Pattern.compile(ua));
                 i++;


### PR DESCRIPTION
… in the datadir (#1186)

The list wasnt emptied if the file was found but contained no properties
(ie all commented out) and thus the default UA list from applicationContext-security.xml
was still in use.

Untested yet, but the logic should be better. Hope this wont conflict/get in the way of  testing #1182