### PR TITLE
Put the maven build timestamp and short commitid in packageVersion (#…

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -425,7 +425,6 @@
               <packageName>georchestra-analytics</packageName>
               <packageDescription>geOrchestra Analytics webapp</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -466,7 +466,6 @@
                             <packageName>georchestra-atlas</packageName>
                             <packageDescription>geOrchestra Atlas</packageDescription>
                             <packageVersion>${project.packageVersion}</packageVersion>
-                            <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
                             <projectOrganization>geOrchestra</projectOrganization>
                             <maintainerName>PSC</maintainerName>
                             <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -286,7 +286,6 @@
               <packageName>georchestra-cas</packageName>
               <packageDescription>geOrchestra CAS server</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -673,7 +673,6 @@
               <packageName>georchestra-console</packageName>
               <packageDescription>geOrchestra LDAP management application</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -422,7 +422,6 @@
               <packageName>georchestra-extractorapp</packageName>
               <packageDescription>geOrchestra Extractor</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1050,7 +1050,6 @@
               <packageName>${packageName}</packageName>
               <packageDescription>geOrchestra GeoServer</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -272,7 +272,6 @@
               <packageName>georchestra-geowebcache</packageName>
               <packageDescription>geOrchestra standalone GeoWebCache</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>geOrchestra PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -178,7 +178,6 @@
               <packageName>georchestra-header</packageName>
               <packageDescription>geOrchestra Header</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -465,7 +465,6 @@
               <packageName>georchestra-mapfishapp</packageName>
               <packageDescription>geOrchestra Viewer</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <gmaven.version>1.0</gmaven.version>
     <gmaven.runtime.version>1.5</gmaven.runtime.version>
     <server>tpl</server>
-    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <geoserver_datadir>geoserver_datadir/</geoserver_datadir>
     <sub.target>dev</sub.target>
     <!-- default when building without a profile specified -->
@@ -124,7 +124,9 @@
               <configuration>
                 <exportAntProperties>true</exportAntProperties>
                 <target>
-                  <condition property="project.packageVersion" value="99.master" else="${project.version}">
+                  <condition property="project.packageVersion"
+                    value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                    else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
                     <matches string="${project.version}" pattern="SNAPSHOT$" />
                   </condition>
                 </target>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -322,7 +322,6 @@
               <packageName>georchestra-security-proxy</packageName>
               <packageDescription>geOrchestra Security Proxy</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>


### PR DESCRIPTION
…1931)

This reverts most of a750b50, and finally sets the full pkgname to
${project}_99.master.201806262006~87597cc-1_all.deb - this one will work for
upgrade paths.  While here remove the dash in the timestamp format, as it might
have a meaning in debian versionning..

of course need backporting to 16.12 & 17.12. sigh. or cherrypicking ? :)