### PR TITLE
Removes dev.mapfish.org maven repository

### DIFF
--- a/epsg-extension/pom.xml
+++ b/epsg-extension/pom.xml
@@ -31,15 +31,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<repositories>
-		<repository>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>mapfish</id>
-			<url>http://dev.mapfish.org/maven/repository</url>
-		</repository>
-	</repositories>
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -373,14 +373,6 @@
       <id>georchestra</id>
       <url>http://sdi.georchestra.org/maven/repository</url>
     </repository>
-    <repository>
-      <snapshots>
-        <enabled>true</enabled>
-        <checksumPolicy>ignore</checksumPolicy>
-      </snapshots>
-      <id>mapfish</id>
-      <url>http://dev.mapfish.org/maven/repository</url>
-    </repository>
     <!-- geotools -->
     <repository>
       <snapshots>
@@ -423,14 +415,6 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <snapshots>
-        <enabled>true</enabled>
-        <checksumPolicy>ignore</checksumPolicy>
-      </snapshots>
-      <id>mapfish</id>
-      <url>http://dev.mapfish.org/maven/repository</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
the dev.m.o server has been shut down recently, no need to keep the reference in the pom.xml files. In addition, we should rely on build.g.o for the dependencies.

Tests: Only tested that the pom.xml are still valid and launching a mvn clean install does launch the maven process. It will probably be too hard to track every missing dependencies.

Note: need to be cascade-merged until reaching master.