### PR TITLE
security-proxy - Disallow proxy request with Class C hostname

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -303,13 +303,25 @@ public class Proxy {
         if (request.getRequestURI().startsWith("/sec/proxy/")) {
             testLegalContentType(request);
             URL url;
+            InetAddress remoteAddress;
             try {
                 url = new URL(sURL);
+                remoteAddress = InetAddress.getByName(url.getHost());
             } catch (MalformedURLException e) { // not an url
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
                 return;
+            } catch (UnknownHostException e){
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+                return;
             }
-            if (proxyPermissions.isDenied(url) || urlIsProtected(request, url)) {
+
+            /*
+             * Disallow :
+             * - Class C IP address (isSiteLocalAddress())
+             * - not allowed urls defined in permissions.xml
+             * - URL defined is target-mappings.xml (urlIsProtected())
+             */
+            if (remoteAddress.isSiteLocalAddress() || proxyPermissions.isDenied(url) || urlIsProtected(request, url)) {
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "URL is not allowed.");
                 return;
             }


### PR DESCRIPTION
Internal proxy (/proxy?url=...) request with be filtered based on
address class of hostname.