### PR TITLE
Querier : Filters can be saved and loaded to/from XML files

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
@@ -84,46 +84,6 @@ public class DocController {
     @Autowired
     private ConnectionPool connectionPool;
 
-    public void init() throws IOException {
-        if (georchestraConfiguration.activated()) {
-            docTempDir = georchestraConfiguration.getProperty("docTempDir");
-
-            Properties userPasswordCreds = georchestraConfiguration.loadCustomPropertiesFile("credentials");
-            credentials.clear();
-            for (String key : userPasswordCreds.stringPropertyNames()) {
-                credentials.put(key, new UsernamePasswordCredentials(userPasswordCreds.getProperty(key)));
-            }
-        }
-    }
-
-    public String getDocTempDir() {
-        return docTempDir;
-    }
-
-	public void setDocTempDir(String docTempDir) {
-	    this.docTempDir = docTempDir;
-	}
-
-
-	// needed for tests
-	public void setConnectionPool(ConnectionPool cp) {
-	    connectionPool = cp;
-    }
-
-	private WFSDataStoreFactory factory = new WFSDataStoreFactory();
-	public void setWFSDataStoreFactory(WFSDataStoreFactory fac) { factory = fac; }
-
-	/**
-	 * mapping from hostname -> credentials
-	 */
-	private Map<String, UsernamePasswordCredentials> credentials = new HashMap<String, UsernamePasswordCredentials>();
-	public Map<String, UsernamePasswordCredentials> getCredentials() {
-	    return credentials;
-	}
-	public void setCredentials(Map<String, UsernamePasswordCredentials> credentials) {
-	    this.credentials = credentials;
-	}
-
     /**
      * variable name that has to be used on client side
      */
@@ -163,6 +123,47 @@ public class DocController {
      * Absolute (from domain name) URL path where the fe service can be called
      */
     public static final String FE_URL = DOC_URL + "fe/";
+
+
+    public void init() throws IOException {
+        if (georchestraConfiguration.activated()) {
+            docTempDir = georchestraConfiguration.getProperty("docTempDir");
+
+            Properties userPasswordCreds = georchestraConfiguration.loadCustomPropertiesFile("credentials");
+            credentials.clear();
+            for (String key : userPasswordCreds.stringPropertyNames()) {
+                credentials.put(key, new UsernamePasswordCredentials(userPasswordCreds.getProperty(key)));
+            }
+        }
+    }
+
+    public String getDocTempDir() {
+        return docTempDir;
+    }
+
+	public void setDocTempDir(String docTempDir) {
+	    this.docTempDir = docTempDir;
+	}
+
+
+	// needed for tests
+	public void setConnectionPool(ConnectionPool cp) {
+	    connectionPool = cp;
+    }
+
+	private WFSDataStoreFactory factory = new WFSDataStoreFactory();
+	public void setWFSDataStoreFactory(WFSDataStoreFactory fac) { factory = fac; }
+
+	/**
+	 * mapping from hostname -> credentials
+	 */
+	private Map<String, UsernamePasswordCredentials> credentials = new HashMap<String, UsernamePasswordCredentials>();
+	public Map<String, UsernamePasswordCredentials> getCredentials() {
+	    return credentials;
+	}
+	public void setCredentials(Map<String, UsernamePasswordCredentials> credentials) {
+	    this.credentials = credentials;
+	}
     
     /*=======================Services entry points==========================================================================*/
 

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
@@ -57,6 +57,7 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
  * - POST: ws/sld/ GET: ws/sld/{filename} <br />
  * - POST: ws/kml/ GET: ws/kml/{filename} <br />
  * - POST: ws/gml/ GET: ws/gml/{filename} <br />
+ * - POST: ws/fe/  GET: ws/fe/{filename}  <br />
  * <br />
  * File can be sent via POST or by upload (max one file at a time)
  * <br />
@@ -157,6 +158,11 @@ public class DocController {
      * Absolute (from domain name) URL path where the gml service can be called
      */
     public static final String GML_URL = DOC_URL + "gml/";
+
+    /**
+     * Absolute (from domain name) URL path where the fe service can be called
+     */
+    public static final String FE_URL = DOC_URL + "fe/";
     
     /*=======================Services entry points==========================================================================*/
 
@@ -222,6 +228,27 @@ public class DocController {
     @RequestMapping(value="/gml/*", method=RequestMethod.GET)
     public void getGMLFile(HttpServletRequest request, HttpServletResponse response) {
         getFile(new GMLDocService(this.docTempDir, this.connectionPool), request, response);
+    }
+
+    /*======================= FE ======================================================================*/
+    /**
+     * POST FE entry point. Store the body of the request POST (or file by upload) in a temporary file.
+     * @param request contains in its body the file in the JSON format
+     * @param response contains the url path to get back the file in CSV: FE_URL/{filename}
+     */
+    @RequestMapping(value="/fe/", method=RequestMethod.POST)
+    public void storeFEFile(HttpServletRequest request, HttpServletResponse response) {
+        storeFile(new FEDocService(this.docTempDir, this.connectionPool), FE_URL, request, response);
+    }
+
+    /**
+     * GET FE entry point. Retrieve the right file previously stored corresponding to the REST argument.
+     * @param request no parameter. The parameter has to be provided REST style: FE_URL/{filename}
+     * @param response contains the file content
+     */
+    @RequestMapping(value="/fe/*", method=RequestMethod.GET)
+    public void getFEFile(HttpServletRequest request, HttpServletResponse response) {
+        getFile(new FEDocService(this.docTempDir, this.connectionPool), request, response);
     }
 
     /*======================= JSON to CSV =====================================================================*/

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/FEDocService.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/FEDocService.java
@@ -44,7 +44,7 @@ public class FEDocService extends A_DocService {
      */
     @Override
     protected void preSave() throws DocServiceException {
-
+        //We do not perform any action before saving the file.
     }
 
     /**
@@ -53,7 +53,7 @@ public class FEDocService extends A_DocService {
      */
     @Override
     protected void postLoad() throws DocServiceException {
-
+        //We do not perform any action on file once loaded in memory.
     }
 
 }

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/FEDocService.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/FEDocService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2009-2016 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.mapfishapp.ws;
+
+import org.georchestra.mapfishapp.model.ConnectionPool;
+
+/**
+ * This service handles the storage and the loading of a Filter Encoding file
+ *
+ * @author yoann buch  - yoann.buch@gmail.com
+ * @author jean-denis giguère - jdenisgiguere@gmail.com
+ *
+ */
+
+public class FEDocService extends A_DocService {
+
+    public static final String FILE_EXTENSION = ".xml";
+    public static final String MIME_TYPE = "application/xml";
+
+    public FEDocService(final String tempDir, ConnectionPool pgpool) {
+        super(FILE_EXTENSION, MIME_TYPE, tempDir, pgpool);
+    }
+
+    /**
+     * Called before saving the content
+     * @throws DocServiceException
+     */
+    @Override
+    protected void preSave() throws DocServiceException {
+
+    }
+
+    /**
+     * Called right after the loading of the file content
+     * @throws DocServiceException
+     */
+    @Override
+    protected void postLoad() throws DocServiceException {
+
+    }
+
+}

--- a/mapfishapp/src/main/webapp/app/js/GEOR.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR.js
@@ -401,7 +401,7 @@ Ext.namespace("GEOR");
             GEOR.querier.events.on({
                 "ready": function(panelCfg) {
 
-                    win = new Ext.Window({
+                    var win = new Ext.Window({
                         title: GEOR.util.shorten(panelCfg.title, 70),
                         layout: "fit",
                         width: 650,

--- a/mapfishapp/src/main/webapp/app/js/GEOR.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR.js
@@ -400,7 +400,29 @@ Ext.namespace("GEOR");
             var querierTitle;
             GEOR.querier.events.on({
                 "ready": function(panelCfg) {
+
+                    win = new Ext.Window({
+                        title: GEOR.util.shorten(panelCfg.title, 70),
+                        layout: "fit",
+                        width: 650,
+                        height: 400,
+                        closeAction: 'close',
+                        constrainHeader: true,
+                        modal: false,
+                        items: Ext.apply(panelCfg, {
+                            title: null,
+                            buttons: panelCfg.buttons.concat([{
+                                text: tr("Close"),
+                                handler: function() {
+                                    win.close();
+                                }
+                            }]).reverse()
+                        })
+                    });
+                    win.show();
+
                     // clear the previous filterbuilder panel, if exists
+                    /*
                     if (eastItems[0].getComponent(1)) {
                         eastItems[0].remove(eastItems[0].getComponent(1));
                     }
@@ -424,7 +446,8 @@ Ext.namespace("GEOR");
                     eastItems[0].getLayout().setActiveItem(1);
                     eastItems[0].getComponent(1).setUp();
                     eastItems[0].doLayout(); // required
-                },
+                    */
+                },/*
                 "showrequest": function() {
                     // at this stage, there is no garantee that 2nd cmp exists
                     if (eastItems[0].getComponent(1)) {
@@ -433,7 +456,7 @@ Ext.namespace("GEOR");
                         eastItems[0].getComponent(1).setUp();
                         eastItems[0].doLayout(); // required
                     }
-                },
+                },*/
                 "search": function(panelCfg) {
                     var tab = southPanel.getActiveTab();
                     if (tab) {

--- a/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
@@ -759,12 +759,14 @@ GEOR.managelayers = (function() {
                 text: tr("Build a query"),
                 listeners: {
                     "click": function(btn, pressed) {
+                        /*
                         if (layerRecord == querierRecord) {
                             // FIXME (later) : this is not how it should be.
                             // (only the module should fire its own events)
                             GEOR.querier.events.fireEvent("showrequest");
                             return;
                         }
+                        */
                         var layer = layerRecord.get('layer'), data;
                         var name = layerRecord.get('title') || layer.name || '';
                         var recordType = GeoExt.data.LayerRecord.create([

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -254,6 +254,7 @@ GEOR.querier = (function() {
                 }
             },
             toolbarType: 'tbar',
+            allowSaveFilter: true,
             bufferSupport: true,
             allowGroups: false,
             noConditionOnInit: true,

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -253,7 +253,6 @@ GEOR.querier = (function() {
                     tpl: GEOR.util.getAttributesComboTpl()
                 }
             },
-            toolbarType: 'tbar',
             allowSaveFilter: true,
             toolbarType: "tbar",
             allowGroups: false,

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -253,6 +253,7 @@ GEOR.querier = (function() {
                     tpl: GEOR.util.getAttributesComboTpl()
                 }
             },
+            toolbarType: 'tbar',
             allowGroups: false,
             noConditionOnInit: true,
             deactivable: true,

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -255,7 +255,7 @@ GEOR.querier = (function() {
             },
             toolbarType: 'tbar',
             allowSaveFilter: true,
-            bufferSupport: true,
+            toolbarType: "tbar",
             allowGroups: false,
             noConditionOnInit: true,
             deactivable: true,

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -70,7 +70,7 @@ GEOR.querier = (function() {
          * Fires when the filterbuilder panel is already built 
          * and we just need to display it.
          */
-        "showrequest",
+        //"showrequest",
         /**
          * Event: searchresults
          * Fires when we've received a response from server 

--- a/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_querier.js
@@ -254,6 +254,7 @@ GEOR.querier = (function() {
                 }
             },
             toolbarType: 'tbar',
+            bufferSupport: true,
             allowGroups: false,
             noConditionOnInit: true,
             deactivable: true,


### PR DESCRIPTION
We can save or load filters to/from XML files. Buttons are added to the filter builder toolbar to make this available.
See https://github.com/georchestra/styler/pull/12 for change on the Styler library side.

This pull request contains a new Doc Service for OGC Filter Encoding. The `allowSaveFilter` property is set in the querier object. The reference to the styler submodule is updated.

