### PR TITLE
extractorapp,mfapp,catalogapp - make build idempotent

### DIFF
--- a/catalogapp/pom.xml
+++ b/catalogapp/pom.xml
@@ -185,6 +185,20 @@
           <target>${java-version}</target>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>jsbuild</directory>
+              <includes>
+                <include>env/**</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -403,6 +403,20 @@
           <executable>jsbuild/${jsbuild.command}</executable>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>jsbuild</directory>
+              <includes>
+                <include>env/**</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -338,6 +338,20 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>jsbuild</directory>
+              <includes>
+                <include>env/**</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
     <resources>
       <resource>


### PR DESCRIPTION
When the repository is moved to another directory, jsbuild is unable to
build the JS anymore, making maven to fail. This is due to python
virtualenv which has to know the actual absolute directory to store its
dependencies.

This case is not supposed to happen, but it might in some specific
environments (Jenkins CI). Removing the generated virtualenv seems
acceptable, since it does not take ages to rebake a one from scratch.

Tests: compilation level on each webapp:
* mvn package after a move fails (logically, it requires a clean)
* mvn clean package OK
* mvn clean: removes target/ and also jsbuild/env

Note: a similar fix could also have been applied onto jsbuild.sh, but I
prefer to have the build logic maven-side, and taking some time to work
on the build minification would be better spent trying some more
integrated tools than a shell script plus a virtualenv plus quite old
dependencies, see https://github.com/georchestra/georchestra/issues/378