### PR TITLE
Fix Ext.isIE not detecting IE11

### DIFF
--- a/extractorapp/src/main/webapp/app/js/GEOR.js
+++ b/extractorapp/src/main/webapp/app/js/GEOR.js
@@ -179,6 +179,9 @@ Ext.namespace("GEOR");
             cancel: tr("Cancel")
         });
 
+        Ext.isIE11 = navigator.userAgent.toLowerCase().lastIndexOf('rv:11') > -1;
+        Ext.isIE = Ext.isIE || Ext.isIE11;
+
         /*
          * Initialize the application.
          */

--- a/mapfishapp/src/main/webapp/app/js/GEOR.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR.js
@@ -154,6 +154,9 @@ Ext.namespace("GEOR");
             cancel: tr("Cancel")
         });
 
+        Ext.isIE11 = navigator.userAgent.toLowerCase().lastIndexOf('rv:11') > -1;
+        Ext.isIE = Ext.isIE || Ext.isIE11;
+
         /*
          * Setting of proj4js global vars.
          */


### PR DESCRIPTION
IE11 is not supported by ExtJS 3.4.1.1, which means, at least, that ExtJS does not detect this newer browser. See https://stackoverflow.com/questions/21881671/ext-isie-return-false-in-ie-11 for reference.

A side effect is that IE11 runs extractorapp code that is dedicated to other browsers: https://github.com/georchestra/georchestra/blob/ce0636f2022b96064056ef3892267bb259c58a92/extractorapp/src/main/webapp/app/js/GEOR_layerstree.js#L677-L701 (and it fails to run it, which results in extractorapp hanging indefinitely when loading a raster layer with an iso MetadataUrl filled in the capabilities)

The current fix addresses this issue.