### PR TITLE
[WIP] Fixing Security-Proxy Spring-Security version bump

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>${log4j1.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <version>${log4j1.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -287,7 +287,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>${log4j1.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>${log4j1.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>${log4j1.version}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -172,7 +172,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>${log4j1.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/ogc-server-statistics/pom.xml
+++ b/ogc-server-statistics/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
+                        <version>${log4j1.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <!-- default when building without a profile specified -->
     <confdir>${project.build.directory}/conf</confdir>
     <encoding>UTF-8</encoding>
+    <log4j1.version>1.2.17</log4j1.version>
     <georchestra.version>${project.version}</georchestra.version>
     <postTreatmentScript><![CDATA[
 

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -152,6 +152,11 @@
       <artifactId>commons-net</artifactId>
       <version>3.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>1.7.25</version>
+    </dependency>
   </dependencies>
   <build>
     <finalName>ROOT-${server}</finalName>

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -250,7 +250,7 @@ public class Proxy {
 
     /* ---------- end work around for no gateway option -------------- */
 
-    @RequestMapping(params = "login", method = { GET, POST })
+    @RequestMapping(value= "**", params = "login", method = { GET, POST })
     public void login(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, URISyntaxException {
         String uri = request.getRequestURI();
         if (uri.startsWith("sec")) {

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -427,32 +427,32 @@ public class Proxy {
 
     // ----------------- Method calls where request is encoded in path of
     // request ----------------- //
-    @RequestMapping(params = { "!url", "!login" }, method = RequestMethod.GET)
+    @RequestMapping(value="**", params = { "!url", "!login" }, method = RequestMethod.GET)
     public void handleGETRequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response, RequestType.GET);
     }
 
-    @RequestMapping(params = { "!url", "!login" }, method = RequestMethod.POST)
+    @RequestMapping(value="**", params = { "!url", "!login" }, method = RequestMethod.POST)
     public void handlePOSTRequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response, RequestType.POST);
     }
 
-    @RequestMapping(params = { "!url", "!login" }, method = RequestMethod.DELETE)
+    @RequestMapping(value="**", params = { "!url", "!login" }, method = RequestMethod.DELETE)
     public void handleDELETERequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response, RequestType.DELETE);
     }
 
-    @RequestMapping(params = { "!url", "!login" }, method = RequestMethod.HEAD)
+    @RequestMapping(value="**", params = { "!url", "!login" }, method = RequestMethod.HEAD)
     public void handleHEADRequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response, RequestType.HEAD);
     }
 
-    @RequestMapping(params = { "!url", "!login" }, method = RequestMethod.OPTIONS)
+    @RequestMapping(value="**", params = { "!url", "!login" }, method = RequestMethod.OPTIONS)
     public void handleOPTIONSRequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response, RequestType.OPTIONS);
     }
 
-    @RequestMapping(params = { "!url", "!login" }, method = RequestMethod.PUT)
+    @RequestMapping(value="**", params = { "!url", "!login" }, method = RequestMethod.PUT)
     public void handlePUTRequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response, RequestType.PUT);
     }


### PR DESCRIPTION
Following previous PR (https://github.com/georchestra/georchestra/pull/1843 and https://github.com/georchestra/georchestra/pull/1880):

* At runtime in georchestra-datadir mode, the webapp instanciation is broken because of a version mismatch between `log4j-over-slf4j` transitively needed by the new version of the cas-client. Fixed by bumping to a newer version of `log4j-over-slf4j`.

* The new version of spring introduced by the previous changes requires now to specify the value parameter of the `RequestMapping` annotation.

Tests: Tested at runtime onto sandbox.georchestra.org. 
* [x] analytics
* [x] extractorapp
* [x] header
* [x] ldapadmin
* [x] mapfishapp
* [x] security-proxy

No deploy issues encountered so far.

Note: The logging management in geOrchestra is currently a bit messy, we might consider migrate to logback, but we don't really have a hand on the transitive dependencies ...

Note 2: The version bump has been done in the 16.12 version, so it might require a backport to this branch.
