### PR TITLE
SP - fix for pr 2033

### DIFF
--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -19,7 +19,7 @@
     </bean>
 
     <bean id="proxy"  init-method="init" class="org.georchestra.security.Proxy">
-          <property name="publicHostname" value="${public.host:https://georchestra.mydomain.org/}"/>
+          <property name="publicHostname" value="${public.host:https://georchestra.mydomain.org}"/>
           <property name="headerManagement" ref="headerManagementBean"/>
           <property name="defaultCharset" value="UTF-8"/>
           <property name="defaultTarget" value="${defaultTarget:/header/}" />

--- a/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/filtered-resources/WEB-INF/proxy-servlet.xml
@@ -19,6 +19,7 @@
     </bean>
 
     <bean id="proxy"  init-method="init" class="org.georchestra.security.Proxy">
+          <property name="publicHostname" value="${public.host:https://georchestra.mydomain.org/}"/>
           <property name="headerManagement" ref="headerManagementBean"/>
           <property name="defaultCharset" value="UTF-8"/>
           <property name="defaultTarget" value="${defaultTarget:/header/}" />
@@ -108,14 +109,16 @@
         </property>
     </bean>
 
-	<context:property-placeholder location="/WEB-INF/security-proxy.properties"
-		ignore-resource-not-found="true" ignore-unresolvable="true" order="2" />
+    <context:property-placeholder location="/WEB-INF/security-proxy.properties"
+      ignore-resource-not-found="true" ignore-unresolvable="true" order="3" />
 
-	<!-- using the one from the geOrchestra datadir first (if available) -->
-	<context:property-placeholder
-		location="file:${georchestra.datadir}/security-proxy/security-proxy.properties"
-		ignore-resource-not-found="true" ignore-unresolvable="true" order="1" />
+    <!-- using the one from the geOrchestra datadir first (if available) -->
+    <context:property-placeholder
+      location="file:${georchestra.datadir}/security-proxy/security-proxy.properties"
+      ignore-resource-not-found="true" ignore-unresolvable="true" order="2" />
 
-
+    <context:property-placeholder
+      location="file:${georchestra.datadir}/default.properties"
+      ignore-resource-not-found="true" ignore-unresolvable="true" order="1" />
 
 </beans>

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -142,6 +142,7 @@ public class Proxy {
      */
     private String defaultTarget;
     private String publicHostname = "https://georchestra.mydomain.org/";
+
     private Map<String, String> targets = Collections.emptyMap();
     private HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
     private FilterRequestsStrategy strategyForFilteringRequests = new AcceptAllRequests();
@@ -163,6 +164,10 @@ public class Proxy {
         this.httpClientTimeout = timeout;
     }
 
+    public void setPublicHostname(String publicHostname) {
+        this.publicHostname = publicHostname;
+    }
+
     public Integer getHttpClientTimeout() {
         return httpClientTimeout;
     }
@@ -180,8 +185,6 @@ public class Proxy {
         // init() call
         if ((georchestraConfiguration != null) && (georchestraConfiguration.activated())) {
             logger.info("geOrchestra configuration detected, reconfiguration in progress ...");
-
-            this.publicHostname = georchestraConfiguration.getProperty("public.host");
 
             Properties pTargets = georchestraConfiguration.loadCustomPropertiesFile("targets-mapping");
 

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -141,7 +141,7 @@ public class Proxy {
      * must be defined
      */
     private String defaultTarget;
-    private String publicHostname = "https://georchestra.mydomain.org/";
+    private String publicHostname = "https://georchestra.mydomain.org";
 
     private Map<String, String> targets = Collections.emptyMap();
     private HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();


### PR DESCRIPTION
In #2033, the official docker-composition was not working, previous PR introduced a regression, making the Proxy bean unable to resolve the public URL variable, following error was arising:

```
org.springframework.beans.factory.BeanCreationException: Error creating
bean with name 'proxy' defined in ServletContext resource
[/WEB-INF/proxy-servlet.xml]: Invocation of init method failed; nested
exception is java.net.MalformedURLException: no protocol: ${publicUrl}
```

The main idea behind this PR is to let the logic of variable resolution to Spring, instead of trying to do it from our side into georchestra-commons.

Tests: runtime in a docker compo.