### PR TITLE
proxy - homogeneized 503 page which does not request /header

### DIFF
--- a/config/defaults/security-proxy/403.jsp
+++ b/config/defaults/security-proxy/403.jsp
@@ -1,6 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="s" %>
 
 <!DOCTYPE html>

--- a/config/defaults/security-proxy/404.jsp
+++ b/config/defaults/security-proxy/404.jsp
@@ -1,6 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="s" %>
 
 <!DOCTYPE html>

--- a/config/defaults/security-proxy/503.jsp
+++ b/config/defaults/security-proxy/503.jsp
@@ -1,26 +1,46 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="s" %>
 
-<!DOCTYPE html>
-<!--TODO: set appropriate lang-->
-<!--TODO: favicon-->
-<html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title><s:message code="503.title"/></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href='/_static/bootstrap_3.0.0/css/bootstrap.min.css' rel="stylesheet" />
-</head>
-
-<body>
-  <%@ include file="header.jsp" %>
-  <div class="container">
-    <div class="page-header">
-      <h1><s:message code="503.title"/></h1>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta name="robots" content="none" />
+    <meta name="googlebot" content="noarchive" />
+    <title><s:message code="503.title"/></title>
+    <style type="text/css">
+      body {
+        background-color:#e6e6e6;
+        font-family:Calibri;
+        text-align:center;
+      }
+      #wrapper {
+        background:#fff;
+        width:492px;
+        position:relative;
+        margin-left:auto;
+        margin-right:auto;
+        text-align:left;
+        border:3px solid #999;
+        overflow:hidden;
+	    padding: 30px;
+        border-bottom-right-radius: 16px;
+        border-bottom-left-radius: 16px;
+      }
+      #wrapper p {
+        padding:5px;
+      }
+    </style>
+  </head>
+  <body lang=FR>
+    <div id="wrapper">
+      <img src="http://www.georchestra.org/public/logos/georchestra_logo.png" alt="geOrchestra" />
+      <s:message code="503.body"/>
     </div>
-    <p class="lead"><s:message code="503.body"/></p>
-  </div>
-</body>
+  </body>
+  <script>
+    window.setTimeout(function() {window.location.href = window.location.href}, 5000);
+  </script>
 </html>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application.properties
@@ -4,6 +4,5 @@
 403.title=Forbidden
 404.body=Resource not found.
 404.title=404 error
-503.title=503 - Service unavailable
-503.body=The remote server did not answer (Unknown host or connection refused).
-
+503.title=Service unavailable
+503.body=<p>The service is momentarily unavailable...</p><p>We're sorry for the inconvenience.</p><p>Please do not close this tab: the requested page will show up automagically when available.</p>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -4,5 +4,5 @@
 403.title=Geschützter Bereich
 404.body=Ressource wurde nicht gefunden.
 404.title=Fehler 404
-503.title=Dienst nicht verfügbar
-503.body=<p>Der Service ist momentan nicht verfügbar ...</p><p>Es tut uns leid für die Unannehmlichkeiten.</p><p>Bitte schließe diesen Tab nicht ein: Die angeforderte Seite wird automatisch angezeigt, wenn verfügbar.<p>
+503.title=Dienst in Wartung
+503.body=<p>Aufgrund eines Wartungsbetriebes ist der angefragte Dienst zurzeit nicht verfügbar.</p><p>Vielen Dank für Ihr Verständnis.</p><p>Bitte schließen Sie diese Seite nicht: sobald der Dienst wieder betriebsbereit sein wird, wird die angefragte Seite angezeigt werden.<p>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -4,5 +4,5 @@
 403.title=Geschützter Bereich
 404.body=Ressource wurde nicht gefunden.
 404.title=Fehler 404
-503.title=Nicht verfügbar
-503.body=<p>The service is momentarily unavailable...</p><p>We're sorry for the inconvenience.</p><p>Please do not close this tab: the requested page will show up automagically when available.</p>
+503.title=Dienst nicht verfügbar
+503.body=<p>Der Service ist momentan nicht verfügbar ...</p><p>Es tut uns leid für die Unannehmlichkeiten.</p><p>Bitte schließe diesen Tab nicht ein: Die angeforderte Seite wird automatisch angezeigt, wenn verfügbar.<p>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -4,5 +4,5 @@
 403.title=Geschützter Bereich
 404.body=Ressource wurde nicht gefunden.
 404.title=Fehler 404
-503.body=Service nicht verfügbar
-503.title=503 - Nicht verfügbar
+503.title=Nicht verfügbar
+503.body=<p>The service is momentarily unavailable...</p><p>We're sorry for the inconvenience.</p><p>Please do not close this tab: the requested page will show up automagically when available.</p>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -4,5 +4,5 @@
 403.title=Prohibido
 404.body=Recurso no encontrado.
 404.title=Error 404
-503.title=Servicio mantenimiento
-503.body=<p>Debido al mantenimiento, el servicio solicitado no está disponible temporalmente</p><p>Gracias por su comprensión</p><p>Por favor, no cierre esta pestaña: la página solicitada aparecerá automágicamente cuando esté disponible.</p>
+503.title=Servicio en mantenimiento
+503.body=<p>Por causa de una operación de mantenimiento, el servicio solicitado esta momentaneamente indisponible.</p><p>Agradecemos su comprensión.</p><p>No cierre esta pestaña: la página solicitada aparecerá apenas el servicio esté nuevamente operativo.</p>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -4,5 +4,5 @@
 403.title=Prohibido
 404.body=Recurso no encontrado.
 404.title=Error 404
-503.title=Service unavailable
-503.body=El servidor no ha respondido
+503.title=Servicio mantenimiento
+503.body=<p>Debido al mantenimiento, el servicio solicitado no está disponible temporalmente</p><p>Gracias por su comprensión</p><p>Por favor, no cierre esta pestaña: la página solicitada aparecerá automágicamente cuando esté disponible.</p>

--- a/security-proxy/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/security-proxy/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -4,5 +4,5 @@
 403.title=Accès interdit
 404.body=Ressource introuvable.
 404.title=Erreur 404
-503.title=Erreur 503 - Service non disponible
-503.body=Le serveur distant n'a pas répondu.
+503.title=Service en maintenance
+503.body=<p>En raison d’une opération de maintenance, le service demandé est momentanément indisponible.</p><p>Nous vous remercions de votre compréhension.</p><p>Ne fermez pas cet onglet : la page demandée s’affichera dès que le service sera de nouveau opérationnel.</p>


### PR DESCRIPTION
WIP to homogeneize the sp-provided 503 page with the one we recommend for the apache config (cf `ErrorDocument 503 /errors/50x.html` in 
 https://github.com/georchestra/georchestra/blob/16.12/docs/setup/apache.md#configuration and https://github.com/georchestra/htdocs/blob/master/errors/50x.html) 

This way, users are more or less presented the same, consistent, error page when the SP or the proxified webapps are down.

In addition, this PR removes the call to `/header` in the 503 page (header might also be down !)

To be thorougly tested and improved (translations), and backported to 16.12 when ready.