### PR TITLE
Ensure etc/georchestra/.git is removed from the debian package (#2094) (for master)

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -387,7 +387,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -426,7 +426,7 @@
                                 <configuration>
                                     <target>
                                         <delete includeemptydirs="true">
-                                            <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                                            <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                                                 <include name="**/*" />
                                                 <exclude name="atlas/**" />
                                             </fileset>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -248,7 +248,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="cas/**" />
                       </fileset>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -635,7 +635,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -384,7 +384,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1012,7 +1012,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geoserver/**" />
                       </fileset>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -234,7 +234,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geowebcache/**" />
                       </fileset>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -140,7 +140,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -425,7 +425,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="mapfishapp/**" />
                       </fileset>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -284,7 +284,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>


### PR DESCRIPTION
Disabling defaultexcludes in antrun delete target makes sure .git is removed in
the remove-useless-directories task.