### PR TITLE
mapfishapp - same behaviour for contexts

### DIFF
--- a/mapfishapp/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/mapfishapp/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -5,8 +5,8 @@
 <urlrewrite>
 
     <rule>
-        <from>^/context/(.*)$</from>
-        <to type="forward" last="true">/ws/context/$1</to>
+        <from>^/context(s?)/(.*)$</from>
+        <to type="forward" last="true">/ws/context/$2</to>
     </rule>
     <rule>
         <from>^/map/(\d{19})/?$</from>


### PR DESCRIPTION
Between datadirs and non-datadirs mode, both urls (/context/blah.wmc and
/contexts/blah.wmc) should redirect onto the context controller.

Should fix #1193

Tests: untested at runtime yet