### PR TITLE
ldap: Change REFINT to true

### DIFF
--- a/ldap/docker/memberof.ldif
+++ b/ldap/docker/memberof.ldif
@@ -10,7 +10,7 @@ objectClass: olcConfig
 objectClass: top
 olcOverlay: memberof
 olcMemberOfDangling: ignore
-olcMemberOfRefInt: FALSE
+olcMemberOfRefInt: TRUE
 olcMemberOfGroupOC: groupOfMembers
 olcMemberOfMemberAD: member
 olcMemberOfMemberOfAD: memberOf

--- a/ldap/memberof.ldif
+++ b/ldap/memberof.ldif
@@ -11,7 +11,7 @@ objectClass: olcConfig
 objectClass: top
 olcOverlay: memberof
 olcMemberOfDangling: ignore
-olcMemberOfRefInt: FALSE
+olcMemberOfRefInt: TRUE
 olcMemberOfGroupOC: groupOfMembers
 olcMemberOfMemberAD: member
 olcMemberOfMemberOfAD: memberOf


### PR DESCRIPTION
Enable integrity check between member and memberOf values. Without this
parameter member and memberOf values are out of sync after some
modifications.