### PR TITLE
build doc - build geonetwork first

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -79,14 +79,25 @@ data (using a batch insert for instance).
 
 ## Build the modules
 
-Building your SDI is just a command-line away:
+Building your SDI is just few command-lines away.
 ```
 cd ~/georchestra
 export MAVEN_OPTS="-XX:MaxPermSize=512M"
-./mvn -Dmaven.test.skip=true -Dserver=myprofile clean install
 ```
 
-Note: this will build **all modules** (except GeoFence).
+Build Geonetwork
+```
+cd geonetwork
+./mvn -DskipTests clean install
+cd ..
+```
+
+Build **all modules** (except GeoFence).
+```
+./mvn -Dmaven.test.skip=true-Dserver=myprofile clean install
+```
+
+
 In case you only want to build one module or a collection, the syntax is a bit different:
 ```
 ./mvn -Dmaven.test.skip=true -Dserver=myprofile -P-all,module1,module2 clean install

--- a/doc/build.md
+++ b/doc/build.md
@@ -88,13 +88,13 @@ export MAVEN_OPTS="-XX:MaxPermSize=512M"
 Build Geonetwork
 ```
 cd geonetwork
-./mvn -DskipTests clean install
+../mvn -DskipTests clean install
 cd ..
 ```
 
 Build **all modules** (except GeoFence).
 ```
-./mvn -Dmaven.test.skip=true-Dserver=myprofile clean install
+./mvn -Dmaven.test.skip=true -Dserver=myprofile clean install
 ```
 
 


### PR DESCRIPTION
When compiling geOrchestra for the first time, Geonetwork must be build first.