### PR TITLE
SP - rewrite HttpClient object instanciations

### DIFF
--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.1</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
The use of deprecated classes was causing SNI for HTTPS to fail. Also includes a version bump of apache-HttpClient (which supports SNI).

Should address #1313 ;

@landryb : care to test it at runtime from your side ? since the code should be called very often when using the whole SDI, it would deserve more tests.

Tests:
- runtime OK
- testsuite OK

