### PR TITLE
root pom - adding a profile for sentry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,16 @@
   </reporting>
   <profiles>
     <profile>
+      <id>sentry-log4j</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.sentry</groupId>
+          <artifactId>sentry-log4j</artifactId>
+          <version>1.6.7</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>localhost</id>
       <properties>
         <server>localhost</server>


### PR DESCRIPTION
Sentry is an opensource solution to track down errors reported by logs (more info here: https://sentry.io/welcome/).

The java integration with log4j1 (mainly used in geOrchestra) requires to add a dependency (hence the added profile in the root pom / current PR), as well as an env variable `-Dsentry.dsn=...` (though other mechanisms can be used, see doc).

This profile is obviously not mandatory, and should not harm the current build process.
