### PR TITLE
crypt instead of wtw.aC5paV.qU

### DIFF
--- a/docker/ssh_data/Dockerfile
+++ b/docker/ssh_data/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 # add a user 'geoserver' with default password : 'geoserver'
 # that can be overriden by environement variable $USER_PASS
 RUN groupadd --gid 999 geoserver
-RUN useradd -ms /bin/bash --home /home/geoserver -p $(perl -e'print crypt("geoserver", "salt")') --uid 999 --gid 999 geoserver
+RUN useradd -ms /bin/bash --home /home/geoserver -p $(perl -e'print crypt("${USER_PASS:-geoserver}", "salt")') --uid 999 --gid 999 geoserver
 
 RUN mkdir /home/geoserver/data
 RUN chown -R 999:999 /home/geoserver/data

--- a/docker/ssh_data/Dockerfile
+++ b/docker/ssh_data/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 # add a user 'geoserver' with default password : 'geoserver'
 # that can be overriden by environement variable $USER_PASS
 RUN groupadd --gid 999 geoserver
-RUN useradd -ms /bin/bash --home /home/geoserver -p $(perl -e'print crypt("${USER_PASS:-geoserver}", "salt")') --uid 999 --gid 999 geoserver
+RUN useradd -ms /bin/bash --home /home/geoserver -p $(echo "print crypt("${USER_PASS:-geoserver}", "salt")" | perl) --uid 999 --gid 999 geoserver
 
 RUN mkdir /home/geoserver/data
 RUN chown -R 999:999 /home/geoserver/data

--- a/docker/ssh_data/Dockerfile
+++ b/docker/ssh_data/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 # add a user 'geoserver' with default password : 'geoserver'
 # that can be overriden by environement variable $USER_PASS
 RUN groupadd --gid 999 geoserver
-RUN useradd -ms /bin/bash --home /home/geoserver -p wtw.aC5paV.qU --uid 999 --gid 999 geoserver
+RUN useradd -ms /bin/bash --home /home/geoserver -p $(perl -e'print crypt("geoserver", "salt")') --uid 999 --gid 999 geoserver
 
 RUN mkdir /home/geoserver/data
 RUN chown -R 999:999 /home/geoserver/data


### PR DESCRIPTION
utilisation de la commande perl crypt pour générer le mot de passe chiffré de geoserver.
