### PR TITLE
Allow mapfishapp addons service to read html file from addon package

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/AddonController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/AddonController.java
@@ -172,6 +172,8 @@ public class AddonController implements ServletContextAware {
             response.setContentType("image/png");
         } else if (("jpg".equalsIgnoreCase(ext)) || ("jpeg".equalsIgnoreCase(ext))) {
             response.setContentType("image/jpeg");
+        } else if (("htm".equalsIgnoreCase(ext)) || ("html".equalsIgnoreCase(ext))) {
+            response.setContentType("text/html");
         } else {
             response.setContentType("text/plain");
         }


### PR DESCRIPTION
Add only "text/html" contentype

Html file should be contained in addon package.

This will be used in cadastrapp to print on client-side. 
See https://github.com/georchestra/cadastrapp/issues/243