### PR TITLE
Ensure etc/georchestra/.git is removed from the debian package (#2094) (for 16.12)

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -387,7 +387,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -426,7 +426,7 @@
                                 <configuration>
                                     <target>
                                         <delete includeemptydirs="true">
-                                            <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                                            <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                                                 <include name="**/*" />
                                                 <exclude name="atlas/**" />
                                             </fileset>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -248,7 +248,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="cas/**" />
                       </fileset>

--- a/catalogapp/pom.xml
+++ b/catalogapp/pom.xml
@@ -285,7 +285,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/downloadform/pom.xml
+++ b/downloadform/pom.xml
@@ -189,7 +189,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -497,7 +497,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -853,7 +853,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geoserver/**" />
                       </fileset>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -234,7 +234,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geowebcache/**" />
                       </fileset>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -183,7 +183,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -662,7 +662,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -469,7 +469,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="mapfishapp/**" />
                       </fileset>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -286,7 +286,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>


### PR DESCRIPTION
Disabling defaultexcludes in antrun delete target makes sure .git is removed in
the remove-useless-directories task.

Backport of #2095 to 16.12, tested to produce debian packages properly named, and without .git subdirs..