### PR TITLE
Console - Allow roles to be renamed

### DIFF
--- a/console/src/main/webapp/manager/app/components/role/role.es6
+++ b/console/src/main/webapp/manager/app/components/role/role.es6
@@ -18,15 +18,17 @@ class RoleController {
     translate('role.deleted', this.i18n)
     translate('role.deleteError', this.i18n)
 
-    this.role = $injector.get('Role').get({id: $routeParams.role})
-    this.originalID = $routeParams.role
+    // Save original cn in case we change cn, because we need to
+    // use original cn with PUT request
+    this.role = $injector.get('Role').get(
+      {id: $routeParams.role},
+      role => { role.originalID = role.cn })
   }
 
   save () {
     let flash = this.$injector.get('Flash')
     let $httpDefaultCache = this.$injector.get('$cacheFactory').get('$http')
     let $router = this.$injector.get('$router')
-    this.role.originalID = this.originalID
     this.role.$update(() => {
       $httpDefaultCache.removeAll()
       flash.create('success', this.i18n.updated)

--- a/console/src/main/webapp/manager/app/components/role/role.es6
+++ b/console/src/main/webapp/manager/app/components/role/role.es6
@@ -19,14 +19,21 @@ class RoleController {
     translate('role.deleteError', this.i18n)
 
     this.role = $injector.get('Role').get({id: $routeParams.role})
+    this.originalID = $routeParams.role
   }
 
   save () {
     let flash = this.$injector.get('Flash')
     let $httpDefaultCache = this.$injector.get('$cacheFactory').get('$http')
+    let $router = this.$injector.get('$router')
+    this.role.originalID = this.originalID
     this.role.$update(() => {
       $httpDefaultCache.removeAll()
       flash.create('success', this.i18n.updated)
+      $router.navigate($router.generate('role', {
+        role: this.role.cn,
+        tab: 'infos'
+      }))
     }, flash.create.bind(flash, 'danger', this.i18n.error))
   }
 

--- a/console/src/main/webapp/manager/app/services/roles.es6
+++ b/console/src/main/webapp/manager/app/services/roles.es6
@@ -10,7 +10,7 @@ angular.module('manager')
         isArray: false
       },
       update: {
-        params: { id: '@cn' },
+        params: { id: '@originalID' },
         method: 'PUT'
       },
       delete: {

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/roles/RolesControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/roles/RolesControllerTest.java
@@ -301,6 +301,7 @@ public class RolesControllerTest {
         Name dn = LdapNameBuilder.newInstance("ou=roles").add("cn", "newName").build();
         Mockito.doThrow(NameNotFoundException.class).when(ldapTemplate).lookup(eq(dn), (ContextMapper) Mockito.any());
 
+        Mockito.doThrow(NameNotFoundException.class).when(ldapTemplate).lookupContext((Name) Mockito.any());
         roleCtrl.update(request, response, "ADMINISTRATOR");
 
         JSONObject ret = new JSONObject(response.getContentAsString());
@@ -313,11 +314,16 @@ public class RolesControllerTest {
     @Test
     public void testUpdateDuplicateCN() throws Exception {
         request.setContent(" { \"cn\": \"newName\", \"description\": \"new Description\" } ".getBytes());
+
         Role retAdmin = RoleFactory.create("ADMINISTRATOR", "administrator role", false);
-        Mockito.when(ldapTemplate.lookup((Name) Mockito.any(), (ContextMapper) Mockito.any())).thenReturn(retAdmin);
-        Mockito.doThrow(DuplicatedCommonNameException.class).when(ldapTemplate).lookup((Name) Mockito.any(), (AttributesMapper) Mockito.any());
-        Name dn = LdapNameBuilder.newInstance("ou=roles").add("cn", "newName").build();
-        Mockito.doThrow(NameNotFoundException.class).when(ldapTemplate).lookup(eq(dn), (ContextMapper) Mockito.any());
+        Role retNewName = RoleFactory.create("newName", "new Description", false);
+        Name adminDn = LdapNameBuilder.newInstance("ou=roles").add("cn", "ADMINISTRATOR").build();
+        Name newNameDn = LdapNameBuilder.newInstance("ou=roles").add("cn", "newName").build();
+        Mockito.when(ldapTemplate.lookup(eq(adminDn), (ContextMapper) Mockito.any())).thenReturn(retAdmin);
+        Mockito.when(ldapTemplate.lookup(eq(newNameDn), (ContextMapper) Mockito.any())).thenReturn(retNewName);
+
+        DirContextOperations context = Mockito.mock(DirContextOperations.class);
+        Mockito.when(ldapTemplate.lookupContext((Name) Mockito.any())).thenReturn(context);
 
         roleCtrl.update(request, response, "ADMINISTRATOR");
 
@@ -335,6 +341,9 @@ public class RolesControllerTest {
         Mockito.doThrow(DataServiceException.class).when(ldapTemplate).lookup((Name) Mockito.any(), (AttributesMapper) Mockito.any());
         Name dn = LdapNameBuilder.newInstance("ou=roles").add("cn", "newName").build();
         Mockito.doThrow(NameNotFoundException.class).when(ldapTemplate).lookup(eq(dn), (ContextMapper) Mockito.any());
+
+        DirContextOperations context = Mockito.mock(DirContextOperations.class);
+        Mockito.when(ldapTemplate.lookupContext((Name) Mockito.any())).thenReturn(context);
 
         try {
             roleCtrl.update(request, response, "ADMINISTRATOR");
@@ -355,6 +364,9 @@ public class RolesControllerTest {
 
         Name dn = LdapNameBuilder.newInstance("ou=roles").add("cn", "newName").build();
         Mockito.doThrow(NameNotFoundException.class).when(ldapTemplate).lookup(eq(dn), (ContextMapper) Mockito.any());
+
+        DirContextOperations context = Mockito.mock(DirContextOperations.class);
+        Mockito.when(ldapTemplate.lookupContext((Name) Mockito.any())).thenReturn(context);
 
         roleCtrl.update(request, response, "USERS");
 


### PR DESCRIPTION
Fix #1822
* [x] TODO: Change ldap command to avoid deleting and recreating role
instead of using ldap rename command