### PR TITLE
Fix permissions on /tmp dir of geoserver docker image

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1056,7 +1056,7 @@
                   <include>geoserver/**</include>
                 </resource>
                 <resource>
-                  <targetPath>/tmp/geoserver_minimal_datadir/</targetPath>
+                  <targetPath>/var/local/geoserver.orig/</targetPath>
                   <directory>${project.build.directory}/geoserver_minimal_datadir/</directory>
                 </resource>
               </resources>

--- a/geoserver/webapp/src/docker/docker-entrypoint.d/00-geoserver-bootstrap
+++ b/geoserver/webapp/src/docker/docker-entrypoint.d/00-geoserver-bootstrap
@@ -5,7 +5,7 @@ then
     echo 'Datadir already initialized'
 else
     echo 'Initializing datadir from georchestra/geoserver_minimal_datadir'
-    cp -Rax /tmp/geoserver_minimal_datadir/* /var/local/geoserver
-    cp -Rax /tmp/geoserver_minimal_datadir/.git /var/local/geoserver
-    cp -Rax /tmp/geoserver_minimal_datadir/.gitignore /var/local/geoserver
+    cp -Rax /var/local/geoserver.orig/* /var/local/geoserver
+    cp -Rax /var/local/geoserver.orig/.git /var/local/geoserver
+    cp -Rax /var/local/geoserver.orig/.gitignore /var/local/geoserver
 fi


### PR DESCRIPTION
This PR moves geoserver minimal datadir from /tmp to /var/local/geoserver.orig. This avoids permission modification on /tmp directory by maven when copying ressources. 
