### PR TITLE
SP - encode parameter names and values in query string (rework on partial fix in #1992)

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -97,6 +97,7 @@ import org.springframework.security.web.RedirectStrategy;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closer;
@@ -494,10 +495,10 @@ public class Proxy {
                 if (query.length() > 1) {
                     query.append('&');
                 }
-                query.append(name);
+                query.append(UriUtils.encode(name, "UTF-8"));
                 if (value != null) {
                     query.append("=");
-                    query.append(value);
+                    query.append(UriUtils.encode(value, "UTF-8"));
                 }
             }
         }

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -209,6 +209,37 @@ public class ProxyTest {
         mockedRequest.setRequestURI("http://localhost/geoserver/");
         String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
 
-        assertTrue("Parameters have been mangled", "?éééààà=àéàéàé".equals(ret));
+        assertTrue("Unexpected escaped query string", "?%C3%A9%C3%A9%C3%A9%C3%A0%C3%A0%C3%A0=%C3%A0%C3%A9%C3%A0%C3%A9%C3%A0%C3%A9".equals(ret));
+    }
+
+    @Test
+    public void testReconstructUrlParametersStringURIAccentedCharAndSpaces() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setQueryString("ééé ààà=àéàéàé and spaces");
+
+        mockedRequest.setRequestURI("http://localhost/geoserver/");
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertTrue("Unexpected escaped query string",
+                "?%C3%A9%C3%A9%C3%A9%20%C3%A0%C3%A0%C3%A0=%C3%A0%C3%A9%C3%A0%C3%A9%C3%A0%C3%A9%20and%20spaces".equals(ret));
+    }
+
+    @Test
+    public void testReconstructUrlParemetersGeonetwork() throws Exception {
+        Method m = ReflectionUtils.findMethod(Proxy.class, "reconstructUrlParameters", HttpServletRequest.class);
+        m.setAccessible(true);
+
+        MockHttpServletRequest mockedRequest = new MockHttpServletRequest();
+        mockedRequest.setQueryString("_content_type=json&template=y&fast=index&from=1&"
+                + "login&to=200&_isTemplate=y%20or%20n&sortBy=title&sortOrder=reverse");
+
+        mockedRequest.setRequestURI("/geonetwork/srv/eng/qi");
+        String ret = (String) ReflectionUtils.invokeMethod(m, proxy, mockedRequest);
+
+        assertTrue("Unexpected escaped query string",
+        "?_content_type=json&template=y&fast=index&from=1&to=200&_isTemplate=y%20or%20n&sortBy=title&sortOrder=reverse".equals(ret));
     }
 }


### PR DESCRIPTION
This addresses the partial fix from the previous PR (#1992), which transmits parameters without URL-encoding them, which causes issues with GeoNetwork as it sometimes sends parameter values with spaces.

Note: Every servlet containers and/or webservers should understand url-encoded characters, even if the HTTP spec allows the use of UTF-8 chars, I could not manage to encode problematic characters like space and in the same time leaving accented characters.

Tests: 
* utests added / adapted
* runtime tests directly onto a deployed env.