### PR TITLE
security-proxy - Remove custom HTTP Host header

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -321,7 +321,7 @@ public class Proxy {
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "URL is not allowed.");
                 return;
             }
-            handleRequest(request, response, type, sURL, false);
+            handleRequest(request, response, type, sURL);
         } else {
             handlePathEncodedRequests(request, response, type);
         }
@@ -548,7 +548,7 @@ public class Proxy {
                 }
             }
 
-            handleRequest(request, response, requestType, sURL, true);
+            handleRequest(request, response, requestType, sURL);
         } catch (IOException e) {
             logger.error("Error connecting to client", e);
         }
@@ -623,7 +623,7 @@ public class Proxy {
         }
     }
 
-    private void handleRequest(HttpServletRequest request, HttpServletResponse finalResponse, RequestType requestType, String sURL, boolean localProxy) {
+    private void handleRequest(HttpServletRequest request, HttpServletResponse finalResponse, RequestType requestType, String sURL) {
         HttpClientBuilder htb = HttpClients.custom().disableRedirectHandling();
 
         RequestConfig config = RequestConfig.custom().setSocketTimeout(this.httpClientTimeout).build();
@@ -690,20 +690,6 @@ public class Proxy {
                 logger.error("Unable to log the request into the statistics logger", e);
             }
 
-            if (localProxy) {
-                //
-                // Hack for geoserver
-                // Should not be here. We must use a ProxyTarget class and
-                // define
-                // if Host header should be forwarded or not.
-                //
-                request.getHeader("Host");
-                proxyingRequest.setHeader("Host", request.getHeader("Host"));
-
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Host header set to: " + proxyingRequest.getFirstHeader("Host").getValue() + " for proxy request.");
-                }
-            }
             proxiedResponse = executeHttpRequest(httpclient, proxyingRequest);
             StatusLine statusLine = proxiedResponse.getStatusLine();
             statusCode = statusLine.getStatusCode();


### PR DESCRIPTION
In order to fix an outdated geoserver bug, Host header is modified to
match original request. So Host header does not match host used in URL.
This can lead to error when using virtual host based on host with
apache.