### PR TITLE
security-proxy - Set default value for http client timeout

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -169,7 +169,7 @@ public class Proxy {
     private String user;
     private String password;
     private Integer maxDatabaseConnections;
-    private Integer httpClientTimeout;
+    private Integer httpClientTimeout = 300000;
 
     public void init() throws Exception {
         if (targets != null) {


### PR DESCRIPTION
With introduction of http_client_timeout parameter we need to set a value in unit tests. This PR set a default value of 5 min.