### PR TITLE
mfapp - Docker - remove the war after having unzipped it

### DIFF
--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
    rm -rf /var/lib/apt/lists/*
 
 RUN unzip -d /var/lib/jetty/webapps/mapfishapp /var/lib/jetty/webapps/mapfishapp.war
+RUN rm -f /var/lib/jetty/webapps/mapfishapp.war
 RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/webapps/mapfishapp/WEB-INF/lib/
 
 RUN mkdir /mnt/mapfishapp_uploads && \


### PR DESCRIPTION
It seems that there are some ambiguities if the war is left into the webapps/ subdir, being unzipped by Jetty in its own tempdir and used in place of the actual already unzipped webapp.

This shall address issues with mfprint PNG output format (GSEST-191).