### PR TITLE
ldapadmin - ensure build is idempotent in regards to JS/CSS resources

### DIFF
--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -408,6 +408,18 @@
     <finalName>${project.artifactId}-${server}</finalName>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${project.basedir}/node</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <version>2.6</version>
         <configuration>
@@ -581,7 +593,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>install-node-and-npm</id>


### PR DESCRIPTION
* Bump to maven-frontend-plugin v1.6 (see https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md, which seems to fix some thread safety issues in v1.4)
* Removes the `node/` directory when calling maven clean target

Possible related issues:

* https://github.com/georchestra/georchestra/issues/1780
* (private) https://github.com/camptocamp/georchestra-georhena-configuration/issues/45

Tests: Compilation + runtime, UI seems OK when launched in jetty:run