### PR TITLE
Port changes from #1931 and #2094 to 17.12

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -379,7 +379,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -424,11 +424,11 @@
             <configuration>
               <packageName>georchestra-analytics</packageName>
               <packageDescription>geOrchestra Analytics webapp</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -387,7 +387,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -426,7 +426,7 @@
                                 <configuration>
                                     <target>
                                         <delete includeemptydirs="true">
-                                            <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                                            <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                                                 <include name="**/*" />
                                                 <exclude name="atlas/**" />
                                             </fileset>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -418,7 +418,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>1.7</version>
                         <executions>
                             <execution>
                                 <id>remove-useless-directories</id>
@@ -465,11 +465,11 @@
                         <configuration>
                             <packageName>georchestra-atlas</packageName>
                             <packageDescription>geOrchestra Atlas</packageDescription>
+                            <packageVersion>${project.packageVersion}</packageVersion>
                             <projectOrganization>geOrchestra</projectOrganization>
                             <maintainerName>PSC</maintainerName>
                             <maintainerEmail>psc@georchestra.org</maintainerEmail>
                             <excludeAllDependencies>true</excludeAllDependencies>
-                            <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -248,7 +248,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="cas/**" />
                       </fileset>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -240,7 +240,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -285,11 +285,11 @@
             <configuration>
               <packageName>georchestra-cas</packageName>
               <packageDescription>geOrchestra CAS server</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -497,7 +497,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -489,7 +489,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -534,11 +534,11 @@
             <configuration>
               <packageName>georchestra-extractorapp</packageName>
               <packageDescription>geOrchestra Extractor</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1010,7 +1010,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geoserver/**" />
                       </fileset>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1002,7 +1002,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -1047,6 +1047,7 @@
             <configuration>
               <packageName>${packageName}</packageName>
               <packageDescription>geOrchestra GeoServer</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>
@@ -1055,7 +1056,6 @@
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -234,7 +234,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geowebcache/**" />
                       </fileset>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -226,7 +226,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -271,11 +271,11 @@
             <configuration>
               <packageName>georchestra-geowebcache</packageName>
               <packageDescription>geOrchestra standalone GeoWebCache</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>geOrchestra PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -183,7 +183,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -175,7 +175,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -220,11 +220,11 @@
             <configuration>
               <packageName>georchestra-header</packageName>
               <packageDescription>geOrchestra Header</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -662,7 +662,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>

--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -654,7 +654,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -699,11 +699,11 @@
             <configuration>
               <packageName>georchestra-ldapadmin</packageName>
               <packageDescription>geOrchestra LDAP management application</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -469,7 +469,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="mapfishapp/**" />
                       </fileset>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -461,7 +461,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -508,11 +508,11 @@
             <configuration>
               <packageName>georchestra-mapfishapp</packageName>
               <packageDescription>geOrchestra Viewer</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <gmaven.version>1.0</gmaven.version>
     <gmaven.runtime.version>1.5</gmaven.runtime.version>
     <server>template</server>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <geoserver_datadir>geoserver_datadir/</geoserver_datadir>
     <sub.target>dev</sub.target>
     <!-- default when building without a profile specified -->
@@ -109,6 +110,30 @@
          <artifactId>dependency-check-maven</artifactId>
          <version>3.0.1</version>
        </plugin>
+       <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-antrun-plugin</artifactId>
+         <version>1.7</version>
+         <executions>
+           <execution>
+              <id>set-project-packageversion</id>
+              <phase>package</phase>
+              <goals>
+                <goal>run</goal>
+              </goals>
+              <configuration>
+                <exportAntProperties>true</exportAntProperties>
+                <target>
+                  <condition property="project.packageVersion"
+                    value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                    else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                    <matches string="${project.version}" pattern="SNAPSHOT$" />
+                  </condition>
+                </target>
+             </configuration>
+          </execution>
+        </executions>
+      </plugin>
      </plugins>
      <pluginManagement>
       <plugins>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -282,7 +282,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
               <execution>
                 <id>remove-useless-directories</id>
@@ -327,6 +327,7 @@
             <configuration>
               <packageName>georchestra-security-proxy</packageName>
               <packageDescription>geOrchestra Security Proxy</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>
@@ -335,7 +336,6 @@
               <maintainerName>PSC</maintainerName>
               <maintainerEmail>psc@georchestra.org</maintainerEmail>
               <excludeAllDependencies>true</excludeAllDependencies>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -290,7 +290,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="${project.artifactId}/**" />
                       </fileset>


### PR DESCRIPTION
Branch generated by merging 16.12 and my pending fix/2094_16.12.

Tested producing packages named correctly:
```
analytics/target/georchestra-analytics_17.12.201806272054~fdfea08-1_all.deb
atlas/target/georchestra-atlas_17.12.201806272054~fdfea08-1_all.deb
cas-server-webapp/target/georchestra-cas_17.12.201806272054~fdfea08-1_all.deb
extractorapp/target/georchestra-extractorapp_17.12.201806272054~fdfea08-1_all.deb
geonetwork/web/target/georchestra-geonetwork3_3.4.1-0.201806272054~0419626-1_all.deb
geoserver/webapp/target/georchestra-geoserver_17.12.201806272054~fdfea08-1_all.deb
geowebcache-webapp/target/georchestra-geowebcache_17.12.201806272054~fdfea08-1_all.deb
header/target/georchestra-header_17.12.201806272054~fdfea08-1_all.deb
ldapadmin/target/georchestra-ldapadmin_17.12.201806272054~fdfea08-1_all.deb
mapfishapp/target/georchestra-mapfishapp_17.12.201806272054~fdfea08-1_all.deb
security-proxy/target/georchestra-security-proxy_17.12.201806272054~fdfea08-1_all.deb
```
and those packages have no .git subdir.

Related to georchestra/geonetwork#75 which also needs merging and submodule bump.