### PR TITLE
Add runtime dependency on apache-log4j-extras (georchestra/georchestr…

### DIFF
--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -110,6 +110,13 @@
       <artifactId>json</artifactId>
       <version>20080701</version>
     </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>apache-log4j-extras</artifactId>
+      <version>1.1</version>
+      <type>jar</type>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>cas-${server}</finalName>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -14,6 +14,15 @@
     <packageName>georchestra-geoserver</packageName>
     <dockerImageName>georchestra/geoserver</dockerImageName>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>apache-log4j-extras</artifactId>
+      <version>1.1</version>
+      <type>jar</type>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
   <build>
     <finalName>geoserver-${server}</finalName>
     <plugins>


### PR DESCRIPTION
…a#1268)


Built-tested, apache-log4j-extras-1.1.jar is added in the webapp:
```
#find cas-server-webapp/target geoserver/webapp/target -name apache-log4j*
cas-server-webapp/target/cas-template/WEB-INF/lib/apache-log4j-extras-1.1.jar
geoserver/webapp/target/geoserver-template/WEB-INF/lib/apache-log4j-extras-1.1.jar
```