### PR TITLE
create dirs for volumes and grant ownership

### DIFF
--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp", "/run/jetty" ]

--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp", "/run/jetty" ]

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/catalogapp/src/docker/Dockerfile
+++ b/catalogapp/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp", "/run/jetty" ]

--- a/catalogapp/src/docker/Dockerfile
+++ b/catalogapp/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/downloadform/src/docker/Dockerfile
+++ b/downloadform/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp", "/run/jetty" ]

--- a/downloadform/src/docker/Dockerfile
+++ b/downloadform/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
+RUN mkdir -p /var/local/extracts && \
+    chown jetty:jetty /var/local/extracts
+
 VOLUME [ "/var/local/extracts", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-RUN mkdir -p /var/local/extracts && \
-    chown jetty:jetty /var/local/extracts
+RUN mkdir -p /etc/georchestra /var/local/extracts && \
+    chown jetty:jetty /etc/georchestra /var/local/extracts
 
 VOLUME [ "/var/local/extracts", "/tmp", "/run/jetty" ]
 

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-RUN mkdir -p /etc/georchestra /var/local/extracts && \
+RUN mkdir /etc/georchestra /var/local/extracts && \
     chown jetty:jetty /etc/georchestra /var/local/extracts
 
 VOLUME [ "/var/local/extracts", "/tmp", "/run/jetty" ]

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -15,6 +15,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
 
 ADD . /
 
+RUN mkdir -p /var/local/geoserver /var/local/geodata /var/local/tiles && \
+    chown jetty:jetty /var/local/geoserver /var/local/geodata /var/local/tiles
+
 VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra /var/local/geoserver /var/local/geodata /var/local/tiles && \
+RUN mkdir /etc/georchestra /var/local/geoserver /var/local/geodata /var/local/tiles && \
     chown jetty:jetty /etc/georchestra /var/local/geoserver /var/local/geodata /var/local/tiles
 
 VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp", "/run/jetty" ]

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -15,8 +15,8 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
 
 ADD . /
 
-RUN mkdir -p /var/local/geoserver /var/local/geodata /var/local/tiles && \
-    chown jetty:jetty /var/local/geoserver /var/local/geodata /var/local/tiles
+RUN mkdir -p /etc/georchestra /var/local/geoserver /var/local/geodata /var/local/tiles && \
+    chown jetty:jetty /etc/georchestra /var/local/geoserver /var/local/geodata /var/local/tiles
 
 VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp", "/run/jetty" ]
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -6,8 +6,8 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /var/local/tiles && \
-    chown jetty:jetty /var/local/tiles
+RUN mkdir -p /etc/georchestra /var/local/tiles && \
+    chown jetty:jetty /etc/georchestra /var/local/tiles
 
 VOLUME [ "/var/local/tiles", "/tmp", "/run/jetty" ]
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra /var/local/tiles && \
+RUN mkdir /etc/georchestra /var/local/tiles && \
     chown jetty:jetty /etc/georchestra /var/local/tiles
 
 VOLUME [ "/var/local/tiles", "/tmp", "/run/jetty" ]

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /var/local/tiles && \
+    chown jetty:jetty /var/local/tiles
+
 VOLUME [ "/var/local/tiles", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp", "/run/jetty" ]

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp" ]

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp" ]
 
 CMD ["sh", "-c", "exec java \

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-RUN mkdir -p /var/local/uploads && \
-    chown jetty:jetty /var/local/uploads
+RUN mkdir -p /etc/georchestra /var/local/uploads && \
+    chown jetty:jetty /etc/georchestra /var/local/uploads
 
 VOLUME [ "/var/local/uploads", "/tmp", "/run/jetty" ]
 

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
-RUN mkdir -p /etc/georchestra /var/local/uploads && \
+RUN mkdir /etc/georchestra /var/local/uploads && \
     chown jetty:jetty /etc/georchestra /var/local/uploads
 
 VOLUME [ "/var/local/uploads", "/tmp", "/run/jetty" ]

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && \
 
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
+RUN mkdir -p /var/local/uploads && \
+    chown jetty:jetty /var/local/uploads
+
 VOLUME [ "/var/local/uploads", "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
-RUN mkdir -p /etc/georchestra && \
+RUN mkdir /etc/georchestra && \
     chown jetty:jetty /etc/georchestra
 
 VOLUME [ "/tmp", "/run/jetty" ]

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+RUN mkdir -p /etc/georchestra && \
+    chown jetty:jetty /etc/georchestra
+
 VOLUME [ "/tmp", "/run/jetty" ]
 
 CMD ["sh", "-c", "exec java \


### PR DESCRIPTION
Having `jetty` owning the `/var/local/tiles` folder is required to let gwc create new folders.

Same is true for the georchestra datadir folder, which is thus writeable by user whose uid is 999