### PR TITLE
Use default user agent on remote server

### DIFF
--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
@@ -154,7 +154,9 @@ public class WfsExtractor {
 
             enablePreemptiveBasicAuth(capabilitiesURL, httpClientBuilder, localContext, httpHost, _adminUsername, _adminPassword);
         } else {
-        	LOG.debug("WfsExtractor.checkPermission - Non Secured Server");
+            // use a user agent that did *not* trigger basic auth on remote server
+            httpClientBuilder.setUserAgent("Apache-HttpClient");
+            LOG.debug("WfsExtractor.checkPermission - Non Secured Server");
         }
 
         final CloseableHttpClient httpclient = httpClientBuilder.build();


### PR DESCRIPTION
This should fix extraction on remote server. Tested with "armoires optiques" from sdi.