### PR TITLE
SP - redirect every webapps to webapps/

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -44,8 +44,11 @@
         <to type="forward" last="true">/$1</to>
     </rule>
     <rule>
+      <from>^/(cas|analytics|catalogapp|downloadform|extractorapp|geonetwork|geoserver|geofence|geowebcache|header|ldapadmin|mapfishapp)$</from>
+      <to type="redirect" last="true">/$1/</to>
+    </rule>
+    <rule>
         <from>^/(?!sec/|favicon.ico|receptor|j_spring_security_logout|j_spring_cas_security_check|header.jsp|_static/|cas-logout.jsp|403.jsp|404.jsp|casfailed.jsp)(.*)$</from>
         <to type="forward" last="true">/sec/$1</to>
     </rule>
-
 </urlrewrite>


### PR DESCRIPTION
This was previously done by the frontend webserver configuration. But in some configurations (docker) there is no need to introduce an extra frontend webserver. This assures that the webapps have the trailing / on the path, sending a redirect to the client, e.g.:

- http://security-proxy/geonetwork -> /geonetwork/
- /geoserver -> /geoserver/
- ...

Following the comments on the PR, there is no need to adapt the documentation because it is still required that Apache (if there is a one) adds it if it intercepts the query before sending it to the SP.

Tests: runtime.