### PR TITLE
Check bytes written by java Channel and continue relaunch transferTo

### DIFF
--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/FileUtils.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/FileUtils.java
@@ -76,7 +76,10 @@ public final class FileUtils {
             zip.putNextEntry(next);
             FileInputStream in = new FileInputStream(file);
             try {
-              in.getChannel().transferTo(0, file.length(), Channels.newChannel(zip));
+                long pos = 0;
+                pos = in.getChannel().transferTo(pos, file.length(), Channels.newChannel(zip));
+                while(pos < file.length())
+                    pos += in.getChannel().transferTo(pos, file.length(), Channels.newChannel(zip));
             } finally {
               in.close();
             }


### PR DESCRIPTION
transferTo() (and transferFrom()) may not transfer all bytes, so we need
to check written bytes count, compare with source file size and recall
transfer method if necessary.