### PR TITLE
removing ROLE_ANONYMOUS from 15.12 on

### DIFF
--- a/extractorapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
+++ b/extractorapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
@@ -77,10 +77,6 @@ String sec_roles = request.getHeader("sec-roles");
 if(sec_roles != null) {
     String[] roles = sec_roles.split(";");
     for (int i = 0; i < roles.length; i++) {
-        // ROLE_ANONYMOUS is added by the security proxy:
-        if (roles[i].equals("ROLE_ANONYMOUS")) {
-            break;
-        }
         if (roles[i].equals("ROLE_SV_ADMIN")) {
             admin = true;
         }

--- a/header/src/main/filtered-resources/WEB-INF/jsp/index.jsp
+++ b/header/src/main/filtered-resources/WEB-INF/jsp/index.jsp
@@ -92,11 +92,6 @@ String sec_roles = request.getHeader("sec-roles");
 if(sec_roles != null) {
     String[] roles = sec_roles.split(";");
     for (int i = 0; i < roles.length; i++) {
-        // ROLE_ANONYMOUS is added by the security proxy:
-        if (roles[i].equals("ROLE_ANONYMOUS")) {
-            //response.setHeader("Cache-Control", "public, max-age=31536000");
-            break;
-        }
         if (roles[i].equals("ROLE_SV_EDITOR") || roles[i].equals("ROLE_SV_REVIEWER") || roles[i].equals("ROLE_SV_ADMIN") || roles[i].equals("ROLE_ADMINISTRATOR") || roles[i].equals("ROLE_SV_USER")) {
             anonymous = false;
         }

--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/HomeController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/HomeController.java
@@ -76,7 +76,7 @@ public class HomeController {
 
         String roles = request.getHeader("sec-roles");
 
-        if (roles != null && !roles.equals("ROLE_ANONYMOUS")) {
+        if (roles != null) {
             String redirectUrl;
             List<String> rolesList = Arrays.asList(roles.split(";"));
 
@@ -98,7 +98,7 @@ public class HomeController {
     @RequestMapping(value="/privateui/")
     public String privateui(HttpServletRequest request) throws IOException{
         String roles = request.getHeader("sec-roles");
-        if(roles != null && !roles.equals("ROLE_ANONYMOUS")) {
+        if(roles != null) {
             List<String> rolesList = Arrays.asList(roles.split(";"));
             if(rolesList.contains("ROLE_MOD_LDAPADMIN")) {
                 return "privateUi";

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/HomeControllerTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/HomeControllerTest.java
@@ -48,7 +48,6 @@ public class HomeControllerTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        request.addHeader("sec-roles", "ROLE_ANONYMOUS");
         ctrl.root(request, response);
 
         assertTrue("expected 302, got " + response.getStatus(), response.getStatus() == HttpServletResponse.SC_MOVED_TEMPORARILY);

--- a/mapfishapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
+++ b/mapfishapp/src/main/filtered-resources/WEB-INF/jsp/index.jsp
@@ -84,11 +84,6 @@ if(sec_roles != null) {
     String[] roles = sec_roles.split(";");
     String[] js_roles_array = new String[roles.length];
     for (int i = 0; i < roles.length; i++) {
-        // ROLE_ANONYMOUS is added by the security proxy:
-        if (roles[i].equals("ROLE_ANONYMOUS")) {
-            js_roles_array[0] = "'ROLE_ANONYMOUS'";
-            break;
-        }
         if (roles[i].equals("ROLE_SV_ADMIN")) {
             admin = true;
         }

--- a/security-proxy/src/main/filtered-resources/WEB-INF/security-proxy.properties
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/security-proxy.properties
@@ -4,7 +4,6 @@
 public.host=${public_host}
 
 # -------  applicationContext-security.xml   -------
-anonymousRole=ROLE_ANONYMOUS
 proxy.contextPath=/sec
 # url called when user has logged out
 logout-success-url=https://${cas.public.host}:${public.ssl}/cas/logout?fromgeorchestra


### PR DESCRIPTION
PR for #1515 

There are other traces of `ROLE_ANONYMOUS` but I'm unsure how to handle them:
```
geowebcache-webapp/src/main/webapp/WEB-INF/acegi-config.xml:        <property name="userAttribute" value="anonymousUser,ROLE_ANONYMOUS" />
security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml:     <s:anonymous granted-authority="ROLE_ANONYMOUS" />
```