### PR TITLE
root pom - adding a profile for jsonevent dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,6 +500,17 @@
         <module>analytics</module>
       </modules>
     </profile>
+    <profile>
+      <id>log4j-logstash</id>
+      <dependencies>
+        <dependency>
+          <groupId>net.logstash.log4j</groupId>
+          <artifactId>jsonevent-layout</artifactId>
+          <version>1.7</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
   <repositories>
     <repository>


### PR DESCRIPTION
This adds an optional dependency in the webapps to be able to log in a JSON fashion compatible with logstash and ELK stacks.

See https://github.com/logstash/log4j-jsonevent-layout#usage for more information about this feature.

This should not affect regular builds and requires the extra profile to be activated (`-Plog4j-logstash`) so that the dependency is added to the generated wars (for now on, geonetwork3 should be the only one unaffected by this commit).

Tests: runtime tested on mapfishapp. since the added dependencies are not related to currently used libraries, this should not harm the current behaviour.