### PR TITLE
ldapadmin - publicContextPath same as shared.ldapadmin.contextpath

### DIFF
--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -548,7 +548,7 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>9.2.11.v20150529</version>
         <configuration>
-          <webApp><contextPath>/ldapadmin/</contextPath></webApp>
+          <webApp><contextPath>/ldapadmin</contextPath></webApp>
           <scanIntervalSeconds>5</scanIntervalSeconds>
           <scanTargets>
             <scanTarget>src/main/java/</scanTarget>

--- a/ldapadmin/src/deb/resources/etc/georchestra/ldapadmin/ldapadmin.properties
+++ b/ldapadmin/src/deb/resources/etc/georchestra/ldapadmin/ldapadmin.properties
@@ -1,5 +1,5 @@
 # general purposes properties
-publicContextPath=/ldapadmin/
+publicContextPath=/ldapadmin
 protectedUser.uid1=geoserver_privileged_user
 moderatedSignup=true
 moderatorEmail=georchestra+testadmin@georchestra.mydomain.org


### PR DESCRIPTION
publicContextPath should be the same as shared.ldapadmin.contextpath, see https://github.com/georchestra/georchestra/blob/15.06/config/shared.maven.filters#L61