### PR TITLE
[Mapfishapp] Add events when layers are cleared from map

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_managelayers.js
@@ -84,6 +84,12 @@ GEOR.managelayers = (function() {
          * Fired before all layers are removed from map
          */
         "beforecontextcleared",
+        
+        /**
+         * @event beforecontextcleared
+         * Fired after all layers are removed from map
+         */
+        "aftercontextcleared",
 
         /**
          * @event searchresults
@@ -994,6 +1000,7 @@ GEOR.managelayers = (function() {
                 map.removeLayer(map.layers[i]);
             }
         }
+        observable.fireEvent("aftercontextcleared");
     };
 
     /**

--- a/mapfishapp/src/main/webapp/app/js/GEOR_wmc.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_wmc.js
@@ -40,7 +40,8 @@ GEOR.wmc = (function() {
          * Listener arguments:
          * count - {Integer} the number of records to restore
          */
-        "beforecontextrestore"
+        "beforecontextrestore",
+        "aftercontextrestore"
     );
 
     /**
@@ -324,6 +325,8 @@ GEOR.wmc = (function() {
                     GEOR.config.CONTEXT_LOADED_INDICATOR_DURATION
                 );
             }
+            
+            observable.fireEvent("aftercontextrestore");
         }
     };
 })();


### PR DESCRIPTION
This PR aim to add 2 events in MFapp : 

- aftercontextrestore in GEOR_wmc.js

- aftercontextcleared in GEOR_managelayers.js

In think thos two events can be very usefull for addons, and tools with their own layers loaded (annotation, print, cadastrapp, search, ...).
With them each layer could catch the event and define a callback for reload his layer(s) when a context is loaded of map is cleared.