### PR TITLE
LDAPAdmin - migrating to c3p0 datasource

### DIFF
--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -331,6 +331,11 @@
       <version>5.0.3.Final</version>
     </dependency>
     <dependency>
+      <groupId>com.mchange</groupId>
+      <artifactId>c3p0</artifactId>
+      <version>0.9.5.2</version>
+    </dependency>
+    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <version>1.0.0.GA</version>
@@ -347,6 +352,17 @@
       <artifactId>jta</artifactId>
       <version>1.1</version>
       <classifier/>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.ez-vcard</groupId>
+      <artifactId>ez-vcard</artifactId>
+      <version>0.9.7</version>
+    </dependency>
+    <!-- geOrchestra commons -->
+    <dependency>
+      <groupId>org.georchestra</groupId>
+      <artifactId>georchestra-commons</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-pool</groupId>
@@ -387,17 +403,6 @@
           <artifactId>xml-apis</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.ez-vcard</groupId>
-      <artifactId>ez-vcard</artifactId>
-      <version>0.9.7</version>
-    </dependency>
-    <!-- geOrchestra commons -->
-    <dependency>
-      <groupId>org.georchestra</groupId>
-      <artifactId>georchestra-commons</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -123,17 +123,13 @@
     <property name="driverClassName" value="org.postgresql.Driver"/>
   </bean>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" depends-on="waitForDb">
-        <property name="url" value="${psql.url}"/>
-        <property name="username" value="${psql.user}"/>
+    <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource" depends-on="waitForDb">
+        <property name="jdbcUrl" value="${psql.url}"/>
+        <property name="user" value="${psql.user}"/>
         <property name="password" value="${psql.pass}"/>
-        <property name="driverClassName" value="org.postgresql.Driver"/>
-        <property name="testOnBorrow" value="true"/>
-        <property name="validationQuery" value="select 1 as dbcp_connection_test"/> 
-        <property name="poolPreparedStatements" value="true"/>
-        <property name="maxOpenPreparedStatements" value="-1"/>
-        <property name="defaultReadOnly" value="false"/>
-        <property name="defaultAutoCommit" value="true"/>
+        <property name="driverClass" value="org.postgresql.Driver"/>
+        <property name="maxPoolSize" value="5"/>
+        <property name="minPoolSize" value="1"/>
     </bean>
 
    <!--<bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">-->

--- a/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/ldapadmin/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -128,7 +128,7 @@
         <property name="user" value="${psql.user}"/>
         <property name="password" value="${psql.pass}"/>
         <property name="driverClass" value="org.postgresql.Driver"/>
-        <property name="maxPoolSize" value="5"/>
+        <property name="maxPoolSize" value="10"/>
         <property name="minPoolSize" value="1"/>
     </bean>
 


### PR DESCRIPTION
We have some issues in certain envs with connection to PostGreSQL being closed and apache dbcp no being able to reopen. Hopefully c3p0 provides a more resilient way to reconnect closed datasource streams.

Tests: currently runtime testing on cigal-dev