### PR TITLE
SP - fixing cookie management

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -140,6 +140,7 @@ public class HeadersManagementStrategy {
         addHeaderToRequestAndLog(proxyRequest, headersLog, SEC_PROXY, "true");
 
         if(localProxy){
+            handleRequestCookies(originalRequest, proxyRequest, headersLog);
             for (HeaderProvider provider : headerProviders) {
 
                 // Don't include headers from security framework for request coming from trusted proxy


### PR DESCRIPTION
Following regression introduced by PR #1874

The cookies are no longer copied to the webapps passing through the SP, which breaks GN (no CSRF sent by the SP to geonetwork anymore).

Tests: runtime (already deployed) on GGE