### PR TITLE
Extractor - Allow dash character in WCS store name

### DIFF
--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WcsExtractor.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WcsExtractor.java
@@ -99,7 +99,7 @@ public class WcsExtractor {
             queriedLayer = tmpLayer[tmpLayer.length - 1];
         }
 
-        Pattern regex = Pattern.compile("(?m)<Layer[^>]*>(\\\\n|\\s)*<Name>\\s*(\\w*:)?" + Pattern.quote(queriedLayer) + "\\s*</Name>");
+        Pattern regex = Pattern.compile("(?m)<Layer[^>]*>(\\\\n|\\s)*<Name>\\s*([\\w_0-9-]*:)?" + Pattern.quote(queriedLayer) + "\\s*</Name>");
         return regex.matcher(getCapabilitiesDocument).find();
 	}
 


### PR DESCRIPTION
Fix regexp used to find layer in GetCapabilities document. Allow number, dash and underscore characters in store name