### PR TITLE
mfapp - sorting contexts alphabetically

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/ContextController.java
@@ -22,7 +22,10 @@ package org.georchestra.mapfishapp.ws;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -70,6 +73,15 @@ public class ContextController implements ServletContextAware {
 
     @Autowired
     public GeorchestraConfiguration georchestraConfiguration;
+
+    /**
+     * Setter for the geOrchestraConfiguration bean, used mainly for testing purposes.
+     *
+     * @param georchestraConfiguration
+     */
+    public void setGeorchestraConfiguration(GeorchestraConfiguration georchestraConfiguration) {
+        this.georchestraConfiguration = georchestraConfiguration;
+    }
 
     private JSONObject getContextInfo(File f) throws Exception {
         JSONObject info = new JSONObject();
@@ -261,7 +273,15 @@ public class ContextController implements ServletContextAware {
                 LOG.error("No context sub-directory found in \"" + ctxDir + "\". Returning an empty array of contexts. Please check your setup.");
                 return ret;
             }
-            Iterator<File> wmcs = FileUtils.iterateFiles(new File(ctxDir, "contexts"), new String[] {"wmc"}, false);
+            List<File> wmcscol = (List<File>) FileUtils.listFiles(new File(ctxDir, "contexts"), new String[] { "wmc" },
+                    false);
+            Collections.sort(wmcscol, new Comparator<File>() {
+                @Override
+                public int compare(File o1, File o2) {
+                    return o1.getName().toLowerCase().compareTo(o2.getName().toLowerCase());
+                }
+            });
+            Iterator<File> wmcs = wmcscol.iterator();
             while (wmcs.hasNext()) {
                 File f = wmcs.next();
                 try {

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/ContextControllerTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/ContextControllerTest.java
@@ -119,10 +119,31 @@ public class ContextControllerTest {
 
         try {
             ReflectionUtils.invokeMethod(prvMethod, ctxCtrl, invalidWmc);
-
         } catch (UndeclaredThrowableException e) {
             throw e.getUndeclaredThrowable();
         }
+    }
+
+    /**
+     * This test ensures that the retrieved contexts are correctly sorted in alphabetical order.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetContexts() throws Exception {
+        URL testPathUrl = this.getClass().getResource(".");
+        assumeTrue("testPathUrl does not exist, skipping test", testPathUrl != null);
+        GeorchestraConfiguration georConfig = Mockito.mock(GeorchestraConfiguration.class);
+        String testPath = new File(testPathUrl.toURI()).toString();
+        Mockito.when(georConfig.getContextDataDir()).thenReturn(testPath);
+
+        ContextController ctxCtrl = new ContextController();
+        ctxCtrl.setGeorchestraConfiguration(georConfig);
+        JSONArray ret = ctxCtrl.getContexts();
+
+        assertTrue(ret.getJSONObject(0).getString("label").equals("2.wmc"));
+        assertTrue(ret.getJSONObject(1).getString("label").equals("a.wmc"));
+        assertTrue(ret.getJSONObject(2).getString("label").equalsIgnoreCase("Z.wmc"));
     }
 
     @Test

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/2.wmc
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/2.wmc
@@ -1,0 +1,5 @@
+<ViewContext>
+  <General>
+    <Title>2.wmc</Title>
+  </General>
+</ViewContext>

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/Z.wmc
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/Z.wmc
@@ -1,0 +1,5 @@
+<ViewContext>
+  <General>
+    <Title>Z.wmc</Title>
+  </General>
+</ViewContext>

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/a.wmc
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/a.wmc
@@ -1,0 +1,5 @@
+<ViewContext>
+  <General>
+    <Title>a.wmc</Title>
+  </General>
+</ViewContext>

--- a/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/z.wmc
+++ b/mapfishapp/src/test/resources/org/georchestra/mapfishapp/ws/contexts/z.wmc
@@ -1,0 +1,5 @@
+<ViewContext>
+  <General>
+    <Title>z.wmc</Title>
+  </General>
+</ViewContext>


### PR DESCRIPTION
This feature was asked by several customers, in datadir mode, since the contexts are not set in the GEOR_custom.js file anymore, we need to set a convenient way to sort them.

an alphabetical sort (case-insensitive) seems to be a good choice.

Tests: u-test added, not tested at runtime yet (planned to do a live-testing on pigma-dev)
