### PR TITLE
docker ldap - index o field

### DIFF
--- a/ldap/docker/indexes.ldif
+++ b/ldap/docker/indexes.ldif
@@ -10,3 +10,4 @@ olcDbIndex: cn,uid eq
 add: olcDbIndex
 olcDbIndex: cn eq,sub,subfinal
 olcDbIndex: uid eq
+olcDbIndex: o eq


### PR DESCRIPTION
This is to fix warnings reported by the LDAP container:
```
04/08/2017 09:28:135984220d <= bdb_equality_candidates: (o) not indexed
```