### PR TITLE
mapfishapp - Remove pMode from thesaurus query

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswbrowser.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswbrowser.js
@@ -332,7 +332,6 @@ GEOR.cswbrowser = (function() {
                 //maxResults: '100', // Should it be changed ?
                 pTypeSearch: 1,
                 // pTypeSearch: 0 = starts with / 1 = contains / 2 = exact match
-                pMode: 'consult',
                 pThesauri: key
             },
             success: function(response) {


### PR DESCRIPTION
When this parameter is set, geonetwork failed with a 500 error.
Geonetwork try to add an element on XML response with thesaurus
identifier and mode.

Problem is in GetKeywords class :
org.fao.geonet.services.thesaurus.GetKeywords#exec
new Element("thesaurus") throw an exception