### PR TITLE
SP - fixing parameters passed in GET

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -36,14 +36,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -58,12 +55,10 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpUtils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -82,9 +77,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -495,19 +488,17 @@ public class Proxy {
                 String name = p.getName();
                 String value = p.getValue();
                 // Skip login & ticket parameter
-                if (name.equals(ServiceProperties.DEFAULT_CAS_ARTIFACT_PARAMETER) || name.equals("login")) {
+                if (ServiceProperties.DEFAULT_CAS_ARTIFACT_PARAMETER.equals(name) || "login".equals(name)) {
                     continue;
                 }
                 if (query.length() > 1) {
                     query.append('&');
                 }
-                if (value == null) {
-                    query.append(name);
-                    continue;
-                }
                 query.append(name);
-                query.append("=");
-                query.append(value);
+                if (value != null) {
+                    query.append("=");
+                    query.append(value);
+                }
             }
         }
         return query.toString();

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -7,15 +7,22 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicHttpResponse;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.ReflectionUtils;
@@ -137,4 +144,75 @@ public class ProxyTest {
         assertTrue(ret.toString().contains("email=psc%2Btestuser%40georchestra.org"));
     }
 
+    @Test
+    public void testReconstructUrlParametersWithFormEncodedPost() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setRequestURI("http://localhost/header/");
+        mockedRequest.setMethod(HttpMethod.POST.toString());
+        mockedRequest.setContent("param_passed_as_post=true".getBytes());
+        mockedRequest.setQueryString("active=geonetwork&extra=params");
+
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertFalse("POSTed parameters found in the reconstructed query string",
+                ret.contains("param_passed_as_post"));
+    }
+
+    @Test
+    public void testReconstructUrlParametersEmptyStringURI() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setRequestURI("http://localhost/header/");
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertTrue("expected an empty query string", ret.equals(""));
+    }
+
+    @Test
+    public void testReconstructUrlParametersStringURIMultipleValues() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setQueryString("extra=param1&extra=param2&another=param");
+
+        mockedRequest.setRequestURI("http://localhost/header/");
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertTrue("multiple values for parameter name extra", ret.contains("extra=param1") && ret.contains("extra=param2"));
+    }
+
+    @Test
+    public void testReconstructUrlParametersStringURINoValue() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setQueryString("ticket=bbb&login&nonvaluatedparam&5");
+
+        mockedRequest.setRequestURI("http://localhost/geoserver/");
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertTrue("multiple values for parameter name extra", ret.contains("nonvaluatedparam") && ! ret.contains("login")
+                && ! ret.contains("ticket"));
+    }
+
+    @Test
+    public void testReconstructUrlParametersStringURIAccentedChar() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setQueryString("éééààà=àéàéàé");
+
+        mockedRequest.setRequestURI("http://localhost/geoserver/");
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertTrue("Parameters have been mangled", ret.equals("?éééààà=àéàéàé"));
+    }
 }

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -7,18 +7,14 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
-import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicHttpResponse;
 import org.junit.Before;
 import org.junit.Test;
@@ -170,7 +166,7 @@ public class ProxyTest {
         mockedRequest.setRequestURI("http://localhost/header/");
         String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
 
-        assertTrue("expected an empty query string", ret.equals(""));
+        assertTrue("expected an empty query string", "".equals(ret));
     }
 
     @Test
@@ -213,6 +209,6 @@ public class ProxyTest {
         mockedRequest.setRequestURI("http://localhost/geoserver/");
         String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
 
-        assertTrue("Parameters have been mangled", ret.equals("?éééààà=àéàéàé"));
+        assertTrue("Parameters have been mangled", "?éééààà=àéàéàé".equals(ret));
     }
 }


### PR DESCRIPTION
Following the SP revamp, every parameters passed as in a form-encoded POST were also passed as GET parameters to the security-proxified webapps, causing problems with every url-formencoded based pages (CAS server login if behind the SP and geonetwork) .

This PR fixes the logic, so that only parameters present in the URI are copied.

Also there was a potential issue with UTF-8 accented characters, that this commit shall address (only the value of the parameter was encoded).

Tests:
* Unit tests added
* Runtime tested on Jetty using a simple controller
* Runtime tested on Tomcat (sandbox.georchestra.org)