### PR TITLE
Add missing config.json files

### DIFF
--- a/mapfishapp/src/main/webapp/app/addons/fullscreen/config.json
+++ b/mapfishapp/src/main/webapp/app/addons/fullscreen/config.json
@@ -1,0 +1,20 @@
+[{
+    "id": "fullscreen_0",
+    "enabled": false,
+    "name": "Fullscreen",
+    "title": {
+        "en": "Fullscreen",
+        "es": "Pantalla Completa",
+        "fr": "Plein écran",
+        "de": "Vollbild"
+    },
+    "options": {
+        "toolbars": true
+    },
+    "description": {
+        "en": "Make the map go fullscreen",
+        "es": "Mostrar el mapa en pantalla completa",
+        "fr": "Voir la carte en plein écran",
+        "de": "Siehe Vollbildkarte"
+    }
+}]

--- a/mapfishapp/src/main/webapp/app/addons/locateme/config.json
+++ b/mapfishapp/src/main/webapp/app/addons/locateme/config.json
@@ -1,0 +1,20 @@
+[{
+    "id": "locateme_0",
+    "name": "LocateMe",
+    "enabled": false,
+    "options": {
+        "target": "bbar_7"
+    },
+    "title": {
+        "fr": "Localisez moi",
+        "en": "Locate me",
+        "es": "localizarme",
+        "de": "Wo bin ich ?"
+    },
+    "description": {
+        "fr": "Cet addon permet d'afficher votre position sur la carte",
+        "en": "This addon allows you to display your position on the map",
+        "es": "Esta herramienta le permite mostrar su posición en el mapa",
+        "de": "Dieses Addon ermöglicht Ihnen, Ihre Position auf der Karte angezeigt werden"
+    }
+}]

--- a/mapfishapp/src/main/webapp/app/addons/measure/config.json
+++ b/mapfishapp/src/main/webapp/app/addons/measure/config.json
@@ -1,0 +1,18 @@
+[{
+    "id": "measure_0",
+    "name": "Measure",
+    "enabled": false,
+    "options": {},
+    "title": {
+        "en": "Measurement tools",
+        "es": "Herramientas de medición",
+        "fr": "Outils de mesure",
+        "de": "Messwerkzeuge"
+    },
+    "description": {
+        "en": "Distance and area measuring tools",
+        "es": "Herramientas de medición de superficies y distancias",
+        "fr": "Outils de mesure de distances et de surfaces",
+        "de": "Werkzeuge zum Messen von Entfernungen und Flächen"
+    }
+}]


### PR DESCRIPTION
measure/config.json shamelessly stolen from https://github.com/GFI-Informatique/georchestra/blob/measurement/mapfishapp/src/main/webapp/app/addons/measure/config.json but defaulting to enabled: false. Fixes mfapp warnings/errors in datadir mode.

Since @pmauduit commited 9daa1827dd46e03339c96f73c0eeb68bce1cf4bf i'm a bit lost wrt addons/contexts configuration in non-datadir mode, is it still valid to use ADDONS and CONTEXTS in GEOR_custom.js or those should be dropped ? (i can do it in this PR). https://github.com/georchestra/georchestra/pull/1022 also got broken in datadir mode, we have to find a new way to configure it.

I'd also amend all the addons README.md because so far they only mention editing GEOR_custom.js, which wont work (at least for datadir mode)

Shouldnt we move addons to georchestra-datadir repo, since that's something end-users will often configure (okay, only the config.json files maybe) ? We'd lose history though..

I need to test if an addon works when its code/img/css is kept in the webapp but the config.json file is found in the datadir, if it overrides the one in the webapp.