### PR TITLE
console - Add extractions stats on user page

### DIFF
--- a/ldapadmin/src/main/webapp/console/app/assets/lang/en.json
+++ b/ldapadmin/src/main/webapp/console/app/assets/lang/en.json
@@ -159,7 +159,7 @@
   "analytics.WEEK"        : "per week",
   "analytics.MONTH"       : "per month",
   "analytics.HOUR"        : "per hour",
-  "analytics.extraction"  : "Layers extractions",
+  "analytics.extractions"  : "Layers extractions",
   "analytics.saveAsPNG"   : "Save as PNG",
   "analytics.saveAsCSV"   : "Save as CSV",
 

--- a/ldapadmin/src/main/webapp/console/app/assets/lang/fr.json
+++ b/ldapadmin/src/main/webapp/console/app/assets/lang/fr.json
@@ -159,7 +159,7 @@
   "analytics.WEEK"        : "par semaine",
   "analytics.MONTH"       : "par mois",
   "analytics.HOUR"        : "par heure",
-  "analytics.extraction"  : "Extractions des couches",
+  "analytics.extractions"  : "Extractions des couches",
   "analytics.saveAsPNG"   : "Enregistrer en PNG",
   "analytics.saveAsCSV"   : "Enregistrer en CSV",
 

--- a/ldapadmin/src/main/webapp/console/app/components/analytics/analytics.es6
+++ b/ldapadmin/src/main/webapp/console/app/components/analytics/analytics.es6
@@ -28,7 +28,7 @@ class AnalyticsController {
     this.config = {
       layers: [ 'layer', 'count' ],
       requests: [ 'date', 'count' ],
-      extraction: [ 'layer', 'count' ]
+      extractions: [ 'layer', 'count' ]
     }
 
     this.load((this.group !== 'all') ? this.group : undefined)
@@ -71,7 +71,7 @@ class AnalyticsController {
       limit: 10
     }
 
-    this.extraction = Analytics.get(extractionOptions, () => {}, err)
+    this.extractions = Analytics.get(extractionOptions, () => {}, err)
     this.extractionOptions = { ...extractionOptions }
     delete this.extractionOptions.limit
     this.extractionOptions.service = 'layersExtraction.csv'

--- a/ldapadmin/src/main/webapp/console/app/components/analytics/analytics.tpl.html
+++ b/ldapadmin/src/main/webapp/console/app/components/analytics/analytics.tpl.html
@@ -18,13 +18,14 @@
 
   <div class="row">
     <stats data="analytics.requests" type="'line'" config="analytics.config.requests"
-           title="'analytics.requests'" class="col-md-6"></stats>
+           title="'analytics.requests'" class="col-md-6"/>
     <stats data="analytics.layers" type="'bar'" config="analytics.config.layers"
-           title="'analytics.layers'" class="col-md-6" csv-config="analytics.usageOptions"></stats>
+           title="'analytics.layers'" class="col-md-6" csv-config="analytics.usageOptions"/>
   </div>
+  <hr>
   <div class="row">
     <stats data="analytics.extractions" type="'bar'" config="analytics.config.extractions"
-           title="'analytics.extractions'" class="col-md-6" csv-config="analytics.extractionOptions"></stats>
+           title="'analytics.extractions'" class="col-md-4" csv-config="analytics.extractionOptions"/>
   </div>
 
 </section>

--- a/ldapadmin/src/main/webapp/console/app/components/analytics/analytics.tpl.html
+++ b/ldapadmin/src/main/webapp/console/app/components/analytics/analytics.tpl.html
@@ -23,8 +23,8 @@
            title="'analytics.layers'" class="col-md-6" csv-config="analytics.usageOptions"></stats>
   </div>
   <div class="row">
-    <stats data="analytics.extraction" type="'bar'" config="analytics.config.extraction"
-           title="'analytics.extraction'" class="col-md-6" csv-config="analytics.extractionOptions"></stats>
+    <stats data="analytics.extractions" type="'bar'" config="analytics.config.extractions"
+           title="'analytics.extractions'" class="col-md-6" csv-config="analytics.extractionOptions"></stats>
   </div>
 
 </section>

--- a/ldapadmin/src/main/webapp/console/app/components/user/user.es6
+++ b/ldapadmin/src/main/webapp/console/app/components/user/user.es6
@@ -115,7 +115,7 @@ class UserController {
     this.config = {
       layers: [ 'layer', 'count' ],
       requests: [ 'date', 'count' ],
-      extraction: [ 'layer', 'count' ]
+      extractions: [ 'layer', 'count' ]
     }
     this.loadAnalyticsData()
   }
@@ -156,7 +156,7 @@ class UserController {
         limit: 10
       }
 
-      this.extraction = Analytics.get(extractionOptions, () => {}, error)
+      this.extractions = Analytics.get(extractionOptions, () => {}, error)
       this.extractionOptions = { ...extractionOptions }
       delete this.extractionOptions.limit
       this.extractionOptions.service = 'layersExtraction.csv'

--- a/ldapadmin/src/main/webapp/console/app/components/user/user.es6
+++ b/ldapadmin/src/main/webapp/console/app/components/user/user.es6
@@ -114,7 +114,8 @@ class UserController {
 
     this.config = {
       layers: [ 'layer', 'count' ],
-      requests: [ 'date', 'count' ]
+      requests: [ 'date', 'count' ],
+      extraction: [ 'layer', 'count' ]
     }
     this.loadAnalyticsData()
   }
@@ -137,11 +138,28 @@ class UserController {
         endDate: this.date.end
       }
       this.requests = Analytics.get(options, () => {}, error)
-      this.layers = Analytics.get({
+
+      let usageOptions = {
         ...options,
         service: 'layersUsage.json',
         limit: 10
-      }, () => {}, error)
+      }
+      this.layers = Analytics.get(usageOptions, () => {}, error)
+
+      this.usageOptions = { ...usageOptions }
+      delete this.usageOptions.limit
+      this.usageOptions.service = 'layersUsage.csv'
+
+      let extractionOptions = {
+        ...options,
+        service: 'layersExtraction.json',
+        limit: 10
+      }
+
+      this.extraction = Analytics.get(extractionOptions, () => {}, error)
+      this.extractionOptions = { ...extractionOptions }
+      delete this.extractionOptions.limit
+      this.extractionOptions.service = 'layersExtraction.csv'
     })
   }
 

--- a/ldapadmin/src/main/webapp/console/app/components/user/user.tpl.html
+++ b/ldapadmin/src/main/webapp/console/app/components/user/user.tpl.html
@@ -73,8 +73,14 @@
         <h4 translate>analytics.title</h4>
         <hr>
         <div class="row">
-          <stats data="user.requests" type="'line'" config="user.config.requests" title="'analytics.requests'" class="col-md-6"></stats>
-          <stats data="user.layers" type="'bar'" config="user.config.layers" title="'analytics.layers'" class="col-md-6"></stats>
+          <stats data="user.requests" type="'line'" config="user.config.requests"
+                 title="'analytics.requests'" class="col-md-6"></stats>
+          <stats data="user.layers" type="'bar'" config="user.config.layers"
+                 title="'analytics.layers'" class="col-md-6" csv-config="user.usageOptions"></stats>
+        </div>
+        <div class="row">
+          <stats data="user.extraction" type="'bar'" config="user.config.extraction"
+                 title="'analytics.extraction'" class="col-md-6" csv-config="user.extractionOptions"></stats>
         </div>
       </div>
 

--- a/ldapadmin/src/main/webapp/console/app/components/user/user.tpl.html
+++ b/ldapadmin/src/main/webapp/console/app/components/user/user.tpl.html
@@ -74,13 +74,13 @@
         <hr>
         <div class="row">
           <stats data="user.requests" type="'line'" config="user.config.requests"
-                 title="'analytics.requests'" class="col-md-6"></stats>
+                 title="'analytics.requests'" class="col-md-6"/>
           <stats data="user.layers" type="'bar'" config="user.config.layers"
-                 title="'analytics.layers'" class="col-md-6" csv-config="user.usageOptions"></stats>
+                 title="'analytics.layers'" class="col-md-6" csv-config="user.usageOptions"/>
         </div>
         <div class="row">
-          <stats data="user.extraction" type="'bar'" config="user.config.extraction"
-                 title="'analytics.extraction'" class="col-md-6" csv-config="user.extractionOptions"></stats>
+          <stats data="user.extractions" type="'bar'" config="user.config.extractions"
+                 title="'analytics.extractions'" class="col-md-6" csv-config="user.extractionOptions"/>
         </div>
       </div>
 

--- a/ldapadmin/src/main/webapp/console/app/components/user/user.tpl.html
+++ b/ldapadmin/src/main/webapp/console/app/components/user/user.tpl.html
@@ -78,6 +78,7 @@
           <stats data="user.layers" type="'bar'" config="user.config.layers"
                  title="'analytics.layers'" class="col-md-6" csv-config="user.usageOptions"/>
         </div>
+        <hr>
         <div class="row">
           <stats data="user.extractions" type="'bar'" config="user.config.extractions"
                  title="'analytics.extractions'" class="col-md-6" csv-config="user.extractionOptions"/>

--- a/ldapadmin/src/main/webapp/console/app/styles/app.scss
+++ b/ldapadmin/src/main/webapp/console/app/styles/app.scss
@@ -17,6 +17,9 @@ a {
 .btn-primary {
   background-color : $lightblue;
 }
+body {
+  padding-bottom: 2em;
+}
 
 iframe {
   width    : 100%;


### PR DESCRIPTION
Extractions stats was available for all users or groups in analytics
page, this PR also adds this statistics for users.