### PR TITLE
[WIP] GS - updating to 2.13.1

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -11,8 +11,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <maven.test.skip>true</maven.test.skip>
-    <gs.version>2.13.0</gs.version>
-    <gt.version>19.0</gt.version>
+    <gs.version>2.13.1</gs.version>
+    <gt.version>19.1</gt.version>
     <geofence.version>3.2-SNAPSHOT</geofence.version>
     <jetty.version>9.2.13.v20150730</jetty.version>
     <marlin.version>0.7.5-Unsafe</marlin.version>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -749,6 +749,16 @@
       </dependencies>
     </profile>
     <profile>
+      <id>vectortiles</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.extension</groupId>
+          <artifactId>gs-vectortiles</artifactId>
+          <version>${gs.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>sfs-store</id>
       <dependencies>
         <dependency>


### PR DESCRIPTION
Not to be merged now, as it has not been tested at runtime yet. Also, there seem to be some issues after a quick static analysis:

* Generated webapp contains asm lib both in v`2.2.3` and `5.0.3`, which is weird because I cannot track either on the `dependency:tree`
* commons-beanutils present in `1.7.0` and `1.9.2-noclassprop`
* same for commons-collections in `3.2.2` and `commons-collection4-4.1` (not exactly the same artifact name, which explains maybe why we find it duplicated)
* `xpp3` present in `1.1.3.4.0` and also in `xpp3_min` `1.1.4c`
