### PR TITLE
analytics - fixing logging

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -166,6 +166,11 @@
       <version>1.4</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.13</version>
+    </dependency>
+    <dependency>
       <groupId>org.georchestra</groupId>
       <artifactId>georchestra-commons</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
Adding slf4j-log4j12 as a direct dependency. slf4j is introduced via transitive dependency with spring-data-commons.

Should address #1279 (logging part).