### PR TITLE
GS - bumping to 2.13.0

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -11,8 +11,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <maven.test.skip>true</maven.test.skip>
-    <gs.version>2.12.1</gs.version>
-    <gt.version>18.1</gt.version>
+    <gs.version>2.13.0</gs.version>
+    <gt.version>19.0</gt.version>
     <geofence.version>3.2-SNAPSHOT</geofence.version>
     <jetty.version>9.2.13.v20150730</jetty.version>
     <marlin.version>0.7.5-Unsafe</marlin.version>


### PR DESCRIPTION
There are mainly one issue detected at runtime in case of geofence usage: cache invalidation is not working.

Also while runtime testing on GGE: there seemed to be an issue with their datadir, because the REST interface on `layer.xml` was broken. No idea which layer was causing this.

Note: GS2.13.0 is needed for a certain GS extension only available in GS >= 2.12.3.