### PR TITLE
Console - Fix loading of email configuration

### DIFF
--- a/console/src/main/java/org/georchestra/console/mailservice/Email.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/Email.java
@@ -162,11 +162,10 @@ public abstract class Email {
 			LOG.debug("body: "+ msg );
 		}
 
-		final Properties props = System.getProperties();
-        props.put("mail.smtp.host", smtpHost);
-        props.put("mail.protocol.port", smtpPort);
+        final Session session = Session.getInstance(System.getProperties(), null);
+        session.getProperties().setProperty("mail.smtp.host", smtpHost);
+        session.getProperties().setProperty("mail.smtp.port", (new Integer(smtpPort)).toString());
 
-        final Session session = Session.getInstance(props, null);
         final MimeMessage message = new MimeMessage(session);
 
         if (isValidEmailAddress(from)) {

--- a/console/src/main/java/org/georchestra/console/ws/emails/EmailController.java
+++ b/console/src/main/java/org/georchestra/console/ws/emails/EmailController.java
@@ -308,10 +308,9 @@ public class EmailController {
         LOG.debug("EMail request : " + payload.toString());
 
         // Instanciate MimeMessage
-        Properties props = System.getProperties();
-        props.put("mail.smtp.host", this.emailFactory.getSmtpHost());
-        props.put("mail.protocol.port", this.emailFactory.getSmtpPort());
-        Session session = Session.getInstance(props, null);
+        final Session session = Session.getInstance(System.getProperties(), null);
+        session.getProperties().setProperty("mail.smtp.host", this.emailFactory.getSmtpHost());
+        session.getProperties().setProperty("mail.smtp.port", (new Integer(this.emailFactory.getSmtpPort())).toString());
         MimeMessage message = new MimeMessage(session);
 
         // Generate From header
@@ -500,11 +499,9 @@ public class EmailController {
      */
     private void send(EmailEntry email) throws NameNotFoundException, DataServiceException, MessagingException {
 
-        final Properties props = System.getProperties();
-        props.put("mail.smtp.host", this.emailFactory.getSmtpHost());
-        props.put("mail.protocol.port", this.emailFactory.getSmtpPort());
-
-        final Session session = Session.getInstance(props, null);
+        final Session session = Session.getInstance(System.getProperties(), null);
+        session.getProperties().setProperty("mail.smtp.host", this.emailFactory.getSmtpHost());
+        session.getProperties().setProperty("mail.smtp.port", (new Integer(this.emailFactory.getSmtpPort())).toString());
         final MimeMessage message = new MimeMessage(session);
 
         Account recipient = this.accountDao.findByUID(email.getRecipient());


### PR DESCRIPTION
It seems that we cannot populate a Properties and then construct Session
object with the Properties instance. So we need to first create Session
instance and then use setProperty() method on it.

It also seems that we need to use a property called `mail.smtp.port`
instead of `mail.protocol.port`.

Fix #2011