### PR TITLE
add config.jar compilation before building war or docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,22 +55,18 @@ docker-clean-images:
 docker-clean-all:
 	docker-compose down --volumes --rmi 'all' --remove-orphans
 
-docker-build: docker-build-dev docker-build-gn3 docker-build-geoserver docker-build-georchestra
+docker-build: build-deps docker-build-dev docker-build-gn3 docker-build-geoserver docker-build-georchestra
 
 
 # WAR related targets
 
-war-build-config:
-	cd config/; \
-	../mvn -Dserver=template install
-
-war-build-geoserver: war-build-config
+war-build-geoserver: build-deps
 	cd geoserver/geoserver-submodule/src/; \
 	../../../mvn clean install -Pcontrol-flow,css,csw,gdal,inspire,pyramid,wps -DskipTests; \
 	cd ../../..; \
 	./mvn clean install -pl geoserver/webapp
 
-war-build-geoserver-geofence: war-build-config
+war-build-geoserver-geofence: build-deps
 	cd geoserver/geoserver-submodule/src/; \
 	../../../mvn clean install -Pcontrol-flow,css,csw,gdal,inspire,pyramid,wps,geofence-server -DskipTests; \
 	cd ../../..; \
@@ -93,14 +89,16 @@ deb-build-geoserver-geofence: war-build-geoserver-geofence
 	cd geoserver; \
 	../mvn clean package deb:package -PdebianPackage --pl webapp
 
-deb-build-deps:
+deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver
+	./mvn package deb:package -pl atlas,catalogapp,cas-server-webapp,downloadform,security-proxy,header,mapfishapp,extractorapp,analytics,geoserver/webapp,ldapadmin,geonetwork/web,geowebcache-webapp -PdebianPackage -DskipTests
+
+# Base geOrchestra config and common modules
+build-deps:
 	./mvn -Dmaven.test.failure.ignore clean install --non-recursive
 	./mvn clean install -pl config -Dmaven.javadoc.failOnError=false
 	./mvn clean install -pl commons,epsg-extension,ogc-server-statistics -Dmaven.javadoc.failOnError=false
-
-deb-build-georchestra: war-build-georchestra deb-build-deps deb-build-geoserver
-	./mvn package deb:package -pl atlas,catalogapp,cas-server-webapp,downloadform,security-proxy,header,mapfishapp,extractorapp,analytics,geoserver/webapp,ldapadmin,geonetwork/web,geowebcache-webapp -PdebianPackage -DskipTests
-
+	cd config/; \
+	../mvn -Dserver=template install
 
 # all
 all: war-build-georchestra deb-build-georchestra docker-build


### PR DESCRIPTION
This PR fix build of docker images with Makefile, it build config and common modules before building other webapps.
Same as https://github.com/georchestra/georchestra/pull/1739 but on 16.12