### PR TITLE
extractor - fixing anonymous extracts

### DIFF
--- a/extractorapp/src/test/java/org/georchestra/extractorapp/ws/extractor/task/ExtractionTaskTest.java
+++ b/extractorapp/src/test/java/org/georchestra/extractorapp/ws/extractor/task/ExtractionTaskTest.java
@@ -37,16 +37,17 @@ public class ExtractionTaskTest {
 
     private boolean pgAvailable;
     private int beforeCount;
+
     @Before
     public void setUp() throws Exception {
         try {
             Connection c = dataSource.getConnection();
             this.beforeCount = getLayerLogCount(c);
         } catch(Exception e) {
-            pgAvailable = false;
+            this.pgAvailable = false;
+            return;
         }
-        pgAvailable = true;
-
+        this.pgAvailable = true;
     }
 
     private int getLayerLogCount(Connection c) throws Exception {

--- a/extractorapp/src/test/java/org/georchestra/extractorapp/ws/extractor/task/ExtractionTaskTest.java
+++ b/extractorapp/src/test/java/org/georchestra/extractorapp/ws/extractor/task/ExtractionTaskTest.java
@@ -1,0 +1,76 @@
+package org.georchestra.extractorapp.ws.extractor.task;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.UUID;
+
+import org.georchestra.extractorapp.ws.extractor.ExtractorLayerRequest;
+import org.georchestra.extractorapp.ws.extractor.RequestConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.ReflectionUtils;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:task-context.xml" })
+public class ExtractionTaskTest {
+
+    @Autowired
+    private ComboPooledDataSource dataSource;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private boolean pgAvailable;
+    private int beforeCount;
+    @Before
+    public void setUp() throws Exception {
+        try {
+            Connection c = dataSource.getConnection();
+            this.beforeCount = getLayerLogCount(c);
+        } catch(Exception e) {
+            pgAvailable = false;
+        }
+        pgAvailable = true;
+
+    }
+
+    private int getLayerLogCount(Connection c) throws Exception {
+        Statement s = c.createStatement();
+        ResultSet r = s.executeQuery("SELECT COUNT(*) AS rowCount FROM extractorapp.extractor_log");
+        r.next();
+        int ret = r.getInt("rowCount");
+        r.close();
+        return ret;
+    }
+
+    @Test
+    public void testAnonymousExtractionRequestStatSetRunning() throws Exception {
+        assumeTrue("No postgresql available for this test", this.pgAvailable);
+        File testDir = tempFolder.newFolder();
+        RequestConfiguration rc = new RequestConfiguration(new ArrayList<ExtractorLayerRequest>(), UUID.randomUUID(), null, null, true, null, null, null, null,
+                "localhost", testDir.toString(), 10000000, true, false, null, null);
+        ExtractionTask et = new ExtractionTask(rc, this.dataSource);
+        Method m = ReflectionUtils.findMethod(et.getClass(), "statSetRunning");
+        m.setAccessible(true);
+
+        ReflectionUtils.invokeMethod(m, et);
+
+        int afterCount = getLayerLogCount(dataSource.getConnection());
+        assertTrue("Expected to have saved at least one record in DB", afterCount > this.beforeCount);
+    }
+}

--- a/extractorapp/src/test/resources/task-context.xml
+++ b/extractorapp/src/test/resources/task-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context
+    http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+  <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource">
+    <property name="driverClass" value="org.hsqldb.jdbc.JDBCDriver" />
+    <property name="jdbcUrl" value="jdbc:postgresql://localhost:5432/georchestra?user=georchestra&amp;password=georchestra" />
+  </bean>
+
+
+</beans>


### PR DESCRIPTION
Bare-metal sql queries won't pass if the spec contains empty (null) fields, especially the roles.split(",") call, leaving the extraction in an unknown (but running) state which never end up.

Tests:
* Integration test added, but requires a PostGIS db with the extractor schema (since one extractor db log requires a geometry column).
* Already tested on georhena-prod by redeploying modified class files