### PR TITLE
add config.jar and common compilation before building war or docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,22 +55,18 @@ docker-clean-images:
 docker-clean-all:
 	docker-compose down --volumes --rmi 'all' --remove-orphans
 
-docker-build: docker-build-dev docker-build-gn3 docker-build-geoserver docker-build-georchestra
+docker-build: build-deps docker-build-dev docker-build-gn3 docker-build-geoserver docker-build-georchestra
 
 
 # WAR related targets
 
-war-build-config:
-	cd config/; \
-	../mvn -Dserver=template install
-
-war-build-geoserver: war-build-config
+war-build-geoserver: build-deps
 	cd geoserver/geoserver-submodule/src/; \
 	../../../mvn clean install -Pcontrol-flow,css,csw,gdal,inspire,pyramid,wps -DskipTests; \
 	cd ../../..; \
 	./mvn clean install -pl geoserver/webapp
 
-war-build-geoserver-geofence: war-build-config
+war-build-geoserver-geofence: build-deps
 	cd geoserver/geoserver-submodule/src/; \
 	../../../mvn clean install -Pcontrol-flow,css,csw,gdal,inspire,pyramid,wps,geofence-server -DskipTests; \
 	cd ../../..; \
@@ -93,14 +89,16 @@ deb-build-geoserver-geofence: war-build-geoserver-geofence
 	cd geoserver; \
 	../mvn clean package deb:package -PdebianPackage --pl webapp
 
-deb-build-deps:
+deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver
+	./mvn package deb:package -pl atlas,catalogapp,cas-server-webapp,downloadform,security-proxy,header,mapfishapp,extractorapp,analytics,geoserver/webapp,ldapadmin,geonetwork/web,geowebcache-webapp -PdebianPackage -DskipTests
+
+# Base geOrchestra config and common modules
+build-deps:
 	./mvn -Dmaven.test.failure.ignore clean install --non-recursive
 	./mvn clean install -pl config -Dmaven.javadoc.failOnError=false
 	./mvn clean install -pl commons,epsg-extension,ogc-server-statistics -Dmaven.javadoc.failOnError=false
-
-deb-build-georchestra: war-build-georchestra deb-build-deps deb-build-geoserver
-	./mvn package deb:package -pl atlas,catalogapp,cas-server-webapp,downloadform,security-proxy,header,mapfishapp,extractorapp,analytics,geoserver/webapp,ldapadmin,geonetwork/web,geowebcache-webapp -PdebianPackage -DskipTests
-
+	cd config/; \
+	../mvn -Dserver=template install
 
 # all
 all: war-build-georchestra deb-build-georchestra docker-build


### PR DESCRIPTION
This PR fix build of docker images with Makefile, it build config and common modules before building other webapps :
```
 joe@wrk12  ~/git/georchestra/georchestra   fix_makefile ●  docker images                    
REPOSITORY                            TAG                    IMAGE ID            CREATED             SIZE
georchestra/header                    latest                 2160c086b910        6 minutes ago       326MB
georchestra/analytics                 latest                 94b20177de98        6 minutes ago       350MB
georchestra/downloadform              latest                 b4cc866bb065        7 minutes ago       325MB
georchestra/security-proxy            latest                 5dba434d4619        8 minutes ago       331MB
georchestra/atlas                     latest                 54261b5801ff        9 minutes ago       406MB
georchestra/mapfishapp                latest                 27c97b90f7b3        17 minutes ago      490MB
georchestra/ldapadmin                 latest                 df3900b093d7        19 minutes ago      354MB
georchestra/geowebcache               latest                 f74c39e60ffc        20 minutes ago      371MB
georchestra/extractorapp              latest                 7e6760465df1        21 minutes ago      490MB
georchestra/catalogapp                latest                 4c7e88f57ef5        24 minutes ago      332MB
georchestra/cas                       latest                 e6c85149f944        25 minutes ago      344MB
georchestra/geoserver                 latest                 f6786a48b8bf        26 minutes ago      416MB
georchestra/geonetwork                3-latest               261b49127f75        29 minutes ago      473MB
georchestra/database                  latest                 2f9820f239cf        43 minutes ago      724MB

```