### PR TITLE
Fix failed docker build because upstream image change

### DIFF
--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/catalogapp/src/docker/Dockerfile
+++ b/catalogapp/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/downloadform/src/docker/Dockerfile
+++ b/downloadform/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
    rm -rf /var/lib/apt/lists/*
@@ -14,6 +17,9 @@ RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
 RUN mkdir /var/local/extracts && \
     chown jetty:jetty /etc/georchestra /var/local/extracts
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/var/local/extracts", "/tmp", "/run/jetty" ]
 

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -2,6 +2,11 @@ FROM jetty:9.2-jre7
 
 ENV XMS=1536M XMX=8G
 
+RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
+
+# Temporary switch to root
+USER root
+
 RUN echo "deb http://httpredir.debian.org/debian jessie main contrib" > /etc/apt/sources.list \
     && echo "deb http://security.debian.org/ jessie/updates main contrib" >> /etc/apt/sources.list \
     && echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections \
@@ -11,12 +16,15 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main contrib" > /etc/apt
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats,jndi
-
 ADD . /
 
 RUN mkdir /var/local/geoserver /var/local/geodata /var/local/tiles && \
     chown jetty:jetty /etc/georchestra /var/local/geoserver /var/local/geodata /var/local/tiles
+
+RUN sed -i 's/threads.max=200/threads.max=50/g' /var/lib/jetty/start.d/server.ini
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/var/local/geoserver", "/var/local/geodata", "/var/local/tiles", "/tmp", "/run/jetty" ]
 

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -4,10 +4,29 @@ ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
+# Temporary switch to root
+USER root
+
+# add non-free for imageio
+RUN echo "deb http://ftp.fr.debian.org/debian jessie contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ jessie/updates contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y libjai-core-java libjai-imageio-core-java && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/share/java/jai_core.jar /var/lib/jetty/lib/ext/ && \
+    ln -s /usr/share/java/jai_codec.jar /var/lib/jetty/lib/ext/ && \
+    ln -s /usr/share/java/mlibwrapper_jai.jar /var/lib/jetty/lib/ext/ && \
+    ln -s /usr/share/java/jai_imageio.jar /var/lib/jetty/lib/ext/ && \
+    ln -s /usr/share/java/clibwrapper_jiio.jar /var/lib/jetty/lib/ext/
+
 ADD . /
 
 RUN mkdir /var/local/tiles && \
     chown jetty:jetty /etc/georchestra /var/local/tiles
+
+# restore jetty user
+USER jetty
 
 VOLUME [ "/var/local/tiles", "/tmp", "/run/jetty" ]
 

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/ldapadmin/src/docker/Dockerfile
+++ b/ldapadmin/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp" ]
 

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
    rm -rf /var/lib/apt/lists/*
@@ -14,6 +17,9 @@ RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
 
 RUN mkdir /var/local/uploads && \
     chown jetty:jetty /etc/georchestra /var/local/uploads
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/var/local/uploads", "/tmp", "/run/jetty" ]
 

--- a/security-proxy/src/docker/Dockerfile
+++ b/security-proxy/src/docker/Dockerfile
@@ -6,7 +6,13 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN chown jetty:jetty /etc/georchestra
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/tmp", "/run/jetty" ]
 


### PR DESCRIPTION
New jetty docker image now set user as jetty also for build step, so we
cannot add package. This commit temporary switch to root user for
installaing packages.
See :
https://github.com/appropriate/docker-jetty/commit/19b433117c3c22550ce87be81cbb6f6952890928#diff-dad6c4a2a53860754faaf15e201d8b0d