### PR TITLE
mapfishapp - add slf4j-simple

### DIFF
--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -94,6 +94,12 @@
       <artifactId>print-lib</artifactId>
       <version>2.1.1</version>
     </dependency>
+    <!-- Note: the print module also depends on slf4j -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.5</version>
+    </dependency>
     <!-- geotools -->
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
This should only be necessary for the mapfish-print, not mapfishapp which makes use of log4j.

Tests: Runtime test in the generated docker image, no more slf4j logs. Built without -DskipTests, so testsuite is ok.