### PR TITLE
add healthchecks to ldap and db containers

### DIFF
--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -23,3 +23,10 @@ RUN chmod +x /docker-entrypoint.d/*
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 CMD [ "slapd", "-d", "32768", "-u", "openldap", "-g", "openldap" ]
+
+HEALTHCHECK --interval=30s --timeout=10s \
+  CMD ldapsearch \
+      -D "cn=admin,dc=georchestra,dc=org" \
+      -w "${SLAPD_PASSWORD}" \
+      -b "dc=georchestra,dc=org" \
+      "cn=geoserver_privileged_user,ou=users,dc=georchestra,dc=org"

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -14,3 +14,6 @@ RUN apt-get update && \
 
 COPY [0-9][0-9]* fix-owner.sql license.txt logo.png /docker-entrypoint-initdb.d/
 RUN chown -R postgres /docker-entrypoint-initdb.d/
+
+HEALTHCHECK --interval=30s --timeout=30s \
+  CMD pg_isready -U postgres


### PR DESCRIPTION
Slightly related with #1867 : this PR adds healthchecks to the ldap and db images.

`docker inspect` on these running containers displays the expected information:
```json
[
    {
        "Id": "7ad6cba71a13ea5a866cedd470ff50650d4438ccf76eec3a78914e466ff18c58",
        "Created": "2018-01-09T09:31:12.206153472Z",
        "Path": "docker-entrypoint.sh",
        "Args": [
            "postgres"
        ],
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 21826,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2018-01-09T09:31:13.043832084Z",
            "FinishedAt": "0001-01-01T00:00:00Z",
            "Health": {
                "Status": "healthy",
                "FailingStreak": 0,
                "Log": [
                    {
                        "Start": "2018-01-09T10:31:43.065702341+01:00",
                        "End": "2018-01-09T10:31:43.165317721+01:00",
                        "ExitCode": 0,
                        "Output": "/var/run/postgresql:5432 - accepting connections\n"
                    }
                ]
            }
        },
       ...
```
and
```json
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 20154,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2018-01-09T09:28:16.195555735Z",
            "FinishedAt": "0001-01-01T00:00:00Z",
            "Health": {
                "Status": "healthy",
                "FailingStreak": 0,
                "Log": [{
                    "Start": "2018-01-09T10:28:46.210636135+01:00",
                    "End": "2018-01-09T10:28:46.258844896+01:00",
                    "ExitCode": 0,
                    "Output": "# extended LDIF\n#\n# LDAPv3\n# base \u003cdc=georchestra,dc=org\u003e with scope subtree\n# filter: cn=geoserver_privileged_user,ou=users,dc=georchestra,dc=org\n# requesting: ALL\n#\n\n# search result\nsearch: 2\nresult: 0 Success\n\n# numResponses: 1\n"
                }]
            }
        },
 ...
```


