### PR TITLE
header - force default encoding of jsp to utf-8

### DIFF
--- a/header/src/main/webapp/WEB-INF/web.xml
+++ b/header/src/main/webapp/WEB-INF/web.xml
@@ -40,5 +40,11 @@ http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
         <servlet-name>ws</servlet-name>
         <url-pattern>/ws/*</url-pattern>
     </servlet-mapping>
- 
+
+    <jsp-config>
+      <jsp-property-group>
+        <url-pattern>*.jsp</url-pattern>
+        <page-encoding>UTF-8</page-encoding>
+      </jsp-property-group>
+    </jsp-config>
 </web-app>


### PR DESCRIPTION
if not specified, under certain circumstances, jsp are sent as encoded in iso-8859-1, but everything in geOrchestra should be considered as utf-8.

Tests: maven jetty plugin: OK
Testsuite: OK (but unrelated to the current modification)

