### PR TITLE
[Mapfishapp] Enable text selection in gridviews

### DIFF
--- a/mapfishapp/src/main/webapp/app/css/main.css
+++ b/mapfishapp/src/main/webapp/app/css/main.css
@@ -519,3 +519,8 @@ div.olMapViewport {
 	background-color: #fff;
 }
 
+.x-selectable, .x-selectable * {
+        -moz-user-select: text!important;
+        -khtml-user-select: text!important;
+}
+

--- a/mapfishapp/src/main/webapp/app/js/GEOR.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR.js
@@ -91,6 +91,16 @@ Ext.namespace("GEOR");
             return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
         };
     }
+    
+    // Redefine the grid template to enable text selection
+    if (!Ext.grid.GridView.prototype.templates) {
+        Ext.grid.GridView.prototype.templates = {};
+    }
+    Ext.grid.GridView.prototype.templates.cell = new Ext.Template(
+        '<td class="x-grid3-col x-grid3-cell x-grid3-td-{id} x-selectable {css}" style="{style}" tabIndex="0" {cellAttr}>',
+        '<div class="x-grid3-cell-inner x-grid3-col-{id}" {attr}>{value}</div>',
+        '</td>'
+    );
 })();
 
 


### PR DESCRIPTION
As discussed in those threads : 
https://github.com/georchestra/georchestra/issues/1753
https://github.com/georchestra/cadastrapp/issues/341

This PR enable to select text in gridviews (GFI results, addons results tabs, ...) and copy/paste it.

Seems like it doesn't break anything, but just tested since 3~4 days, so need to confirm with more time.

After that it could be a good thing to backport it on 16.12 & 15.12