### PR TITLE
security-proxy - Use human readable org name for ogc stats

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -654,7 +654,7 @@ public class Proxy {
 
             try {
                 Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-                Header[] originalHeaders = proxyingRequest.getHeaders("sec-org");
+                Header[] originalHeaders = proxyingRequest.getHeaders("sec-orgname");
                 String org = "";
                 for (Header originalHeader : originalHeaders) {
                     org = originalHeader.getValue();


### PR DESCRIPTION
instead of internal identifier