### PR TITLE
Forgot password, try to avoid stack traces.

### DIFF
--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -24,6 +24,7 @@
         <property name="url" value="${dlJdbcUrlOGC}"/>
         <property name="driverClassName" value="org.postgresql.Driver"/>
         <property name="testOnBorrow" value="true"/>
+        <property name="validationQuery" value="select 1 as dbcp_connection_test"/>
         <property name="poolPreparedStatements" value="true"/>
         <property name="maxOpenPreparedStatements" value="-1"/>
         <property name="defaultReadOnly" value="false"/>

--- a/downloadform/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/downloadform/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -28,6 +28,7 @@
     <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource">
       <property name="url" value="${dlJdbcUrl}"/>
       <property name="testOnBorrow" value="true"/>
+      <property name="validationQuery" value="select 1 as dbcp_connection_test"/>
       <property name="poolPreparedStatements" value="true"/>
       <property name="maxOpenPreparedStatements" value="-1"/>
       <property name="defaultReadOnly" value="false"/>

--- a/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -131,6 +131,7 @@
         <property name="password" value="${psql.pass}"/>
         <property name="driverClassName" value="org.postgresql.Driver"/>
         <property name="testOnBorrow" value="true"/>
+        <property name="validationQuery" value="select 1 as dbcp_connection_test"/> 
         <property name="poolPreparedStatements" value="true"/>
         <property name="maxOpenPreparedStatements" value="-1"/>
         <property name="defaultReadOnly" value="false"/>


### PR DESCRIPTION
Stack traces are erratic.

Don't know how to test it.

Suppose it has to do with attempt to reuse yesterday connections (it happens in the morning ?), which are not discarded from the connection pool.

Apache docs states that when "testOnBorrow" true, validation query is "The SQL query that will be used to validate connections from this pool before returning them to the caller. If specified, this query MUST be an SQL SELECT statement that returns at least one row. If not specified, connections will be validation by calling the isValid() method".

Theory is that isValid method is not sufficient to leverage the connection up.