### PR TITLE
ldapadmin - excluding node_modules from war

### DIFF
--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -408,6 +408,13 @@
     <finalName>${project.artifactId}-${server}</finalName>
     <plugins>
       <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <packagingExcludes>console/node_modules/**</packagingExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
Fixes #1436, ldapadmin.war 109MB -> 30MB