### PR TITLE
Backport 31fc62d to 16.12 for #1931

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -425,7 +425,6 @@
               <packageName>georchestra-analytics</packageName>
               <packageDescription>geOrchestra Analytics webapp</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -466,7 +466,6 @@
                             <packageName>georchestra-atlas</packageName>
                             <packageDescription>geOrchestra Atlas</packageDescription>
                             <packageVersion>${project.packageVersion}</packageVersion>
-                            <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
                             <projectOrganization>geOrchestra</projectOrganization>
                             <maintainerName>PSC</maintainerName>
                             <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -286,7 +286,6 @@
               <packageName>georchestra-cas</packageName>
               <packageDescription>geOrchestra CAS server</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/catalogapp/pom.xml
+++ b/catalogapp/pom.xml
@@ -277,7 +277,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -323,7 +323,6 @@
               <packageName>georchestra-catalogapp</packageName>
               <packageDescription>geOrchestra Catalogapp (CSW frontend)</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/downloadform/pom.xml
+++ b/downloadform/pom.xml
@@ -181,7 +181,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -227,7 +227,6 @@
               <packageName>georchestra-downloadform</packageName>
               <packageDescription>geOrchestra DownloadForm</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -535,7 +535,6 @@
               <packageName>georchestra-extractorapp</packageName>
               <packageDescription>geOrchestra Extractor</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -891,7 +891,6 @@
               <packageName>${packageName}</packageName>
               <packageDescription>geOrchestra GeoServer</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -272,7 +272,6 @@
               <packageName>georchestra-geowebcache</packageName>
               <packageDescription>geOrchestra standalone GeoWebCache</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>geOrchestra PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -221,7 +221,6 @@
               <packageName>georchestra-header</packageName>
               <packageDescription>geOrchestra Header</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -700,7 +700,6 @@
               <packageName>georchestra-ldapadmin</packageName>
               <packageDescription>geOrchestra LDAP management application</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -509,7 +509,6 @@
               <packageName>georchestra-mapfishapp</packageName>
               <packageDescription>geOrchestra Viewer</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <gmaven.version>1.0</gmaven.version>
     <gmaven.runtime.version>1.5</gmaven.runtime.version>
     <server>template</server>
-    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <geoserver_datadir>geoserver_datadir/</geoserver_datadir>
     <sub.target>dev</sub.target>
     <!-- default when building without a profile specified -->
@@ -125,7 +125,9 @@
               <configuration>
                 <exportAntProperties>true</exportAntProperties>
                 <target>
-                  <condition property="project.packageVersion" value="99.master" else="${project.version}">
+                  <condition property="project.packageVersion"
+                    value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                    else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
                     <matches string="${project.version}" pattern="SNAPSHOT$" />
                   </condition>
                 </target>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -324,7 +324,6 @@
               <packageName>georchestra-security-proxy</packageName>
               <packageDescription>geOrchestra Security Proxy</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>


### PR DESCRIPTION
To be forward-ported or cascade-merged or whatever to 17.12, generates the following:
```
$find * -path '*target*' -name '*.deb'
analytics/target/georchestra-analytics_16.12.201806270821~7060d2b-1_all.deb
atlas/target/georchestra-atlas_16.12.201806270821~7060d2b-1_all.deb
cas-server-webapp/target/georchestra-cas_16.12.201806270821~7060d2b-1_all.deb
catalogapp/target/georchestra-catalogapp_16.12.201806270853~f7b428a-1_all.deb
downloadform/target/georchestra-downloadform_16.12.201806270853~f7b428a-1_all.deb
extractorapp/target/georchestra-extractorapp_16.12.201806270821~7060d2b-1_all.deb
geoserver/webapp/target/georchestra-geoserver_16.12.201806270821~7060d2b-1_all.deb
geowebcache-webapp/target/georchestra-geowebcache_16.12.201806270821~7060d2b-1_all.deb
header/target/georchestra-header_16.12.201806270821~7060d2b-1_all.deb
ldapadmin/target/georchestra-ldapadmin_16.12.201806270841~7060d2b-1_all.deb
mapfishapp/target/georchestra-mapfishapp_16.12.201806270821~7060d2b-1_all.deb
security-proxy/target/georchestra-security-proxy_16.12.201806270821~7060d2b-1_all.deb
```
and the version field in the debian packages has the full '16.12.201806270821~7060d2b' info