### PR TITLE
GS - Going back to GS 2.12.1

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -11,8 +11,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <maven.test.skip>true</maven.test.skip>
-    <gs.version>2.13.0</gs.version>
-    <gt.version>19.0</gt.version>
+    <gs.version>2.12.1</gs.version>
+    <gt.version>18.1</gt.version>
     <geofence.version>3.2-SNAPSHOT</geofence.version>
     <jetty.version>9.2.13.v20150730</jetty.version>
     <marlin.version>0.7.5-Unsafe</marlin.version>


### PR DESCRIPTION
See #2074, #2072 

statically compared against the GGE deployed GS, looks good but untested at runtime.