### PR TITLE
SP - re-introducing default target

### DIFF
--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -17,8 +17,8 @@
 
           <property name="checkHealth" value="${checkHealth}"/>
           <property name="maxDatabaseConnections" value="${max.database.connections}"/>
+          <property name="defaultTarget" value="${defaultTarget:/header/}" />
           <property name="database" value="${psql.db}"/>
-
           <property name="host" value="${psql.host}"/>
           <property name="port" value="${psql.port}"/>
           <property name="user" value="${psql.user}"/>

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -21,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.google.common.collect.Maps;
 
@@ -61,6 +63,8 @@ public class ProxyTest {
         targets.put("geonetwork", "http://www.google.com/geonetwork-private");
         targets.put("extractorapp", "http://localhost/extractorapp-private");
         proxy.setTargets(targets);
+
+        proxy.setDefaultTarget("/mapfishapp/");
 
     }
 
@@ -112,6 +116,15 @@ public class ProxyTest {
         request = new MockHttpServletRequest("GET", "/unmapped/x");
         proxy.handleGETRequest(request, httpResponse);
         assertFalse(executed);
+    }
+
+    @Test
+    public void testDefaultTarget() throws Exception {
+        request = new MockHttpServletRequest("GET", "http://localhost:8080/");
+        proxy.handleRequest(request, httpResponse);
+
+        assertTrue(httpResponse.getRedirectedUrl().equals("/mapfishapp/"));
+
     }
 
     @Test


### PR DESCRIPTION
Once upon a time (relying on the source code), there was a parameter
"default target" in the SP which allowed to redirect onto a default
servlet container.

Since the defaultTarget in the properties file as well as in the
proxy-servlet.xml somehow disappeared, I think that this parameter is
not used anymore.

This commit proposes to reintroduce it, but modifying slightly its
original purpose: By defining a defaultTarget in your
security-proxy.properties, you can select a default redirection path. By
default, when hitting the SP at its root, eg:

GET http://georchestra.mydomain.org/

will not return a 404 by default anymore, but send a 302 found
(temporary redirect) onto /header/

but defining defaultTarget=/portail/ in your sp.properties file would
redirect by default to http://georchestra.mydomain.org/portail/.

Tests:
- Added a utest but would deserve some integration tests.
- Testsuite OK
- runtime tests OK