### PR TITLE
dockerfiles improvements

### DIFF
--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=512M
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/tmp" ]
+VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.3-jre8
 
-ENV XMS=256M XMX=512M
+ENV XMS=256M XMX=1G
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 

--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=1G
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/tmp" ]
+VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/catalogapp/src/docker/Dockerfile
+++ b/catalogapp/src/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=512M
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/tmp" ]
+VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/catalogapp/src/docker/Dockerfile
+++ b/catalogapp/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-jar","/usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ ldapadmin:
     - /run/jetty
     - /tmp
   environment:
-    - XMS=256M
+    - XMS=512M
     - XMX=1G
 
 geonetwork:
@@ -162,7 +162,7 @@ geonetwork:
     - /tmp
   environment:
     - XMS=1G
-    - XMX=2G
+    - XMX=6G
 
 analytics:
   image: georchestra/analytics:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,20 +48,24 @@ geoserver:
     - geoserver_datadir:/var/local/geoserver
     - geoserver_geodata:/var/local/geodata
     - geoserver_tiles:/var/local/tiles
+    - /run/jetty
     - /tmp
   links:
     - database
     - ldap
   environment:
-    - XMX=2g
+    - XMS=512M
+    - XMX=2G
 
 geowebcache:
   image: georchestra/geowebcache:latest
   volumes:
     - geowebcache_tiles:/var/local/tiles
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=1g
+    - XMS=256M
+    - XMX=1G
 
 proxy:
   image: georchestra/security-proxy:latest
@@ -81,48 +85,56 @@ proxy:
     - catalogapp
     - downloadform
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=1g
+    - XMS=256M
+    - XMX=1G
 
 cas:
   image: georchestra/cas:latest
   links:
     - ldap
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=1g
+    - XMS=256M
+    - XMX=1G
 
 mapfishapp:
   image: georchestra/mapfishapp:latest
   volumes:
     - mapfishapp_uploads:/var/local/uploads
+    - /run/jetty
     - /tmp
   links:
     - database
   environment:
-    - XMX=1g
+    - XMS=256M
+    - XMX=1G
 
 extractorapp:
   image: georchestra/extractorapp:latest
-  volumes:
-    - extractorapp_extracts:/var/local/extracts
   links:
     - database
     - smtp
   volumes:
     - extractorapp_extracts:/var/local/extracts
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=1g
+    - XMS=256M
+    - XMX=1G
 
 header:
   image: georchestra/header:latest
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=512m
+    - XMS=256M
+    - XMX=512M
 
 ldapadmin:
   image: georchestra/ldapadmin:latest
@@ -131,9 +143,11 @@ ldapadmin:
     - ldap
     - smtp
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=1g
+    - XMS=256M
+    - XMX=1G
 
 geonetwork:
   image: georchestra/geonetwork:3-latest
@@ -144,29 +158,37 @@ geonetwork:
     - ldap
   volumes:
     - geonetwork_datadir:/var/local/geonetwork
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=2g
+    - XMS=1G
+    - XMX=2G
 
 analytics:
   image: georchestra/analytics:latest
   links:
     - database
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=512m
+    - XMS=256M
+    - XMX=512M
 
 catalogapp:
   image: georchestra/catalogapp:latest
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=512m
+    - XMS=256M
+    - XMX=512M
 
 downloadform:
   image: georchestra/downloadform:latest
   volumes:
+    - /run/jetty
     - /tmp
   environment:
-    - XMX=512m
+    - XMS=256M
+    - XMX=512M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,6 @@ geoserver:
     - geoserver_datadir:/var/local/geoserver
     - geoserver_geodata:/var/local/geodata
     - geoserver_tiles:/var/local/tiles
-    - /run/jetty
-    - /tmp
   links:
     - database
     - ldap
@@ -61,8 +59,6 @@ geowebcache:
   image: georchestra/geowebcache:latest
   volumes:
     - geowebcache_tiles:/var/local/tiles
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=1G
     - XMX=2G
@@ -84,9 +80,6 @@ proxy:
     - analytics
     - catalogapp
     - downloadform
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=512M
     - XMX=1G
@@ -95,9 +88,6 @@ cas:
   image: georchestra/cas:latest
   links:
     - ldap
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=256M
     - XMX=1G
@@ -106,8 +96,6 @@ mapfishapp:
   image: georchestra/mapfishapp:latest
   volumes:
     - mapfishapp_uploads:/var/local/uploads
-    - /run/jetty
-    - /tmp
   links:
     - database
   environment:
@@ -121,17 +109,12 @@ extractorapp:
     - smtp
   volumes:
     - extractorapp_extracts:/var/local/extracts
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=1G
     - XMX=2G
 
 header:
   image: georchestra/header:latest
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=256M
     - XMX=512M
@@ -142,9 +125,6 @@ ldapadmin:
     - database
     - ldap
     - smtp
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=512M
     - XMX=1G
@@ -158,8 +138,6 @@ geonetwork:
     - ldap
   volumes:
     - geonetwork_datadir:/var/local/geonetwork
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=1G
     - XMX=6G
@@ -168,27 +146,18 @@ analytics:
   image: georchestra/analytics:latest
   links:
     - database
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=256M
     - XMX=1G
 
 catalogapp:
   image: georchestra/catalogapp:latest
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=256M
     - XMX=512M
 
 downloadform:
   image: georchestra/downloadform:latest
-  volumes:
-    - /run/jetty
-    - /tmp
   environment:
     - XMS=256M
     - XMX=512M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ geoserver:
     - database
     - ldap
   environment:
-    - XMS=512M
-    - XMX=2G
+    - XMS=1536M
+    - XMX=8G
 
 geowebcache:
   image: georchestra/geowebcache:latest
@@ -64,8 +64,8 @@ geowebcache:
     - /run/jetty
     - /tmp
   environment:
-    - XMS=256M
-    - XMX=1G
+    - XMS=1G
+    - XMX=2G
 
 proxy:
   image: georchestra/security-proxy:latest
@@ -88,7 +88,7 @@ proxy:
     - /run/jetty
     - /tmp
   environment:
-    - XMS=256M
+    - XMS=512M
     - XMX=1G
 
 cas:
@@ -111,8 +111,8 @@ mapfishapp:
   links:
     - database
   environment:
-    - XMS=256M
-    - XMX=1G
+    - XMS=1G
+    - XMX=2G
 
 extractorapp:
   image: georchestra/extractorapp:latest
@@ -124,8 +124,8 @@ extractorapp:
     - /run/jetty
     - /tmp
   environment:
-    - XMS=256M
-    - XMX=1G
+    - XMS=1G
+    - XMX=2G
 
 header:
   image: georchestra/header:latest
@@ -173,7 +173,7 @@ analytics:
     - /tmp
   environment:
     - XMS=256M
-    - XMX=512M
+    - XMX=1G
 
 catalogapp:
   image: georchestra/catalogapp:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ geoserver:
     - geoserver_datadir:/var/local/geoserver
     - geoserver_geodata:/var/local/geodata
     - geoserver_tiles:/var/local/tiles
+    - /tmp
   links:
     - database
     - ldap
@@ -58,6 +59,7 @@ geowebcache:
   image: georchestra/geowebcache:latest
   volumes:
     - geowebcache_tiles:/var/local/tiles
+    - /tmp
   environment:
     - XMX=1g
 
@@ -78,6 +80,8 @@ proxy:
     - analytics
     - catalogapp
     - downloadform
+  volumes:
+    - /tmp
   environment:
     - XMX=1g
 
@@ -85,6 +89,8 @@ cas:
   image: georchestra/cas:latest
   links:
     - ldap
+  volumes:
+    - /tmp
   environment:
     - XMX=1g
 
@@ -92,6 +98,7 @@ mapfishapp:
   image: georchestra/mapfishapp:latest
   volumes:
     - mapfishapp_uploads:/var/local/uploads
+    - /tmp
   links:
     - database
   environment:
@@ -112,6 +119,8 @@ extractorapp:
 
 header:
   image: georchestra/header:latest
+  volumes:
+    - /tmp
   environment:
     - XMX=512m
 
@@ -121,6 +130,8 @@ ldapadmin:
     - database
     - ldap
     - smtp
+  volumes:
+    - /tmp
   environment:
     - XMX=1g
 
@@ -133,6 +144,7 @@ geonetwork:
     - ldap
   volumes:
     - geonetwork_datadir:/var/local/geonetwork
+    - /tmp
   environment:
     - XMX=2g
 
@@ -140,11 +152,21 @@ analytics:
   image: georchestra/analytics:latest
   links:
     - database
+  volumes:
+    - /tmp
   environment:
     - XMX=512m
 
 catalogapp:
   image: georchestra/catalogapp:latest
+  volumes:
+    - /tmp
+  environment:
+    - XMX=512m
 
 downloadform:
   image: georchestra/downloadform:latest
+  volumes:
+    - /tmp
+  environment:
+    - XMX=512m

--- a/downloadform/src/docker/Dockerfile
+++ b/downloadform/src/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=512M
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/tmp" ]
+VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/downloadform/src/docker/Dockerfile
+++ b/downloadform/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty", "-Dgeorchestra.datadir=/etc/georchestra","-Xmx512m","-jar","/usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.3-jre8
 
-ENV XMS=256M XMX=1G
+ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=1G
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
@@ -10,7 +12,7 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-VOLUME [ "/var/local/extracts", "/tmp" ]
+VOLUME [ "/var/local/extracts", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
@@ -18,6 +20,7 @@ CMD ["sh", "-c", "exec java \
 -Djava.util.prefs.systemRoot=/tmp/systemPrefs \
 -Dgeorchestra.datadir=/etc/georchestra \
 -Dextractor.storage.dir=/var/local/extracts \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
+
+ADD . /
 
 RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
@@ -12,4 +12,12 @@ RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
 VOLUME [ "/var/local/extracts", "/tmp" ]
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Djava.util.prefs.userRoot=/tmp/userPrefs -Djava.util.prefs.systemRoot=/tmp/systemPrefs -Dgeorchestra.datadir=/etc/georchestra -Dextractor.storage.dir=/var/local/extracts -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Djava.util.prefs.userRoot=/tmp/userPrefs \
+-Djava.util.prefs.systemRoot=/tmp/systemPrefs \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Dextractor.storage.dir=/var/local/extracts \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM jetty:9.2-jre7
 
+ENV XMS=512M XMX=2G
+
 RUN echo "deb http://httpredir.debian.org/debian jessie contrib" >> /etc/apt/sources.list
 RUN echo "deb http://security.debian.org/ jessie/updates contrib" >> /etc/apt/sources.list
 
@@ -11,7 +13,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
 
 ADD . /
 
-VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp" ]
+VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
@@ -19,6 +21,7 @@ CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
 -DGEOSERVER_DATA_DIR=/var/local/geoserver \
 -DGEOWEBCACHE_CACHE_DIR=/var/local/tiles \
 -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar" ]

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -11,13 +11,14 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
 
 ADD . /
 
-VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles" ]
+VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp" ]
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra \
--DGEOSERVER_DATA_DIR=/var/local/geoserver \
+CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
 -Dgeofence.dir=/etc/georchestra/geoserver/geofence \
+-DGEOSERVER_DATA_DIR=/var/local/geoserver \
 -DGEOWEBCACHE_CACHE_DIR=/var/local/tiles \
 -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 \
 -Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
 -jar /usr/local/jetty/start.jar" ]
-

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.2-jre7
 
-ENV XMS=512M XMX=2G
+ENV XMS=1536M XMX=8G
 
 RUN echo "deb http://httpredir.debian.org/debian jessie contrib" >> /etc/apt/sources.list
 RUN echo "deb http://security.debian.org/ jessie/updates contrib" >> /etc/apt/sources.list

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -1,11 +1,16 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
-VOLUME [ "/var/local/tiles" ]
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra \
--DGEOWEBCACHE_CACHE_DIR=/var/local/tiles -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+ADD . /
+
+VOLUME [ "/var/local/tiles", "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-DGEOWEBCACHE_CACHE_DIR=/var/local/tiles \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.3-jre8
 
-ENV XMS=256M XMX=1G
+ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -1,16 +1,18 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=1G
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/var/local/tiles", "/tmp" ]
+VOLUME [ "/var/local/tiles", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
 -DGEOWEBCACHE_CACHE_DIR=/var/local/tiles \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]
-

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=512M
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/tmp" ]
+VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=512M XMX=1G
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
@@ -9,6 +11,6 @@ VOLUME [ "/tmp" ]
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+ -Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
 -jar /usr/local/jetty/start.jar"]

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.3-jre8
 
-ENV XMS=256M XMX=1G
+ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=1G
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
@@ -10,12 +12,13 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-VOLUME [ "/var/local/uploads", "/tmp" ]
+VOLUME [ "/var/local/uploads", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
 -Dmapfish-print-config=/etc/georchestra/mapfishapp/print/config.yaml \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
+
+ADD . /
 
 RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
@@ -10,7 +10,12 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-VOLUME [ "/var/local/uploads" ]
+VOLUME [ "/var/local/uploads", "/tmp" ]
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Dmapfish-print-config=/etc/georchestra/mapfishapp/print/config.yaml -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
-
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Dmapfish-print-config=/etc/georchestra/mapfishapp/print/config.yaml \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM jetty:9.3-jre8
 
-ADD . /
-
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
-CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xmx$XMX -Xms$XMX -jar /usr/local/jetty/start.jar"]
+ADD . /
 
+VOLUME [ "/tmp" ]
+
+CMD ["sh", "-c", "exec java \
+-Djava.io.tmpdir=/tmp/jetty \
+-Dgeorchestra.datadir=/etc/georchestra \
+-Xmx$XMX -Xms$XMX \
+-XX:-UsePerfData \
+-jar /usr/local/jetty/start.jar"]

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.3-jre8
 
-ENV XMS=256M XMX=1G
+ENV XMS=512M XMX=1G
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM jetty:9.3-jre8
 
+ENV XMS=256M XMX=1G
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-VOLUME [ "/tmp" ]
+VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--Xmx$XMX -Xms$XMX \
+-Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
+${JAVA_OPTIONS} \
 -jar /usr/local/jetty/start.jar"]


### PR DESCRIPTION
This PR adds a volume for the /tmp and /run/jetty folder in every container, in order to achieve `ro` containers.

It also:
 * reorganizes docker image layers (in order to get the best of docker image cache)
 * disables JVM statistics with `-XX:-UsePerfData` (it was writing a `hsperfdata_root` folder in /tmp, see #1507) 
 * adds XMX handling to catalogapp & downloadform
 * adds XMS to all webapps
 * adds a /run/jetty volume
 * adds support for `JAVA_OPTIONS` (see also https://hub.docker.com/_/jetty/)
 * adjusts XMS and XMX values to more sensible defaults