### PR TITLE
mapfishapp: restore ability to choose which context is shown by default

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_config.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_config.js
@@ -48,18 +48,6 @@ GEOR.config = (function() {
         HEADER_HEIGHT: getCustomParameter("HEADER_HEIGHT", 90),
 
         /**
-         * Constant: DEFAULT_WMC
-         * The relative path to the default context.
-         *
-         * Must be one of those, either copied to the datadir
-         * or contained in the webapp.
-         *
-         * Defaults to the first one got by mapfishapp's ContextController.java,
-         * probably something like "context/default.wmc"
-         */
-        DEFAULT_WMC: getCustomParameter("DEFAULT_WMC", GEOR.config.CONTEXTS[0]["wmc"]),
-
-        /**
          * Constant: ANONYMOUS
          * Whether a user is logged in or not: can be overriden
          * dynamically in index.jsp

--- a/mapfishapp/src/main/webapp/app/js/GEOR_config.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_config.js
@@ -48,20 +48,16 @@ GEOR.config = (function() {
         HEADER_HEIGHT: getCustomParameter("HEADER_HEIGHT", 90),
 
         /**
-         * Method: DEFAULT_WMC
-         * runtime method to get the current default WMC
+         * Constant: DEFAULT_WMC
+         * The relative path to the default context.
+         *
+         * Must be one of those, either copied to the datadir
+         * or contained in the webapp.
+         *
+         * Defaults to the first one got by mapfishapp's ContextController.java,
+         * probably something like "context/default.wmc"
          */
-        DEFAULT_WMC: function() {
-            if (GEOR.config.CONTEXTS &&
-                GEOR.config.CONTEXTS[0] &&
-                GEOR.config.CONTEXTS[0]["wmc"]) {
-                return GEOR.config.CONTEXTS[0]["wmc"];
-            }
-            alert("Administrator: "+
-                "GEOR.config.CONTEXTS is not configured as expected !");
-            // should not happen:
-            return "default.wmc";
-        },
+        DEFAULT_WMC: getCustomParameter("DEFAULT_WMC", GEOR.config.CONTEXTS[0]["wmc"]),
 
         /**
          * Constant: ANONYMOUS

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -451,7 +451,7 @@ GEOR.mapinit = (function() {
             // and finally we're running our global success callback:
             cb.call();
         } else {
-            updateStoreFromWMC(GEOR.config.DEFAULT_WMC());
+            updateStoreFromWMC(GEOR.config.DEFAULT_WMC);
         }
     };
 
@@ -589,7 +589,7 @@ GEOR.mapinit = (function() {
                 // this is so that the map object and fake base layer are
                 // properly configured when adding the other layers
                 // to the map
-                updateStoreFromWMC(GEOR.config.DEFAULT_WMC(), {
+                updateStoreFromWMC(GEOR.config.DEFAULT_WMC, {
                     success: function() {
                         loadLayers(initState);
                     }

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -524,6 +524,16 @@ GEOR.mapinit = (function() {
             layerStore = ls;
             tr = OpenLayers.i18n;
             cb = callback || OpenLayers.Util.Void;
+
+            // the default WMC is either the one provided by the admin in GEOR.custom,
+            // or the first one publicized by mapfishapp's ContextController.java 
+            // in GEOR.config.CONTEXTS
+            GEOR.config.DEFAULT_WMC = GEOR.custom.DEFAULT_WMC ||
+                // first context publicized by ContextController:
+                (GEOR.config.CONTEXTS[0] && GEOR.config.CONTEXTS[0]["wmc"]) ||
+                // this last one should not happen
+                "context/default.wmc";
+
             var url;
             // POSTing a content to the app (which results in GEOR.initstate
             // being set) has priority over everything else:


### PR DESCRIPTION
Mapfishapp's `ContextController.java` writes `GEOR.config.CONTEXTS` in the home page, providing input to the `GEOR.mapinit` module, which currently loads the first context, provided the browser's LocalStorage has not been initialized yet (which happens for first time users).

As a result, the platform admin has no way to choose which context is displayed by default on first visit.

This PR aims to address this regression, by providing a `DEFAULT_WMC` config option in the `GEOR_custom.js` file.

If `GEOR.custom.DEFAULT_WMC` is not set, the first context provided by `GEOR.config.CONTEXTS` is loaded.