### PR TITLE
mapfishapp - load layers via the querystring

### DIFF
--- a/mapfishapp/README.md
+++ b/mapfishapp/README.md
@@ -29,6 +29,13 @@ The application accepts several GET parameters :
  * **lang** can be set to any of the following : fr, en, es, ru, de,
  * **debug** when set to true, the application loads unminified javascript files,
  * **noheader** when set to true, the application does not load the header.
+ * **layername**, **owstype** and **owsurl** are used to load OGC layers, or to browse OGC servers
+
+Valid query strings:
+ * ?owstype=WMS&owsurl=http://server/ows
+ * ?layername=layer&owstype=WMSLayer&owsurl=http://server/ows
+ * ?layername=layer1,layer2&owstype=WMSLayer,WMSLayer&owsurl=http://server1/ows,https://server2/ows
+ * ?layername=layer1,layer2&owstype=WMSLayer,WMSLayer&owsurl=http://server1/ows,https://server2/ows&wmc=https://server3/path/to/file.wmc
 
 
 It is also possible to POST a JSON string to the home controller, for instance :
@@ -50,7 +57,7 @@ It is also possible to POST a JSON string to the home controller, for instance :
         }]
     }
 
-In response, the viewer will add the above two layers to the map, and display a dialog window showing the layers from the http://ids.pigma.org/geoserver/ign_r/wms WMS server. The department will only display features which have id_dept equals to 47.
+In response, the viewer will add the above two layers to the map, and display a dialog window showing the layers from the `http://ids.pigma.org/geoserver/ign_r/wms` WMS server. The CQL filter also applies, eg here: the department layer will only display features with `id_dept = 47`.
 
 
 CSWquerier

--- a/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_mapinit.js
@@ -578,6 +578,42 @@ GEOR.mapinit = (function() {
                         scope: this
                     });
                 }
+                // Handle the case where OGC layers/servers are being sent via GET parameters...
+                // eg ?layername=commune_bdcarto,opendata:carroyage
+                // &owstype=WMSLayer,WMSLayer
+                // &owsurl=http://geobretagne.fr/geoserver/dreal_b/ows,https://preprod.ppige-npdc.fr/geoserver/ows
+                var p = GEOR.util.splitURL(window.location.href).params;
+                if (p.hasOwnProperty('LAYERNAME') && p.hasOwnProperty('OWSTYPE')
+                    && p.hasOwnProperty('OWSURL')) {
+                    // load the given layer on top of the WMC
+                    if (Ext.isArray(p.OWSURL) && Ext.isArray(p.OWSTYPE)
+                        && Ext.isArray(p.LAYERNAME) && p.OWSURL.length === p.OWSTYPE.length
+                        && p.OWSURL.length === p.LAYERNAME.length) {
+                        // several layers, eventually from different servers
+                        initState = [];
+                        Ext.each(p.OWSURL, function(item, idx) {
+                            initState.push({
+                                "url": p.OWSURL[idx],
+                                "type": p.OWSTYPE[idx],
+                                "name": p.LAYERNAME[idx]
+                            });
+                        });
+                    } else if (Ext.isString(p.OWSURL) && Ext.isString(p.OWSTYPE)
+                        && Ext.isString(p.LAYERNAME)) {
+                        // only one layer
+                        initState = [{
+                            "url": p.OWSURL,
+                            "type": p.OWSTYPE,
+                            "name": p.LAYERNAME
+                        }];
+                    } else {
+                        // query string error
+                        GEOR.util.errorDialog({
+                            msg: OpenLayers.i18n("Error while decoding querystring")
+                        });
+                    }
+                    loadLayers(initState);
+                }
                 return;
             }
 


### PR DESCRIPTION
The following PR adds more capabilities to mapfishapp by extending the query string parameters.
It is useful for those who'd like to create links to a viewer preloaded with OGC layers.