### PR TITLE
ogc-services-log - more coherent roles logging

### DIFF
--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/log4j/OGCServiceMessageFormatter.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/log4j/OGCServiceMessageFormatter.java
@@ -57,17 +57,9 @@ public class OGCServiceMessageFormatter {
 		// utility class
 	}
 
-	public static String format(final String user, final String request, final String org,String [] roles){
-			return format(user, new Date(), request, org,roles);
+	public static String format(final String user, final String request, final String org, final String [] roles) {
+			return format(user, new Date(), request, org, roles);
 	}
-	/*
-	public static String format(final String user,final String request, String org) { // roles null  ???
-		
-			return format(user, new Date(), request, org,null);
-
-	}
-
-	*/
 	/**
 	 * Builds a formated string that can be recognized by the OGCServicesAppender.
 	 * <pre>
@@ -83,59 +75,57 @@ public class OGCServiceMessageFormatter {
 	 * 
 	 * @return The ogcservice message
 	 */
-	public static String format(final String user, final Date date, final String request, final String org,final String [] roles){
+	public static String format(final String user, final Date date, final String request, final String org, final String [] roles) {
 		
-		if((user == null)|| "".equals(user) ){
+		if ((user == null )||  "".equals(user)) {
 			throw new IllegalArgumentException("user cannot be null");
 		}
-		if( date== null ){
+		if (date == null) {
 			throw new IllegalArgumentException("date cannot be null");
 		}
-		if((request == null)|| "".equals(request) ){
+		if ((request == null) || "".equals(request)) {
 			throw new IllegalArgumentException("request cannot be null");
 		}
-		if(roles == null){
-			roles[0] = "";
+		if (roles == null) {
+			throw new IllegalArgumentException("roles cannot be null");
 		}
 		// org can be null
-		
-		// appends user
 
-		
+		// appends user
 		StringBuilder ogcLogBuilder = new StringBuilder(user);
 		ogcLogBuilder.append(SEPARATOR);
-		
+
 		// appends date
 		DateFormat formatter = new SimpleDateFormat(DATE_FORMAT);
 		ogcLogBuilder.append(formatter.format(date));
 		ogcLogBuilder.append(SEPARATOR);
-		 
+
 		// appends ogc service request
 		ogcLogBuilder.append(request);
 		ogcLogBuilder.append(SEPARATOR);
-		
+
 		// appends ogc service org
 		ogcLogBuilder.append(org);
 		ogcLogBuilder.append(SEPARATOR);
-		
+
 		// appends ogc service roles
 		StringBuilder rolesBuilder = new StringBuilder();
 		int i=0;
 		for(String s : roles) {
-		   if (i > 0) {
-			   rolesBuilder.append(",");
-		   }
-		   rolesBuilder.append(s);
-		   i++;
+			if (i > 0) {
+				rolesBuilder.append(",");
+			}
+			rolesBuilder.append(s);
+			i++;
 		}
 		
 		ogcLogBuilder.append(rolesBuilder.toString());
 
-	    final String ogcStatisticLog = ogcLogBuilder.toString();
-	    
-	    // log additional information to test the system
-	    log(ogcLogBuilder);
-		
+		final String ogcStatisticLog = ogcLogBuilder.toString();
+
+		// log additional information to test the system
+		log(ogcLogBuilder);
+
 		return ogcStatisticLog;
 	}
 	
@@ -186,15 +176,6 @@ public class OGCServiceMessageFormatter {
 			 debugLog.append(SEPARATOR);
 		 }
 
-		 
-//		 Properties p = System.getProperties();   
-//		    p.list(System.out); 
-//		    
-//		    System.out.print("Total CPU:");
-//		    System.out.println(Runtime.getRuntime().availableProcessors());
-//		    System.out.println("os.name=" + System.getProperty("os.name"));
-		    
-		    
 		 LOGGER.debug(debugLog);	
 	}
 

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -658,13 +658,14 @@ public class Proxy {
                 }
                 // no OGC SERVICE log if request going through /proxy/?url=
                 if (!request.getRequestURI().startsWith("/sec/proxy/")) {
-                	String [] roles = null;
-                	try{
-                	Header[] rolesHeaders = proxyingRequest.getHeaders("sec-roles");
-                	roles = rolesHeaders[0].getValue().split(";");
-                	
-                	} catch (Exception e) {
-                        logger.error("Unable to compute roles", e);
+                    String [] roles = new String[] {""};
+                    try {
+                        Header[] rolesHeaders = proxyingRequest.getHeaders("sec-roles");
+                        if (rolesHeaders.length > 0) {
+                            roles = rolesHeaders[0].getValue().split(";");
+                        }
+                    } catch (Exception e) {
+                        logger.error("Unable to compute roles");
                     }
                     statsLogger.info(OGCServiceMessageFormatter.format(authentication.getName(), sURL, org, roles));
                 


### PR DESCRIPTION
This one is for @vdorut ;-)

To be coherent with the way the logger is coded, we want to check before calling the format() method that the roles is not null.

Also fixes some indent in the modified file, as well as removing comments.

Getting this stacktrace currently in the SP:

```
proxy_1             | 2016-02-11 17:38:36 security [ERROR] Unable to compute roles
proxy_1             | java.lang.ArrayIndexOutOfBoundsException: 0
proxy_1             | 	at org.georchestra.security.Proxy.handleRequest(Proxy.java:664)
[...]
proxy_1             | 2016-02-11 17:38:36 security [ERROR] Unable to log the request into the statistics logger
proxy_1             | java.lang.NullPointerException
proxy_1             | 	at org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter.format(OGCServiceMessageFormatter.java:98)
proxy_1             | 	at org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter.format(OGCServiceMessageFormatter.java:61)
proxy_1             | 	at org.georchestra.security.Proxy.handleRequest(Proxy.java:669)
proxy_1             | 	at org.georchestra.security.Proxy.handlePathEncodedRequests(Proxy.java:526)
proxy_1             | 	at org.georchestra.security.Proxy.handleGETRequest(Proxy.java:402)

``` 
