### PR TITLE
SP - redirect every word to word/

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -44,8 +44,11 @@
         <to type="forward" last="true">/$1</to>
     </rule>
     <rule>
+        <from>^/([a-zA-Z0-9]+)$</from>
+        <to type="redirect" last="true">/$1/</to>
+    </rule>
+    <rule>
         <from>^/(?!sec/|favicon.ico|receptor|j_spring_security_logout|j_spring_cas_security_check|header.jsp|_static/|cas-logout.jsp|403.jsp|404.jsp|casfailed.jsp)(.*)$</from>
         <to type="forward" last="true">/sec/$1</to>
     </rule>
-
 </urlrewrite>


### PR DESCRIPTION
This was previously done by the frontend webserver configuration. The idea behind this commit is to allow the redirection of "words" to "words/", eg

- http://security-proxy/geonetwork -> /geonetwork/
- ...

Using the "^/[A-Za-z0-9]$" regex pattern should avoid side-effects / regressions.

Tests: runtime tested.