### PR TITLE
poms - deactivating javadoc linting

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -296,6 +296,7 @@ log.info("Finished running variable substitution test")
 				<configuration>
 					<show>private</show>
 					<quiet>true</quiet>
+					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
 				<executions>
 					<execution>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -872,6 +872,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.9</version>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.9</version>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In some JDKs (not all ones though), there is a javadoc linting which makes the build fail, passing the added option avoids this.

Note: cadastrapp does have the same kind of issue here: https://github.com/georchestra/cadastrapp/issues/370