### PR TITLE
[Mapfishapp] Correct annotation bug

### DIFF
--- a/mapfishapp/src/main/webapp/app/addons/annotation/js/Annotation.js
+++ b/mapfishapp/src/main/webapp/app/addons/annotation/js/Annotation.js
@@ -582,7 +582,7 @@ GEOR.Annotation = Ext.extend(Ext.util.Observable, {
                             feature = formatGeoJSON.read(featureJSON,"Feature");
                         feature.style = style;
                         feature.layer = targetLayer;
-                        if ( style.label) {
+                        if ( style && style.label) {
                             feature.isLabel = true;
                         }
                         targetLayer.features.push(feature);


### PR DESCRIPTION
Actually, when I load an exported JSON from Annotation addon, I have a message : it is not valid.

This little correction solve the problem.