### PR TITLE
Limit memory usage of webapps with XMX environement variable

### DIFF
--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx512m","-jar","/usr/local/jetty/start.jar"]
 

--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx512m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
 

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,11 +51,15 @@ geoserver:
   links:
     - database
     - ldap
+  environment:
+    - XMX=2g
 
 geowebcache:
   image: georchestra/geowebcache:latest
   volumes:
     - geowebcache_tiles:/var/local/tiles
+  environment:
+    - XMX=1g
 
 proxy:
   image: georchestra/security-proxy:latest
@@ -74,11 +78,15 @@ proxy:
     - analytics
     - catalogapp
     - downloadform
+  environment:
+    - XMX=1g
 
 cas:
   image: georchestra/cas:latest
   links:
     - ldap
+  environment:
+    - XMX=1g
 
 mapfishapp:
   image: georchestra/mapfishapp:latest
@@ -88,6 +96,8 @@ mapfishapp:
     - database
   volumes:
     - mapfishapp_uploads:/var/local/uploads
+  environment:
+    - XMX=1g
 
 extractorapp:
   image: georchestra/extractorapp:latest
@@ -98,10 +108,13 @@ extractorapp:
     - smtp
   volumes:
     - extractorapp_extracts:/var/local/extracts
-
+  environment:
+    - XMX=1g
 
 header:
   image: georchestra/header:latest
+  environment:
+    - XMX=512m
 
 ldapadmin:
   image: georchestra/ldapadmin:latest
@@ -109,6 +122,8 @@ ldapadmin:
     - database
     - ldap
     - smtp
+  environment:
+    - XMX=1g
 
 geonetwork:
   image: georchestra/geonetwork:3-latest
@@ -119,11 +134,15 @@ geonetwork:
     - ldap
   volumes:
     - geonetwork_datadir:/var/local/geonetwork
+  environment:
+    - XMX=2g
 
 analytics:
   image: georchestra/analytics:latest
   links:
     - database
+  environment:
+    - XMX=512m
 
 catalogapp:
   image: georchestra/catalogapp:latest

--- a/downloadform/src/docker/Dockerfile
+++ b/downloadform/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx512m","-jar","/usr/local/jetty/start.jar"]
 

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -13,5 +13,5 @@ RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 VOLUME [ "/var/local/extracts" ]
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra", "-Dextractor.storage.dir=/var/local/extracts", "-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra", "-Dextractor.storage.dir=/var/local/extracts","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
 

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -12,6 +12,5 @@ RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
 VOLUME [ "/var/local/extracts" ]
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra", "-Dextractor.storage.dir=/var/local/extracts","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Dextractor.storage.dir=/var/local/extracts -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -18,5 +18,5 @@ VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles" ]
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD [ "java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra",                     \
       "-DGEOSERVER_DATA_DIR=/var/local/geoserver", "-Dgeofence.dir=/etc/georchestra/geoserver/geofence", \
-      "-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles", "-jar","/usr/local/jetty/start.jar" ]
+      "-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles", "-Xmx2048m", "-jar","/usr/local/jetty/start.jar" ]
 

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -15,8 +15,10 @@ ADD . /
 
 VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles" ]
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD [ "java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra",                     \
-      "-DGEOSERVER_DATA_DIR=/var/local/geoserver", "-Dgeofence.dir=/etc/georchestra/geoserver/geofence", \
-      "-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles", "-Xmx2048m", "-jar","/usr/local/jetty/start.jar" ]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra \
+-DGEOSERVER_DATA_DIR=/var/local/geoserver \
+-Dgeofence.dir=/etc/georchestra/geoserver/geofence \
+-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles \
+-Xmx$XMX -Xms$XMX \
+-jar /usr/local/jetty/start.jar" ]
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -9,5 +9,5 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 CMD [ "java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra",         \
-      "-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles", "-jar","/usr/local/jetty/start.jar" ]
+      "-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles","-Xmx1024m","-jar","/usr/local/jetty/start.jar" ]
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -6,8 +6,6 @@ VOLUME [ "/var/local/tiles" ]
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
-
-CMD [ "java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra",         \
-      "-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles","-Xmx1024m","-jar","/usr/local/jetty/start.jar" ]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra \
+-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx512m","-jar","/usr/local/jetty/start.jar"]
 

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx512m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
 

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -14,5 +14,5 @@ RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 VOLUME [ "/var/local/uploads" ]
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
 

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -10,9 +10,7 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-
 VOLUME [ "/var/local/uploads" ]
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
 

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -4,5 +4,5 @@ ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx1024m","-jar","/usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
 


### PR DESCRIPTION
* `sh -c` is used to replace environment variable
* `exec` is used to keep PID 1 on java process
