### PR TITLE
SP - discarding the transfer-encoding header in the proxified request

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -118,6 +118,10 @@ public class HeadersManagementStrategy {
                 if (noAcceptEncoding && headerName.equalsIgnoreCase(ACCEPT_ENCODING)) {
                     continue;
                 }
+                // It is the HttpClient's lib duty to add this header accordingly.
+                if (headerName.equalsIgnoreCase(TRANSFER_ENCODING)) {
+                    continue;
+                }
                 if (headerName.equalsIgnoreCase(HOST)) {
                     continue;
                 }
@@ -132,6 +136,7 @@ public class HeadersManagementStrategy {
                 if (referer != null && headerName.equalsIgnoreCase(REFERER_HEADER_NAME)) {
                     continue;
                 }
+                
                 String value = originalRequest.getHeader(headerName);
                 addHeaderToRequestAndLog(proxyRequest, headersLog, headerName, value);
             }


### PR DESCRIPTION
The `transfer-encoding` header is actually set by the HTTP client library used in the SP. Trying to put it by hand before the lib will cause an exception.

We should stay the closest possible from the incoming HTTP request, but here I think we can rely on apache-httpclient to do its job and set the http header correctly.

Tests: runtime on a live env (as a result, this has already been deployed)
