### PR TITLE
Add libgeos-dev package to use spatialite-3.7.22.4-libspatialitejdbc.so

### DIFF
--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://httpredir.debian.org/debian stretch main contrib" > /etc/ap
     && echo "deb http://security.debian.org/ stretch/updates main contrib" >> /etc/apt/sources.list \
     && echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections \
     && apt-get update \
-    && apt-get install -y ttf-mscorefonts-installer \
+    && apt-get install -y ttf-mscorefonts-installer libgeos-dev libproj-dev \
     && apt-get clean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Should fix following warning :
  java.lang.UnsatisfiedLinkError:
  /tmp/jetty/spatialite-3.7.22.4-libspatialitejdbc.so: libgeos_c.so.1:
  cannot open shared object file: No such file or directory