### PR TITLE
GS - force TLSv1.1 on Java7

### DIFF
--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -19,6 +19,7 @@ CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/e
 -DGEOSERVER_DATA_DIR=/var/local/geoserver \
 -Dgeofence.dir=/etc/georchestra/geoserver/geofence \
 -DGEOWEBCACHE_CACHE_DIR=/var/local/tiles \
+-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 \
 -Xmx$XMX -Xms$XMX \
 -jar /usr/local/jetty/start.jar" ]
 


### PR DESCRIPTION
This won't resolve every SSL-related issues, but at least should force tlsv1.1 on HTTPS connections.

Tested onto a custom Java class which opens an Https connection onto dev.cigalsace.org:

```
$ java -Dhttps.protocols=TLSv1.1,TLSv1.2  HttpsClient https://dev.cigalsace.org/
Response Code : 302

$ java  HttpsClient https://dev.cigalsace.org/
javax.net.ssl.SSLHandshakeException: Remote host closed connection during handshake
```