### PR TITLE
Fix URL encoding of query part by removing decoding on this part

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -856,9 +856,31 @@ public class Proxy {
     private HttpRequestBase makeRequest(HttpServletRequest request, RequestType requestType, String sURL) throws IOException {
         HttpRequestBase targetRequest;
         try {
-            // Decode URL to replace %20, %xx
-            URL url = new URL(URLDecoder.decode(sURL, "UTF-8"));
-            URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+            // Split URL
+            URL url = new URL(sURL);
+
+            // Let URI constructor encode Path part
+            URI uri = new URI(url.getProtocol(),
+                    url.getUserInfo(),
+                    url.getHost(),
+                    url.getPort(),
+                    url.getPath(),
+                    null, // Don't use query part because URI constructor will try to double encode it
+                    // (query part is already encoded in sURL)
+                    url.getRef());
+
+            // Reconstruct URL with encoded path from URI class and others parameters from URL class
+            StringBuilder rawUrl = new StringBuilder(url.getProtocol() + "://" + url.getHost());
+
+            if(url.getPort() != -1)
+                rawUrl.append(":" + String.valueOf(url.getPort()));
+
+            rawUrl.append(uri.getRawPath()); // Use encoded version from URI class
+
+            if(url.getQuery() != null)
+                rawUrl.append("?" + url.getQuery()); // Use already encoded query part
+
+            uri = new URI(rawUrl.toString());
             switch (requestType) {
             case GET: {
                 logger.debug("New request is: " + sURL + "\nRequest is GET");


### PR DESCRIPTION
sURl comes from spring with path part not encoded but query part encoded
so we need to encode path part with URI constructor but keep query part
as is.
Tested with space in path and encoded entities in query part :
email=psc%2Btestuser%40georchestra.org