### PR TITLE
Console - Add email proxy

### DIFF
--- a/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/emails/EmailController.java
+++ b/ldapadmin/src/main/java/org/georchestra/ldapadmin/ws/emails/EmailController.java
@@ -286,7 +286,7 @@ public class EmailController {
      * }
      *
      */
-    @RequestMapping(value = "/EmailProxy", method = RequestMethod.POST,
+    @RequestMapping(value = "/emailProxy", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8", consumes="application/json")
     @ResponseBody
     public String emailProxy(@RequestBody String rawRequest, HttpServletRequest request)
@@ -318,7 +318,7 @@ public class EmailController {
 
         // Generate From header
         InternetAddress from = new InternetAddress();
-        from.setAddress(this.georConfig.getProperty("proxyFromAddress"));
+        from.setAddress(this.georConfig.getProperty("emailProxyFromAddress"));
         from.setPersonal(request.getHeader("sec-firstname") + " " + request.getHeader("sec-lastname"));
         message.setFrom(from);
 
@@ -360,9 +360,9 @@ public class EmailController {
             throw new JSONException("No subject specified, 'subject' field is required");
 
         // Check subject size
-        if(payload.getString("subject").length() > Integer.parseInt(georConfig.getProperty("proxyMaxSubjectSize")))
+        if(payload.getString("subject").length() > Integer.parseInt(georConfig.getProperty("emailProxyMaxSubjectSize")))
             throw new IllegalArgumentException("Subject is too long, it should not exceed " +
-                    georConfig.getProperty("proxyMaxSubjectSize") + " bytes");
+                    georConfig.getProperty("emailProxyMaxSubjectSize") + " bytes");
     }
 
     /**
@@ -376,9 +376,9 @@ public class EmailController {
             throw new JSONException("No body specified, 'body' field is required");
 
         // Check subject and body size
-        if(payload.getString("body").length() > Integer.parseInt(georConfig.getProperty("proxyMaxBodySize")))
+        if(payload.getString("body").length() > Integer.parseInt(georConfig.getProperty("emailProxyMaxBodySize")))
             throw new IllegalArgumentException("Body is too long, it should not exceed " +
-                    georConfig.getProperty("proxyMaxBodySize") + " bytes");
+                    georConfig.getProperty("emailProxyMaxBodySize") + " bytes");
 
     }
 
@@ -396,9 +396,9 @@ public class EmailController {
             throw new JSONException("One of 'to', 'cc' or 'bcc' must be present in request");
 
         // Check recipient count against proxyMaxRecipient
-        if((to.length + cc.length + bcc.length) > Integer.parseInt(georConfig.getProperty("proxyMaxRecipient")))
+        if((to.length + cc.length + bcc.length) > Integer.parseInt(georConfig.getProperty("emailProxyMaxRecipient")))
             throw new IllegalArgumentException("Too many recipient in request, max recipient : "
-                    + georConfig.getProperty("proxyMaxRecipient"));
+                    + georConfig.getProperty("emailProxyMaxRecipient"));
 
         // Check Recipients validity
         for(int i = 0; i < to.length; i++)
@@ -467,7 +467,7 @@ public class EmailController {
     private boolean recipientIsAllowed(String recipient) throws DataServiceException {
         // Load configuration if not already loaded
         if(this.recipientWhiteList == null)
-            this.recipientWhiteList = Arrays.asList(this.georConfig.getProperty("proxyRecipientWhitelist").split("\\s*,\\s*"));
+            this.recipientWhiteList = Arrays.asList(this.georConfig.getProperty("emailProxyRecipientWhitelist").split("\\s*,\\s*"));
 
         // Check recipient in whitelist
         if(this.recipientWhiteList.contains(recipient))

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/emails/EmailControllerTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/emails/EmailControllerTest.java
@@ -1,0 +1,339 @@
+package org.georchestra.ldapadmin.ws.emails;
+
+import org.georchestra.commons.configuration.GeorchestraConfiguration;
+import org.georchestra.ldapadmin.ds.AccountDao;
+import org.georchestra.ldapadmin.ds.DataServiceException;
+import org.georchestra.ldapadmin.dto.Account;
+import org.json.JSONException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+
+public class EmailControllerTest {
+
+    private GeorchestraConfiguration georConfig;
+    private HttpServletRequest request;
+    private EmailController ctrl;
+    private AccountDao accountDao;
+
+    @Before
+    public void setUpConfiguration() throws MessagingException {
+
+        // Mock configuration
+        this.georConfig = mock(GeorchestraConfiguration.class);
+        when(georConfig.getProperty(eq("proxyMaxRecipient"))).thenReturn("10");
+        when(georConfig.getProperty(eq("proxyMaxBodySize"))).thenReturn("10000");
+        when(georConfig.getProperty(eq("proxyMaxSubjectSize"))).thenReturn("200");
+        when(georConfig.getProperty(eq("proxyRecipientWhitelist")))
+                .thenReturn("psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org");
+
+        // Mock headers
+        this.request = mock(HttpServletRequest.class);
+        when(request.getHeader(eq("sec-roles"))).thenReturn("ROLE_TEST");
+        when(request.getHeader(eq("sec-firstname"))).thenReturn("Test");
+        when(request.getHeader(eq("sec-lastname"))).thenReturn("Admin");
+        when(request.getHeader(eq("sec-email"))).thenReturn("test-admin@georchestra.org");
+
+        // Instanciate controller
+        this.ctrl = new EmailController();
+        this.ctrl.setGeorConfig(this.georConfig);
+
+        // Account DAO
+        this.accountDao = mock(AccountDao.class);
+        this.ctrl.setAccountDao(accountDao);
+    }
+
+    /**
+     * This test checks that JSON is valid
+     */
+
+    @Test(expected = JSONException.class)
+    public void testJSONParse() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"secret@rm.fr, missing closing square bracket, " +
+                "\"subject\": \"test email\", " +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+         this.ctrl.emailProxy(jsonPayload, this.request);
+    }
+
+    /**
+     * This test checks that JSON contains an array under 'to', 'cc' or 'bbc' key
+     */
+    @Test(expected = JSONException.class)
+    public void testJSONParse2() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": \"valid@address.com\", " +
+                "\"subject\": \"test email\", " +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        this.ctrl.emailProxy(jsonPayload, this.request);
+    }
+
+    /**
+     * This test checks that EMail addresses are valid. Tests populateRecipient() method
+     */
+    @Test(expected = AddressException.class)
+    public void testParseAddress() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"invalid email address\"], " +
+                "\"subject\": \"test email\", " +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        this.ctrl.emailProxy(jsonPayload, this.request);
+    }
+
+    /**
+     * Checks that subject is present
+     */
+    @Test
+    public void testSubjectPresent() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"valid@address.com\"], " +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (JSONException ex){
+            Assert.assertEquals("No subject specified, 'subject' field is required", ex.getMessage());
+        }
+    }
+
+    /**
+     * Checks that subject is not empty
+     */
+    @Test
+    public void testSubjectNotEmpty() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"valid@address.com\"], " +
+                "\"subject\": \"\"," +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (JSONException ex){
+            Assert.assertEquals("No subject specified, 'subject' field is required", ex.getMessage());
+        }
+    }
+
+
+    /**
+     * Checks that subject length do not exceed configuration : proxyMaxSubjectSize
+     */
+    @Test
+    public void testSubjectTooLong() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"valid@address.com\"], " +
+                "\"subject\": \"This is a very very very very very very very very very very very very very very very " +
+                "very very very very very very very very very very very very very very very long subject that should " +
+                "exceed configured max subject size\", " +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (IllegalArgumentException ex){
+            Assert.assertEquals("Subject is too long, it should not exceed 200 bytes", ex.getMessage());
+        }
+    }
+
+    /**
+     * Checks that body is present
+     */
+    @Test
+    public void testBodyPresent() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"valid@address.com\"], " +
+                "\"subject\": \"Hello\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (JSONException ex){
+            Assert.assertEquals("No body specified, 'body' field is required", ex.getMessage());
+        }
+    }
+
+    /**
+     * Checks that body length do not exceed configuration : proxyMaxBodySize
+     */
+    @Test
+    public void testBodyTooLong() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+        // Build a body that exceed 10000 bytes
+        int bodySize = 0;
+        StringBuilder body = new StringBuilder();
+        while(bodySize < 10000) {
+            body.append("Hi, this a test EMail, please do not reply. ");
+            bodySize = body.length();
+        }
+
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\"], " +
+                "\"bcc\": [\"valid@address.com\"], " +
+                "\"subject\": \"Hello\", " +
+                "\"body\": \"" + body + "\" }";
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (IllegalArgumentException ex){
+            Assert.assertEquals("Body is too long, it should not exceed 10000 bytes", ex.getMessage());
+        }
+    }
+
+    /**
+     * Checks that reicpient is not missing either as 'to', 'cc' or 'bcc'
+     */
+    @Test
+    public void testNoRecipient() throws UnsupportedEncodingException, MessagingException, DataServiceException, JSONException {
+        String jsonPayload = "{ \"subject\": \"Hello\"," +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (JSONException ex) {
+            Assert.assertEquals("One of 'to', 'cc' or 'bcc' must be present in request", ex.getMessage());
+        }
+
+        jsonPayload = "{ \"to\": [], " +
+                "\"subject\": \"Hello\"," +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (JSONException ex) {
+            Assert.assertEquals("One of 'to', 'cc' or 'bcc' must be present in request", ex.getMessage());
+        }
+
+        jsonPayload = "{ \"to\": [\"\"], " +
+                "\"subject\": \"Hello\"," +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (AddressException ex) {
+            Assert.assertEquals("Missing final '@domain'", ex.getMessage());
+        }
+
+        jsonPayload = "{ \"to\": [], " +
+                "\"cc\": [], " +
+                "\"bcc\": [], " +
+                "\"subject\": \"Hello\"," +
+                "\"body\": \"Hi, this a test EMail, please do not reply.\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (JSONException ex) {
+            Assert.assertEquals("One of 'to', 'cc' or 'bcc' must be present in request", ex.getMessage());
+        }
+    }
+
+    /**
+     * Checks that recipients count does not exceed configuration
+     */
+    @Test
+    public void testRecipientSize() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+
+        String jsonPayload = "{ \"to\": [\"you@rm.fr\", \"another-guy@rm.fr\", \"another-guy@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"cc\": [\"him@rm.fr\", \"another-guy@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"bcc\": [\"valid@address.com\", \"another-guy@rm.fr\", \"another-guy@rm.fr\", \"another-guy@rm.fr\"], " +
+                "\"subject\": \"Hello\", " +
+                "\"body\": \"Hello, maybe there is too many recipient ?\" }";
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (IllegalArgumentException ex){
+            Assert.assertEquals("Too many recipient in request, max recipient : 10", ex.getMessage());
+        }
+    }
+
+
+    /**
+     * Checks recipients whitelist
+     */
+    @Test
+    public void testRecipientAgainstWhitelist() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
+
+        String jsonPayload = "{ \"to\": [\"psc@georchestra.org\"], " +
+                "\"cc\": [\"postmaster@georchestra.org\"], " +
+                "\"bcc\": [\"listmaster@georchestra.org\"], " +
+                "\"subject\": \"Hello\", " +
+                "\"body\": \"Hello, maybe there is too many recipient ?\" }";
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+        } catch (NullPointerException ex) {
+            // NullPointerException is throw because configuration is missing EmailFactoryImpl
+        }
+
+        jsonPayload = "{ \"to\": [\"psc-noexist@georchestra.org\"], " +
+                "\"cc\": [\"postmaster@georchestra.org\"], " +
+                "\"bcc\": [\"listmaster@georchestra.org\"], " +
+                "\"subject\": \"Hello\", " +
+                "\"body\": \"Hello, maybe there is too many recipient ?\" }";
+
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Recipient not allowed : psc-noexist@georchestra.org", ex.getMessage());
+        }
+    }
+
+    /**
+     * Check recipient against LDAP directory
+     */
+    @Test
+    public void testRecipientAgainstLdap() throws DataServiceException, UnsupportedEncodingException, MessagingException, JSONException {
+        Account account = mock(Account.class);
+        when(this.accountDao.findByEmail(eq("adresse1@georchestra.org"))).thenReturn(account);
+        when(this.accountDao.findByEmail(eq("adresse2@georchestra.org"))).thenReturn(account);
+        when(this.accountDao.findByEmail(eq("adresse3@georchestra.org"))).thenReturn(account);
+
+        String jsonPayload = "{ \"to\": [\"adresse1@georchestra.org\"], " +
+                "\"cc\": [\"adresse2@georchestra.org\"], " +
+                "\"bcc\": [\"adresse3@georchestra.org\"], " +
+                "\"subject\": \"Hello\", " +
+                "\"body\": \"Hello, maybe there is too many recipient ?\" }";
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+        } catch (NullPointerException ex) {
+            // NullPointerException is throw because configuration is missing EmailFactoryImpl
+        }
+
+        jsonPayload = "{ \"to\": [\"adresse-tata@georchestra.org\"], " +
+                "\"cc\": [\"adresse-toto@georchestra.org\"], " +
+                "\"bcc\": [\"adresse-nonexist@georchestra.org\"], " +
+                "\"subject\": \"Hello\", " +
+                "\"body\": \"Hello, maybe there is too many recipient ?\" }";
+        try {
+            this.ctrl.emailProxy(jsonPayload, this.request);
+            Assert.fail();
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Recipient not allowed : adresse-tata@georchestra.org", ex.getMessage());
+        }
+    }
+
+}

--- a/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/emails/EmailControllerTest.java
+++ b/ldapadmin/src/test/java/org/georchestra/ldapadmin/ws/emails/EmailControllerTest.java
@@ -30,10 +30,10 @@ public class EmailControllerTest {
 
         // Mock configuration
         this.georConfig = mock(GeorchestraConfiguration.class);
-        when(georConfig.getProperty(eq("proxyMaxRecipient"))).thenReturn("10");
-        when(georConfig.getProperty(eq("proxyMaxBodySize"))).thenReturn("10000");
-        when(georConfig.getProperty(eq("proxyMaxSubjectSize"))).thenReturn("200");
-        when(georConfig.getProperty(eq("proxyRecipientWhitelist")))
+        when(georConfig.getProperty(eq("emailProxyMaxRecipient"))).thenReturn("10");
+        when(georConfig.getProperty(eq("emailProxyMaxBodySize"))).thenReturn("10000");
+        when(georConfig.getProperty(eq("emailProxyMaxSubjectSize"))).thenReturn("200");
+        when(georConfig.getProperty(eq("emailProxyRecipientWhitelist")))
                 .thenReturn("psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org");
 
         // Mock headers
@@ -137,7 +137,7 @@ public class EmailControllerTest {
 
 
     /**
-     * Checks that subject length do not exceed configuration : proxyMaxSubjectSize
+     * Checks that subject length do not exceed configuration : emailProxyMaxSubjectSize
      */
     @Test
     public void testSubjectTooLong() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {
@@ -175,7 +175,7 @@ public class EmailControllerTest {
     }
 
     /**
-     * Checks that body length do not exceed configuration : proxyMaxBodySize
+     * Checks that body length do not exceed configuration : emailProxyMaxBodySize
      */
     @Test
     public void testBodyTooLong() throws MessagingException, DataServiceException, JSONException, UnsupportedEncodingException {


### PR DESCRIPTION
This PR adds a new service to ldapadmin.

The new service sends an email based on a JSON payload. 
The recipients should be present in the LDAP directory or in a configured whitelist.

This is interesting when eg a mapfishapp client-only addon has to send preformatted emails to an administrator (in whitelist).

Json payload with the following keys :
 * **to**      : json array of email to send email to ex: ["you@rm.fr", "another-guy@rm.fr"]
 * cc      : json array of email to 'CC' email ex: ["him@rm.fr"]
 * bcc     : json array of email to add recipient as blind CC ["secret@rm.fr"]
 * **subject** : subject of email
 * **body**  : Body of email

The 'subject' and 'body' fields are mandatory. 
Either 'to', 'cc' or 'bcc' parameter must be present in request. 

The following configuration should also be added in the datadir (ldapadmin.properties) :

```properties
# Email proxy configuration
emailProxyFromAddress=no-reply@georchestra.org
emailProxyMaxRecipient=10
emailProxyMaxBodySize=10000
emailProxyMaxSubjectSize=200
emailProxyRecipientWhitelist=psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org
```