### PR TITLE
mapfishapp - extractorapp - fixing GDAL bindings integration in docker

### DIFF
--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
    rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
+RUN unzip -d /var/lib/jetty/webapps/extractorapp /var/lib/jetty/webapps/extractorapp.war
+RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/webapps/extractorapp/WEB-INF/lib/
 
 RUN mkdir /mnt/extractorapp_extracts && \
     chown jetty:jetty /etc/georchestra /mnt/extractorapp_extracts

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
    rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/lib/ext/
+RUN unzip -d /var/lib/jetty/webapps/mapfishapp /var/lib/jetty/webapps/mapfishapp.war
+RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/webapps/mapfishapp/WEB-INF/lib/
 
 RUN mkdir /mnt/mapfishapp_uploads && \
     chown jetty:jetty /etc/georchestra /mnt/mapfishapp_uploads


### PR DESCRIPTION
From https://github.com/pmauduit/georchestra/commit/0332e62621869a343a2b059142f1039203fce0b3 : if we add gdal.jar to the Jetty classloader, Mfapp via GeoTools will not be able to load the library once again in its own webapp classloader, and GT will consider the binding as unavailable.