### PR TITLE
[Mapfishapp] Add WMC's roles to datadir

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
@@ -79,6 +79,8 @@ public class ContextController implements ServletContextAware {
         // image
         // defaulting to default.png
         String image = "context/image/default.png";
+        // roles
+        JSONArray roles = new JSONArray();
 
         File imagePath = new File(pathCtx, "images");
         if (! imagePath.isDirectory()) {
@@ -92,6 +94,30 @@ public class ContextController implements ServletContextAware {
                 }
             }
         }
+        
+        File rolePath = new File(pathCtx);
+        Collection<File> files = FileUtils.listFiles(rolePath, new String[] { "XML", "xml" }, false);
+        for (File curRoleFile : files) {
+            if (FilenameUtils.getBaseName(curRoleFile.toString()).equalsIgnoreCase(title)) {
+                DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder builder = domFactory.newDocumentBuilder();
+                Document doc = builder.parse(curRoleFile);
+                XPath xpath = XPathFactory.newInstance().newXPath();
+                
+                // Parsing roles
+                XPathExpression xpRole = xpath.compile("//AllowedRoles/Role");
+                Object oRole = xpRole.evaluate(doc, XPathConstants.NODESET);
+                
+                if (oRole instanceof NodeList) {
+                    NodeList nl = (NodeList) oRole;
+                    for (int i = 0; i < nl.getLength(); ++i) {
+                        roles.put(nl.item(i).getTextContent());
+                    }
+                }
+                break;
+            }
+        }
+        
         // filename
         String wmcUrl = "context/" + f.getName();
 
@@ -103,6 +129,7 @@ public class ContextController implements ServletContextAware {
         info.put("wmc", wmcUrl);
         info.put("tip", xmlInfos.get("tip").equals("unset") ? title : xmlInfos.get("tip"));
         info.put("keywords", xmlInfos.getJSONArray("keywords").put(title));
+        info.put("roles", roles);
 
         return info;
     }

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
@@ -143,20 +143,16 @@ public class ContextController implements ServletContextAware {
     private JSONArray getRolesForContext(String pathContext, String title) {
         JSONArray roles = new JSONArray();
         File rolePath = new File(pathContext);
-        Collection<File> files = FileUtils.listFiles(rolePath, new String[] { "XML", "xml" }, false);
-        // TODO: instead of iterating on each XML files from the directory, it
-        // might be more relevant to consider using a file with the same
-        // basename as the WMC ?
-        for (File curRoleFile : files) {
-            if (FilenameUtils.getBaseName(curRoleFile.toString()).equalsIgnoreCase(title)) {
-                try {
-                    roles = parseRoleXmlFile(curRoleFile);
-                } catch (Exception e) {
-                    LOG.error("Error parsing role file: " + curRoleFile, e);
-                }
-                break;
+        File roleFile = new File(rolePath, title + ".xml");
+
+        try {
+            if (roleFile.exists()) {
+                roles = parseRoleXmlFile(roleFile);
             }
+        } catch (Exception e) {
+            LOG.error("Error parsing role file: " + roleFile, e);
         }
+
         return roles;
     }
 

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
@@ -29,7 +29,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/ContextControllerTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/ContextControllerTest.java
@@ -2,11 +2,13 @@ package org.georchestra.mapfishapp.ws;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeNotNull;
 
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.georchestra.commons.configuration.GeorchestraConfiguration;
@@ -42,6 +44,48 @@ public class ContextControllerTest {
         assertTrue("Unexpected keywords: does not contain \"OSM\"", jsRet.getJSONArray("keywords").toString().contains("OSM"));
         assertTrue("Unexpected keywords: does not contain \"Géobretagne\"", jsRet.getJSONArray("keywords").toString().contains("Géobretagne"));
 
+    }
+
+    @Test
+    public void testgetRolesForContext() throws NoSuchMethodException, SecurityException, URISyntaxException {
+        URL defaultCtxUrl = this.getClass().getResource("/default.wmc");
+        assumeNotNull(new Object[] {defaultCtxUrl});
+
+        ContextController ctxCtrl = new ContextController();
+        Method prvMethod = ctxCtrl.getClass().getDeclaredMethod("getRolesForContext", String.class, String.class);
+        prvMethod.setAccessible(true);
+
+        File resourceDir = new File(this.getClass().getResource("/").toURI());
+
+        Object ret = ReflectionUtils.invokeMethod(prvMethod, ctxCtrl, resourceDir.getPath(), "default");
+        assertTrue(((JSONArray) ret).length() == 2);
+        assertTrue(((JSONArray) ret).toString().contains("ROLE_ADMINISTRATOR"));
+    }
+
+    @Test
+    public void testParseRoleXmlFile() throws URISyntaxException, NoSuchMethodException, SecurityException {
+        URL u1 = this.getClass().getResource("roles/several_roles.xml");
+        URL u2 = this.getClass().getResource("roles/one_role.xml");
+        URL u3 = this.getClass().getResource("roles/empty_role.xml");
+        assumeNotNull(new Object[] { u1, u2, u3 });
+
+        File f1 = new File(u1.toURI());
+        File f2 = new File(u2.toURI());
+        File f3 = new File(u3.toURI());
+
+        ContextController ctxCtrl = new ContextController();
+        Method prvMethod = ctxCtrl.getClass().getDeclaredMethod("parseRoleXmlFile", File.class);
+        prvMethod.setAccessible(true);
+
+        Object ret = ReflectionUtils.invokeMethod(prvMethod, ctxCtrl, f1);
+        assertTrue(((JSONArray) ret).length() == 4);
+        assertTrue(((JSONArray) ret).toString().contains("ROLE_ADMINISTRATOR"));
+
+        ret = ReflectionUtils.invokeMethod(prvMethod, ctxCtrl, f2);
+        assertTrue(((JSONArray) ret).length() == 1);
+
+        ret = ReflectionUtils.invokeMethod(prvMethod, ctxCtrl, f3);
+        assertTrue(((JSONArray) ret).length() == 0);
     }
 
     @Test

--- a/mapfishapp/src/test/resources/default.xml
+++ b/mapfishapp/src/test/resources/default.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AllowedRoles>
+  <Role>ROLE_ADMINISTRATOR</Role>
+  <Role>ROLE_PERM_COMMUNES</Role>
+</AllowedRoles>

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/roles/empty_role.xml
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/roles/empty_role.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AllowedRoles/>

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/roles/one_role.xml
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/roles/one_role.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AllowedRoles>
+  <Role>ROLE_ADMINISTRATOR</Role>
+</AllowedRoles>

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/roles/several_roles.xml
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/roles/several_roles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AllowedRoles>
+  <Role>ROLE_ADMINISTRATOR</Role>
+  <Role>ROLE_SER_URBANISME</Role>
+  <Role>ROLE_SER_INGENIERIE</Role>
+  <Role>ROLE_PERM_COMMUNES</Role>
+</AllowedRoles>


### PR DESCRIPTION
As seen in this PR : https://github.com/georchestra/georchestra/pull/1022

The datadir config load CONTEXTS directly from wmc files, but those files haven't any field for ACL.

This patch load allowed roles from an XML file with the same name as the WMC one.

For example, for example.wmc the loaded XML will be example.xml and have to contain : 
```
<?xml version="1.0" encoding="UTF-8"?>
<AllowedRoles>
    <Role>ROLE_ADMINISTRATOR</Role>
    <Role>ROLE_SER_URBANISME</Role>
    <Role>ROLE_SER_INGENIERIE</Role>
    <Role>ROLE_PERM_COMMUNES</Role>
</AllowedRoles>
```

If the file doesn't exist, all roles will be enabled.

Maybe add this example XML file in the datadir README.md ?