### PR TITLE
Create 'admin_emails' table before before loading test data

### DIFF
--- a/postgresql/05-ldapadmin-data.sql
+++ b/postgresql/05-ldapadmin-data.sql
@@ -21,6 +21,16 @@ CREATE TABLE email_template (
   CONSTRAINT email_template_pkey PRIMARY KEY (id)
 );
 
+CREATE TABLE ldapadmin.admin_emails (
+  id bigserial,
+  body character varying(255),
+  date timestamp without time zone,
+  recipient character varying(255),
+  sender character varying(255),
+  subject character varying(255),
+  CONSTRAINT admin_emails_pkey PRIMARY KEY (id)
+);
+
 INSERT INTO email_template (content, name) VALUES ('Bonjour et bienvenue', 'Hello');
 INSERT INTO email_template (content, name) VALUES ('Votre compte a été supprimé', 'Deleted');
 


### PR DESCRIPTION
`admin_emails` table is created by webapp at runtime but if we want test data in this table. We need to create it on an empty database.