### PR TITLE
postgresql docker - fixing patch for the entrypoint

### DIFF
--- a/postgresql/docker-entrypoint.sh.patch
+++ b/postgresql/docker-entrypoint.sh.patch
@@ -1,10 +1,10 @@
---- docker-entrypoint.sh	2016-05-12 18:41:12.719077954 +0200
-+++ docker-entrypoint_modified.sh	2016-05-12 18:33:38.349967649 +0200
-@@ -79,6 +79,7 @@
+--- docker-entrypoint.sh	2017-01-05 19:05:53.734607718 +0100
++++ docker-entrypoint_modified.sh	2017-01-05 19:07:20.810103301 +0100
+@@ -103,6 +103,7 @@
  		for f in /docker-entrypoint-initdb.d/*; do
  			case "$f" in
  				*.sh)     echo "$0: running $f"; . "$f" ;;
-+ 				*-data.sql) if [ "$IGNORE_DATA" = 'true' ]; then echo "$0: ignoring $f";  else echo "$0: running $f"; "${psql[@]}" < "$f"; echo ; fi ;;
- 				*.sql)    echo "$0: running $f"; "${psql[@]}" < "$f"; echo ;;
++				*-data.sql) if [ "$IGNORE_DATA" = 'true' ]; then echo "$0: ignoring $f";  else echo "$0: running $f"; "${psql[@]}" < "$f"; echo ; fi ;;
+ 				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
  				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
  				*)        echo "$0: ignoring $f" ;;


### PR DESCRIPTION
The build on jenkins is failing since a probable change upstream on the postgresql entrypoint. The patch needs to be adjusted.

Anyway, even if I am pretty confident in this patch, I'd prefer to go through a review since if something changed upstream it might be a reason.

Tests: docker build OK, but might deserve a runtime test.

Note: I'm not very fond of a patch to be applied in the image, it makes it hard to review/understand and reminds me of GeoNetwork first integration in geOr :( 