### PR TITLE
extractorapp: volume for java.util.prefs.userRoot and systemRoot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ extractorapp:
     - smtp
   volumes:
     - extractorapp_extracts:/var/local/extracts
-    - extractorapp_tmp:/var/local/extractorapp_tmp
+    - /tmp
   environment:
     - XMX=1g
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ extractorapp:
     - smtp
   volumes:
     - extractorapp_extracts:/var/local/extracts
+    - extractorapp_tmp:/var/local/extractorapp_tmp
   environment:
     - XMX=1g
 

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-VOLUME [ "/var/local/extracts", "/var/local/extractorapp_tmp" ]
+VOLUME [ "/var/local/extracts", "/tmp" ]
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/var/local/extractorapp_tmp/jetty -Djava.util.prefs.userRoot=/var/local/extractorapp_tmp/userPrefs -Djava.util.prefs.systemRoot=/var/local/extractorapp_tmp/systemPrefs -Dgeorchestra.datadir=/etc/georchestra -Dextractor.storage.dir=/var/local/extracts -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Djava.util.prefs.userRoot=/tmp/userPrefs -Djava.util.prefs.systemRoot=/tmp/systemPrefs -Dgeorchestra.datadir=/etc/georchestra -Dextractor.storage.dir=/var/local/extracts -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-VOLUME [ "/var/local/extracts" ]
+VOLUME [ "/var/local/extracts", "/var/local/extractorapp_tmp" ]
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Dextractor.storage.dir=/var/local/extracts -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
-
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/var/local/extractorapp_tmp/jetty -Djava.util.prefs.userRoot=/var/local/extractorapp_tmp/userPrefs -Djava.util.prefs.systemRoot=/var/local/extractorapp_tmp/systemPrefs -Dgeorchestra.datadir=/etc/georchestra -Dextractor.storage.dir=/var/local/extracts -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]


### PR DESCRIPTION
This PR partially addresses issues https://github.com/georchestra/georchestra/issues/871 and https://github.com/georchestra/georchestra/issues/1407 by setting the `java.util.prefs.userRoot` and `java.util.prefs.systemRoot` options to a writable volume.