### PR TITLE
mount docker volumes in /mnt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,16 +38,16 @@ geodata:
   ports:
     - "2222:22"
   volumes:
-    - geoserver_geodata:/home/geoserver/data
+    - geoserver_geodata:/mnt/geoserver_geodata
 
 # geOrchestra images
     
 geoserver:
   image: georchestra/geoserver:latest
   volumes:
-    - geoserver_datadir:/var/local/geoserver
-    - geoserver_geodata:/var/local/geodata
-    - geoserver_tiles:/var/local/tiles
+    - geoserver_datadir:/mnt/geoserver_datadir
+    - geoserver_geodata:/mnt/geoserver_geodata
+    - geoserver_tiles:/mnt/geoserver_tiles
   links:
     - database
     - ldap
@@ -58,7 +58,7 @@ geoserver:
 geowebcache:
   image: georchestra/geowebcache:latest
   volumes:
-    - geowebcache_tiles:/var/local/tiles
+    - geowebcache_tiles:/mnt/geowebcache_tiles
     - /etc/georchestra:/etc/georchestra
   environment:
     - XMS=1G
@@ -101,7 +101,7 @@ mapfishapp:
   image: georchestra/mapfishapp:latest
   volumes:
     - /etc/georchestra:/etc/georchestra
-    - mapfishapp_uploads:/var/local/uploads
+    - mapfishapp_uploads:/mnt/mapfishapp_uploads
   links:
     - database
   environment:
@@ -115,7 +115,7 @@ extractorapp:
     - smtp
   volumes:
     - /etc/georchestra:/etc/georchestra
-    - extractorapp_extracts:/var/local/extracts
+    - extractorapp_extracts:/mnt/extractorapp_extracts
   environment:
     - XMS=1G
     - XMX=2G
@@ -147,7 +147,7 @@ geonetwork:
     - ldap
   volumes:
     - /etc/georchestra:/etc/georchestra
-    - geonetwork_datadir:/var/local/geonetwork
+    - geonetwork_datadir:/mnt/geonetwork_datadir
   environment:
     - XMS=1G
     - XMX=6G

--- a/docker/README.md
+++ b/docker/README.md
@@ -77,12 +77,12 @@ ssh -p 2222 geoserver@localhost
 ```
 The default password is `geoserver`.
 
-File should be transfered to the `/home/geoserver/data/` folder:
+File should be transfered to the `/mnt/geoserver_geodata/` folder:
 ```bash
-geoserver@20d925d9072b:~$ ls -al /home/geoserver/data/
+geoserver@20d925d9072b:~$ ls -al /mnt/geoserver_geodata/
 total 8
 drwxr-xr-x 2 geoserver geoserver 4096 Jan 22 13:10 .
 drwxr-xr-x 4 geoserver geoserver 4096 Jan 22 13:10 ..
 ```
 
-They will be made available to all geoserver instances in `/var/local/geodata`. 
+They will be made available to all geoserver instances in `/mnt/geoserver_geodata`. 

--- a/docker/ssh_data/Dockerfile
+++ b/docker/ssh_data/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && \
 RUN groupadd --gid 999 geoserver
 RUN useradd -ms /bin/bash --home /home/geoserver -p $(echo "print crypt("${USER_PASS:-geoserver}", "salt")" | perl) --uid 999 --gid 999 geoserver
 
-RUN mkdir /home/geoserver/data
-RUN chown -R 999:999 /home/geoserver/data
+RUN mkdir /mnt/geoserver_geodata
+RUN chown -R 999:999 /mnt/geoserver_geodata
 
 ADD start.sh /root/
 RUN chmod +x /root/start.sh

--- a/docker/ssh_data/start.sh
+++ b/docker/ssh_data/start.sh
@@ -5,8 +5,7 @@ if [ "$USER_PASS" ]; then
     echo geoserver:"$USER_PASS" |chpasswd
 fi
 
-chown -R 999:999 /home/geoserver
-
+chown -R 999:999 /mnt/geoserver_geodata &
 
 # start openssh server
 exec /usr/sbin/sshd -D

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,11 +43,11 @@ To login, use these credentials:
 
 To upload data into the GeoServer data volume (`geoserver_geodata`), use rsync:
 ```
-rsync -arv -e `ssh -p 2222` /path/to/geodata/ geoserver@localhost:/home/geoserver/data 
+rsync -arv -e `ssh -p 2222` /path/to/geodata/ geoserver@localhost:/mnt/geoserver_geodata/
 ```
 (password is: `geoserver`)
 
-Files uploaded into this volume will be available for the geoserver instance in `/var/local/geodata`.
+Files uploaded into this volume will also be available to the geoserver instance in `/mnt/geoserver_geodata/`.
 
 
 ## Notes


### PR DESCRIPTION
This is to simplify volume usage : it's indeed easier to remember where volumes are located if all of them are mounted at the same place.

We also introduce the convention that the folder name where a volume is mounted should have the same name as the volume itself.