### PR TITLE
GS - fixing dependencies inclusions

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1258,18 +1258,38 @@
               <groupId>org.geoserver.geofence</groupId>
               <artifactId>geofence-model</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>com.vividsolutions</groupId>
+              <artifactId>jts</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-geofence-server</artifactId>
           <version>${gs.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>cglib</groupId>
+              <artifactId>cglib</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.vividsolutions</groupId>
+              <artifactId>jts</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <!-- These are needed in the GeoFence geOrchestra integration but not mandatory in default GF setups -->
         <dependency>
           <groupId>org.hibernatespatial</groupId>
           <artifactId>hibernate-spatial-postgis</artifactId>
           <version>${hibernate-spatial-version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>com.vividsolutions</groupId>
+              <artifactId>jts</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.postgis</groupId>


### PR DESCRIPTION
Fix proposal for #2014

Tests: Only tested at compilation time, using `mvn dependency:tree`. The dependencies are present in the expected versions without activating any maven profile, so I think this PR is quite safe.
