### PR TITLE
[WIP] mapfishapp - Use ogr2ogr to convert KML to geoJson

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagement.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagement.java
@@ -422,7 +422,7 @@ public class UpLoadFileManagement {
      *
      * @return the geofile
      */
-    private String searchGeoFile() {
+    public String searchGeoFile() {
 
         for (String fileName : this.fileDescriptor.listOfFiles) {
 


### PR DESCRIPTION
ogr2ogr only support KML with one layer, so with multiple layers it
fails. We can add the name of the layer to convert on ogr2ogr command
(last parameter) and we can list layers in KML with following commands :

```bash
for layer in "$(ogrinfo -ro -so -q file.kml | cut -d ' ' -f 2)"
do
    ogr2ogr -f "GeoJSON" "file_${layer}.json" file.kml "${layer}"
done
```

Another option is to use : https://mapbox.github.io/togeojson/ to
convert KML and GPX file on client side.