### PR TITLE
all - log4j-logstash profile removing scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,6 @@
           <groupId>net.logstash.log4j</groupId>
           <artifactId>jsonevent-layout</artifactId>
           <version>1.7</version>
-          <scope>runtime</scope>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
This is required if the profile is activated because the GWC webapp do need to have the apache commons-lang:2.6 at compilation time. Activating the profile will currently make the build fail on GWC.
 
