### PR TITLE
Revert "geodetic print backported"

### DIFF
--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1-GEORCHESTRA-geodetic</version>
+      <version>2.1.1</version>
     </dependency>
     <!-- geotools -->
     <dependency>


### PR DESCRIPTION
This reverts commit 66d7fe070f355650ec6702b9dcf0a6505131c254.
When 'geodetic' parameter is set on JSON payload, geodetic correction is
already applied. So we don't need mfp modification anymore !