### PR TITLE
Atlas improvements

### DIFF
--- a/atlas/src/main/java/org/georchestra/atlas/AtlasMailComponent.java
+++ b/atlas/src/main/java/org/georchestra/atlas/AtlasMailComponent.java
@@ -37,6 +37,9 @@ public class AtlasMailComponent {
 
     public void init() {
         Properties vProp = new Properties();
+        vProp.put("runtime.log.logsystem.class", "org.apache.velocity.runtime.log.NullLogChute");
+        vProp.put("runtime.log.logsystem.log4j.category", "velocity");
+        vProp.put("runtime.log.logsystem.log4j.logger", "velocity");
         if ((georConfiguration != null) && (georConfiguration.activated())) {
             vProp.setProperty("resource.loader", "file");
             vProp.setProperty("file.resource.loader.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");

--- a/atlas/src/test/java/org/georchestra/atlas/CamelMapfishPrintComponentTest.java
+++ b/atlas/src/test/java/org/georchestra/atlas/CamelMapfishPrintComponentTest.java
@@ -1,0 +1,33 @@
+package org.georchestra.atlas;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.pdf.PdfReader;
+import com.itextpdf.text.pdf.parser.PdfReaderContentParser;
+import com.itextpdf.text.pdf.parser.SimpleTextExtractionStrategy;
+import com.itextpdf.text.pdf.parser.TextExtractionStrategy;
+
+public class CamelMapfishPrintComponentTest {
+
+    @Test
+    public void generateErrorPdftest() throws DocumentException, IOException {
+        CamelMapfishPrintComponent comp = new CamelMapfishPrintComponent();
+        Throwable e = new RuntimeException("something is messed up");
+
+        ByteArrayOutputStream out = comp.generateErrorPdf(e);
+
+        // re-read pdf
+        PdfReader reader = new PdfReader(out.toByteArray());
+        PdfReaderContentParser p = new PdfReaderContentParser(reader);
+        TextExtractionStrategy strategy = p.processContent(1,
+                new SimpleTextExtractionStrategy());
+        assertTrue("Missing exception in the generated PDF",
+                strategy.getResultantText().contains("something is messed up"));
+    }
+}


### PR DESCRIPTION
- fixing error appearing at runtime on rennes-metropole with velocity (mail template) configuration:

```
Caused by: org.apache.velocity.exception.VelocityException: Error initializing log: Failed to initialize an instance of org.apache.velocity.runtime.log.Log4JLogChute with the current runtime configuration.
	at org.apache.velocity.runtime.RuntimeInstance.initializeLog(RuntimeInstance.java:875)
	at org.apache.velocity.runtime.RuntimeInstance.init(RuntimeInstance.java:262)

```

- Better MFPrintv3 error handling
