### PR TITLE
docker - allow customization of image name

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -420,6 +420,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -428,7 +431,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -385,6 +385,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/cas</dockerImageName>
+      </properties>
       <build>
         <finalName>cas</finalName>
         <plugins>
@@ -393,7 +396,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/cas</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/catalogapp/pom.xml
+++ b/catalogapp/pom.xml
@@ -408,6 +408,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -416,7 +419,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/downloadform/pom.xml
+++ b/downloadform/pom.xml
@@ -326,6 +326,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -334,7 +337,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -617,6 +617,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -625,7 +628,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <gs.unpack.dir>${project.build.directory}/geoserver-unpacked-webapp</gs.unpack.dir>
     <packageName>georchestra-geoserver</packageName>
-    <dockerImageName>georchestra/geoserver</dockerImageName>
   </properties>
   <dependencies>
     <dependency>
@@ -984,6 +983,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/geoserver</dockerImageName>
+      </properties>
       <build>
         <finalName>geoserver</finalName>
         <plugins>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -371,6 +371,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/geowebcache</dockerImageName>
+      </properties>
       <build>
         <finalName>geowebcache</finalName>
         <plugins>
@@ -379,7 +382,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/geowebcache</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -320,6 +320,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>header</finalName>
         <plugins>
@@ -328,7 +331,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -749,6 +749,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -757,7 +760,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -591,6 +591,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>mapfishapp</finalName>
         <plugins>
@@ -599,7 +602,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -425,6 +425,9 @@
     </profile>
     <profile>
       <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
+      </properties>
       <build>
         <finalName>ROOT</finalName>
         <plugins>
@@ -433,7 +436,7 @@
             <artifactId>docker-maven-plugin</artifactId>
             <version>0.3.8</version>
             <configuration>
-              <imageName>georchestra/${project.artifactId}</imageName>
+              <imageName>${dockerImageName}</imageName>
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>


### PR DESCRIPTION
This commit introduces the possibility to fully customize the target docker image name generated by the docker-maven plugin. i.e. for each module you can now use the following command:

```
$ mvn clean package docker:build -Pdocker \
-DdockerImageName=myorg/analytics:\${project.parent.version\}-1 \
--pl analytics
```

This will generate a docker image named `myorg/analytics` and tagged with the current geOrchestra version suffixed by `-1`.

- tests: compilation time on the analytics module, reported the modification on each modules, but untested one by one.

- drawbacks: it needs to compile each module separately (because of certain modules needing to have an hardcoded image name, see cas or geoserver for instance.

- Note: Since this modification is kind of trivial, I took the opportunity to push it on the geonetwork submodule, hence the submodule bump in this commit.