### PR TITLE
OGC statistics - Reopens the JDBC connection if closed

### DIFF
--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/DataServicesConfiguration.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/DataServicesConfiguration.java
@@ -72,12 +72,12 @@ public final class DataServicesConfiguration {
 
 		Class.forName("org.postgresql.Driver");
 
-		if(this.connection == null){
+		if ((this.connection == null) || (this.connection.isClosed())) {
 			synchronized (this) {
-				
 				this.connection = DriverManager.getConnection(this.jdbcURL, this.user, this.password);
 			}
 		}
+
 		return this.connection;
 	}
 


### PR DESCRIPTION
It seems that the network connection to the database used to persist OGC statistics entry can be closed, and nothing in the code was done to detect it. This commit proposes to reopen the connection in case it is detected as closed.

Note: a clearly proper way to address this issue would be to introduce c3p0 to this module.

Tests: clean package ok. Would deserve runtime tests.

Motivations: see
https://github.com/camptocamp/georchestra-rennes-configuration/issues/611