### PR TITLE
Introducing GEOR.config.METADATA_VIEW_BASE_URL

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_config.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_config.js
@@ -114,6 +114,14 @@ GEOR.config = (function() {
             "/geonetwork"),
 
         /**
+         * Constant: METADATA_VIEW_BASE_URL
+         * The base URL to the "view metadata" service
+         * Defaults to "/geonetwork/?uuid="
+         */
+        METADATA_VIEW_BASE_URL: getCustomParameter("METADATA_VIEW_BASE_URL",
+            "/geonetwork/?uuid="),
+
+        /**
          * Constant: CSW_GETDOMAIN_SORTING
          * true to case insensitive sort (client side) the keywords
          * got from a CSW getDomain request. false to disable

--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswbrowser.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswbrowser.js
@@ -125,8 +125,7 @@ GEOR.cswbrowser = (function() {
 
                         metadataURL = null;
                         if (record.identifier && record.identifier[0]) {
-                            metadataURL = GEOR.config.GEONETWORK_BASE_URL + 
-                                '/?uuid='+record.identifier[0].value;
+                            metadataURL = GEOR.config.METADATA_VIEW_BASE_URL + record.identifier[0].value;
                             name += '<a href="'+metadataURL +
                                 '" target="_blank" onclick="window.open(this.href);return false;">'+mdTitle+'</a>';
                         }

--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
@@ -51,7 +51,9 @@ GEOR.CustomCSWRecordsReader = function(meta, recordType) {
             {name: "md_uuid"},
             {name: "md_title"},
             {name: "md_abstract"},
-            {name: "md_thumbnail_url"}
+            {name: "md_thumbnail_url"},
+            {name: "csw_url"} // csw service providing the metadata: 
+            // useful to guess if METADATA_VIEW_BASE_URL applies !
         ]);
     }
     GEOR.CustomCSWRecordsReader.superclass.constructor.call(
@@ -111,7 +113,8 @@ Ext.extend(GEOR.CustomCSWRecordsReader, Ext.data.DataReader, {
                                 "md_uuid": r.get('identifier'),
                                 "md_title": r.get('title'),
                                 "md_abstract": r.get('abstract'),
-                                "md_thumbnail_url": thumbnailURL
+                                "md_thumbnail_url": thumbnailURL,
+                                "csw_url": r.store.proxy.url
                             };
                             records.push(
                                 new recordType(values, r.get('identifier')+'_'+item.value+'_'+item.name)
@@ -401,10 +404,21 @@ GEOR.cswquerier = (function() {
 
         var context = {
             "metadataURL": function(values) {
-                // this part is 100% geonetwork specific:
-                var url = CSWRecordsStore.proxy.url;
-                // replace /srv/*/csw with /?uuid=
-                return url.replace(/\/srv\/(\S+)\/csw/, '/?uuid='+values.md_uuid);
+                var base,
+                    localMetadata = values.csw_url[0] === "/" ||
+                        values.csw_url.indexOf(window.location.origin) === 0;
+                if (GEOR.config.METADATA_VIEW_BASE_URL && localMetadata) {
+                    // someone defined a custom metadataBaseURL
+                    // use it if and only if the metadata is coming from the local catalog (same origin)
+                    base = GEOR.config.METADATA_VIEW_BASE_URL;
+                } else {
+                    // this part is 100% geonetwork specific:
+                    // (but we have no way to do better ATM for **remote CSW services**)
+                    var url = CSWRecordsStore.proxy.url;
+                    // replace /srv/*/csw with /?uuid=
+                    base = url.replace(/\/srv\/(\S+)\/csw/, '/?uuid=');
+                }
+                return base+values.md_uuid;
             },
             "thumbnailURL": function(values) {
                 if (values.md_thumbnail_url) {

--- a/mapfishapp/src/main/webapp/app/js/GEOR_workspace.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_workspace.js
@@ -86,7 +86,7 @@ GEOR.workspace = (function() {
                             if (r && r[1]) {
                                 // wait a while for the MD to be made available:
                                 new Ext.util.DelayedTask(function(){
-                                    window.open(GEOR.config.GEONETWORK_BASE_URL+"/?uuid="+r[1]);
+                                    window.open(GEOR.config.METADATA_VIEW_BASE_URL+r[1]);
                                 }).delay(1000);
                                 return;
                             }


### PR DESCRIPTION
This new config option allows SDI administrators to declare a custom metadata view service.

By default, the metadata view service is `/geonetwork/?uuid=` (which is fine for a standard geOrchestra).

In complex setups, for instance when the local catalog harvests a remote node, the SDI admin might want to choose a different metadata view service (eg the original one `/portail/geocatalogue?uuid=`).
The current PR addresses this issue.