### PR TITLE
Makefile - fixing GS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,17 @@ docker-build-gn3: docker-pull-jetty
 	../../mvn -P docker -DskipTests package docker:build
 
 docker-build-geoserver: docker-pull-jetty
-	cd geoserver/geoserver-submodule/src; \
-	rm -rf ../data/citewfs-1.1/workspaces/sf/sf/E*; \
-	LANG=C ../../../mvn clean install -DskipTests; \
-	cd ../../webapp; \
+	cd geoserver/; \
+	rm -rf geoserver-submodule/data/citewfs-1.1/workspaces/sf/sf/E*; \
+	LANG=C ../mvn clean install -DskipTests; \
+	cd webapp; \
 	../../mvn clean install docker:build -Pdocker,colormap,mbtiles,spatialite,wps-download,app-schema,control-flow,csw,feature-pregeneralized,gdal,importer,inspire,libjpeg-turbo,monitor,pyramid,wps -DskipTests
 
 docker-build-geoserver-geofence: docker-pull-jetty
-	cd geoserver/geoserver-submodule/src; \
-	rm -fr ../data/citewfs-1.1/workspaces/sf/sf/E*; \
-	LANG=C ../../../mvn clean install -Pgeofence-server -DskipTests; \
-	cd ../../webapp; \
+	cd geoserver; \
+	rm -fr geoserver-submodule/data/citewfs-1.1/workspaces/sf/sf/E*; \
+	LANG=C ../mvn clean install -Pgeofence -DskipTests; \
+	cd webapp; \
 	../../mvn clean install docker:build -Pdocker,colormap,mbtiles,spatialite,wps-download,app-schema,control-flow,csw,feature-pregeneralized,gdal,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,geofence -DskipTests
 
 docker-build-ldapadmin: docker-pull-jetty


### PR DESCRIPTION
Sorry, I forgot about this makefile. the pom.xml in geoserver/ now references the modules needed by the build, depending on which profile is activated (mainly geofence or not geofence).

So depending on the chosen build mode, it will generate the specific georchestra geoserver jars in the geoserver-submodule/ subdirectories, which should concern 3 or 4 jars max, the rest comes from the official boundless repositories.

To avoid ambiguity, I only kept the geofence profile in poms, no geofence-server profile anymore, but the needed dependencies should finish in the generated artifact in the end.