### PR TITLE
SP - refactor / adding utests on PR1538

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -853,34 +853,38 @@ public class Proxy {
         }
     }
 
+    private URI buildUri(URL url) throws URISyntaxException {
+        // Let URI constructor encode Path part
+        URI uri = new URI(url.getProtocol(),
+                url.getUserInfo(),
+                url.getHost(),
+                url.getPort(),
+                url.getPath(),
+                null, // Don't use query part because URI constructor will try to double encode it
+                // (query part is already encoded in sURL)
+                url.getRef());
+
+        // Reconstruct URL with encoded path from URI class and others parameters from URL class
+        StringBuilder rawUrl = new StringBuilder(url.getProtocol() + "://" + url.getHost());
+
+        if(url.getPort() != -1)
+            rawUrl.append(":" + String.valueOf(url.getPort()));
+
+        rawUrl.append(uri.getRawPath()); // Use encoded version from URI class
+
+        if(url.getQuery() != null)
+            rawUrl.append("?" + url.getQuery()); // Use already encoded query part
+
+        return new URI(rawUrl.toString());
+    }
+
     private HttpRequestBase makeRequest(HttpServletRequest request, RequestType requestType, String sURL) throws IOException {
         HttpRequestBase targetRequest;
         try {
             // Split URL
             URL url = new URL(sURL);
+            URI uri = buildUri(url);
 
-            // Let URI constructor encode Path part
-            URI uri = new URI(url.getProtocol(),
-                    url.getUserInfo(),
-                    url.getHost(),
-                    url.getPort(),
-                    url.getPath(),
-                    null, // Don't use query part because URI constructor will try to double encode it
-                    // (query part is already encoded in sURL)
-                    url.getRef());
-
-            // Reconstruct URL with encoded path from URI class and others parameters from URL class
-            StringBuilder rawUrl = new StringBuilder(url.getProtocol() + "://" + url.getHost());
-
-            if(url.getPort() != -1)
-                rawUrl.append(":" + String.valueOf(url.getPort()));
-
-            rawUrl.append(uri.getRawPath()); // Use encoded version from URI class
-
-            if(url.getQuery() != null)
-                rawUrl.append("?" + url.getQuery()); // Use already encoded query part
-
-            uri = new URI(rawUrl.toString());
             switch (requestType) {
             case GET: {
                 logger.debug("New request is: " + sURL + "\nRequest is GET");

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNoException;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Map;
@@ -22,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.google.common.collect.Maps;
@@ -162,5 +166,19 @@ public class ProxyTest {
         proxy.init();
 
         // no exception? good
+    }
+
+    @Test
+    public void testBuildUri() throws Exception {
+        proxy = new Proxy();
+        Method m = ReflectionUtils.findMethod(Proxy.class, "buildUri", URL.class);
+        m.setAccessible(true);
+
+        URI ret = (URI) ReflectionUtils.invokeMethod(m, proxy, new URL("https://dev.pigma.org/geonetwork/srv/fre/xml.keyword.get?"+
+        "thesaurus=local.theme.pigma&id=http://ids.pigma.org/themes%23Eau&multiple=false&transformation=to-iso19139-keyword"));
+        assertTrue(ret.toString().contains("id=http://ids.pigma.org/themes%23Eau"));
+
+        ret = (URI) ReflectionUtils.invokeMethod(m, proxy, new URL("https://sdi.georchestra.org/ldapadmin/account/recover?email=psc%2Btestuser%40georchestra.org"));
+        assertTrue(ret.toString().contains("email=psc%2Btestuser%40georchestra.org"));
     }
 }


### PR DESCRIPTION
Following @fvanderbiest's feedback on previous PR, refactor the URI calculation in its own method to make it testable. Adding utests.

Tests: utests added, since there is no functional changes, it should not harm to be merged as is, but would deserve a runtime test on a dev environment.