### PR TITLE
Add delegated admin & pending users/orgs to the sample data (#2112)

### DIFF
--- a/ldap/README.md
+++ b/ldap/README.md
@@ -33,7 +33,7 @@ The basic users:
  * ```testreviewer``` has the USER & GN_REVIEWER roles. The password is **testreviewer**.
  * ```testeditor``` has the USER & GN_EDITOR roles. The password is **testeditor**.
  * ```testadmin``` has the USER, GN_ADMIN, ADMINISTRATOR and MOD_* roles. The password is **testadmin**
- * ```testdelegatedadmin``` has the USER & ORGADMIN roles. The password is **testdelegatedadmin**
+ * ```testdelegatedadmin``` has the USER role. Is able to grant the EXTRACTORAPP & GN_EDITOR roles to members of the psc & c2c orgs. The password is **testdelegatedadmin**
  * ```geoserver_privileged_user``` is a required user. It is internally used by the extractorapp, mapfishapp & geofence modules. The default password is ```gerlsSnFd6SmM``` (you should change it, and update the ```shared.privileged.geoserver.pass``` option in your shared.maven.filters file).
 
 Please note that `test*` users should be deleted before going into production !

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -29,9 +29,11 @@ It creates 3 Organisational Units (ou):
 
 The basic users:
  * ```testuser``` has the USER role. The password is **testuser**.
+ * ```testpendinguser``` has the PENDING role, which means an admin has to validate it. The password is **testpendinguser**.
  * ```testreviewer``` has the USER & GN_REVIEWER roles. The password is **testreviewer**.
  * ```testeditor``` has the USER & GN_EDITOR roles. The password is **testeditor**.
  * ```testadmin``` has the USER, GN_ADMIN, ADMINISTRATOR and MOD_* roles. The password is **testadmin**
+ * ```testdelegatedadmin``` has the USER & ORGADMIN roles. The password is **testdelegatedadmin**
  * ```geoserver_privileged_user``` is a required user. It is internally used by the extractorapp, mapfishapp & geofence modules. The default password is ```gerlsSnFd6SmM``` (you should change it, and update the ```shared.privileged.geoserver.pass``` option in your shared.maven.filters file).
 
 Please note that `test*` users should be deleted before going into production !

--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -12,7 +12,6 @@ objectClass: inetOrgPerson
 objectClass: shadowAccount
 objectClass: top
 mail: psc+testuser@georchestra.org
-o: geOrchestra
 uid: testuser
 givenName: Test
 sn: USER
@@ -36,7 +35,6 @@ description: Reviewer
 employeeNumber: 2
 userPassword:: e1NIQX1Nb3IzdXZ5cnpISWpHK0crSEcvblhxZW8reWc9
 mail: psc+testreviewer@georchestra.org
-o: geOrchestra
 cn: testreviewer
 
 # testeditor, users, georchestra.org
@@ -53,7 +51,6 @@ description: editor
 employeeNumber: 3
 userPassword:: e1NIQX1mVTFvSmdzV0FEZ1ZtTHBHeHBxdFBVa2RiekU9
 mail: psc+testeditor@georchestra.org
-o: geOrchestra
 cn: testeditor
 
 # testadmin, users, georchestra.org
@@ -70,7 +67,6 @@ description: Admin user
 employeeNumber: 4
 userPassword:: e1NIQX1kREU1SkEvMkVpVTRGMFFObUt5eXpuazUrN1E9
 mail: psc+testadmin@georchestra.org
-o: geOrchestra
 cn: testadmin
 
 # geoserver_privileged_user, users, georchestra.org

--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -84,6 +84,22 @@ employeeNumber: 5
 description: Do not modify.  This is a required user for extractorapp, geofence, mapfishapp...
 userPassword:: e1NIQX1XMlY4d2UrOFdNanpma28rMUtZVDFZcWZFVDQ9
 
+# testpendinguser, users, georchestra.org
+dn: uid=testpendinguser,ou=users,dc=georchestra,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: shadowAccount
+objectClass: top
+uid: testpendinguser
+givenName: Test
+sn: PENDINGUSER
+description: Utilisateur en attente de validation
+employeeNumber: 6
+userPassword:: e1NIQX16cnJXRCtmbnc2QjZGVDRpcFVYMzh0d1VxRHM9
+mail: psc+testpendinguser@georchestra.org
+cn: testpendinguser
+
 # roles, georchestra.org
 dn: ou=roles,dc=georchestra,dc=org
 objectClass: organizationalUnit
@@ -109,6 +125,7 @@ objectClass: groupOfMembers
 cn: PENDING
 ou: 2
 description: This group does not grant any right inside the SDI. Users in this group are requesting a fully fledged account.
+member: uid=testpendinguser,ou=users,dc=georchestra,dc=org
 
 # SUPERUSER, roles, georchestra.org
 dn: cn=SUPERUSER,ou=roles,dc=georchestra,dc=org
@@ -239,3 +256,19 @@ member: uid=testreviewer,ou=users,dc=georchestra,dc=org
 o: Conseil régional d'Alsace
 ou: CRA
 seeAlso: o=cra,ou=orgs,dc=georchestra,dc=org
+
+dn: o=pendingorg,ou=orgs,dc=georchestra,dc=org
+objectClass: organization
+objectClass: top
+o: pendingorg
+businessCategory: COMPANY
+postalAddress: Null island
+
+dn: cn=pendingorg,ou=orgs,dc=georchestra,dc=org
+objectClass: groupOfMembers
+objectClass: top
+cn: pendingorg
+businessCategory: PENDING
+description: 59107
+member: uid=testpendinguser,ou=users,dc=georchestra,dc=org
+o: Organisme fictif en attente de validation

--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -94,7 +94,7 @@ objectClass: top
 uid: testpendinguser
 givenName: Test
 sn: PENDINGUSER
-description: Utilisateur en attente de validation
+description: User pending admin validation
 employeeNumber: 6
 userPassword:: e1NIQX16cnJXRCtmbnc2QjZGVDRpcFVYMzh0d1VxRHM9
 mail: psc+testpendinguser@georchestra.org
@@ -110,7 +110,7 @@ objectClass: top
 uid: testdelegatedadmin
 givenName: Test
 sn: DELEGATEDADMIN
-description: Utilisateur avec delegation
+description: User with admin delegation
 employeeNumber: 7
 userPassword:: e1NIQX02OGRFejBlb25BYkdjVm1aWkFoQVVDYmo3bTQ9
 mail: psc+testdelegatedadmin@georchestra.org
@@ -286,6 +286,6 @@ cn: pendingorg
 businessCategory: PENDING
 description: 59107
 member: uid=testpendinguser,ou=users,dc=georchestra,dc=org
-o: Organisme fictif en attente de validation
+o: Fictive org pending admin validation
 ou: PENDINGORG
 seeAlso: o=pendingorg,ou=orgs,dc=georchestra,dc=org

--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -106,6 +106,22 @@ objectClass: organizationalUnit
 objectClass: top
 ou: roles
 
+# testdelegatedadmin, users, georchestra.org
+dn: uid=testdelegatedadmin,ou=users,dc=georchestra,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: shadowAccount
+objectClass: top
+uid: testdelegatedadmin
+givenName: Test
+sn: DELEGATEDADMIN
+description: Utilisateur avec delegation
+employeeNumber: 7
+userPassword:: e1NIQX02OGRFejBlb25BYkdjVm1aWkFoQVVDYmo3bTQ9
+mail: psc+testdelegatedadmin@georchestra.org
+cn: testdelegatedadmin
+
 
 # ADMINISTRATOR, roles, georchestra.org
 dn: cn=ADMINISTRATOR,ou=roles,dc=georchestra,dc=org
@@ -184,6 +200,7 @@ member: uid=testuser,ou=users,dc=georchestra,dc=org
 member: uid=testeditor,ou=users,dc=georchestra,dc=org
 member: uid=testreviewer,ou=users,dc=georchestra,dc=org
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
+member: uid=testdelegatedadmin,ou=users,dc=georchestra,dc=org
 
 # ORGADMIN, roles, georchestra.org
 dn: cn=ORGADMIN,ou=roles,dc=georchestra,dc=org
@@ -192,8 +209,7 @@ objectClass: groupOfMembers
 cn: ORGADMIN
 ou: 24
 description: This role is automatically granted to all users holding an admin delegation
-member: uid=testuser,ou=users,dc=georchestra,dc=org
-member: uid=testeditor,ou=users,dc=georchestra,dc=org
+member: uid=testdelegatedadmin,ou=users,dc=georchestra,dc=org
 
 # orgs, georchestra.org
 dn: ou=orgs,dc=georchestra,dc=org

--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -100,12 +100,6 @@ userPassword:: e1NIQX16cnJXRCtmbnc2QjZGVDRpcFVYMzh0d1VxRHM9
 mail: psc+testpendinguser@georchestra.org
 cn: testpendinguser
 
-# roles, georchestra.org
-dn: ou=roles,dc=georchestra,dc=org
-objectClass: organizationalUnit
-objectClass: top
-ou: roles
-
 # testdelegatedadmin, users, georchestra.org
 dn: uid=testdelegatedadmin,ou=users,dc=georchestra,dc=org
 objectClass: inetOrgPerson
@@ -122,6 +116,11 @@ userPassword:: e1NIQX02OGRFejBlb25BYkdjVm1aWkFoQVVDYmo3bTQ9
 mail: psc+testdelegatedadmin@georchestra.org
 cn: testdelegatedadmin
 
+# roles, georchestra.org
+dn: ou=roles,dc=georchestra,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: roles
 
 # ADMINISTRATOR, roles, georchestra.org
 dn: cn=ADMINISTRATOR,ou=roles,dc=georchestra,dc=org

--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -287,3 +287,5 @@ businessCategory: PENDING
 description: 59107
 member: uid=testpendinguser,ou=users,dc=georchestra,dc=org
 o: Organisme fictif en attente de validation
+ou: PENDINGORG
+seeAlso: o=pendingorg,ou=orgs,dc=georchestra,dc=org

--- a/postgresql/05-console-data.sql
+++ b/postgresql/05-console-data.sql
@@ -47,7 +47,6 @@ INSERT INTO admin_attachments (content, mimetype, name) VALUES (lo_import('/dock
 
 INSERT INTO admin_emails (body, date, recipient, sender, subject) VALUES ( 'Votre compte a été suprimé', '2016-05-18 09:31:47.928', 'testadmin', 'testadmin', 'Deleted');
 
-INSERT INTO delegations (uid, orgs, roles) VALUES ('testeditor', '{psc, c2c}', '{EXTRACTORAPP, GN_EDITOR}');
-INSERT INTO delegations (uid, orgs, roles) VALUES ('testuser', '{psc, cra}', '{GN_REVIEWER, GN_EDITOR}');
+INSERT INTO delegations (uid, orgs, roles) VALUES ('testdelegatedadmin', '{psc, c2c}', '{EXTRACTORAPP, GN_EDITOR}');
 
 COMMIT;


### PR DESCRIPTION
Tested in the following cases:
  * logged as `testdelegatedadmin`, i see the two orgs and two roles for which i have delegation, but not the users in the orgs i have delegation for. expected ?
  * the `testpendinguser` validation form doesnt show that he wants to be part of `pendingorg`, which is strange..
  * the `pendingorg`validation form doesnt show that the businessCategory attr is 'COMPANY', strange too
  * once `testadmin` has validated `testpendinguser` that user can login. He can't login before being validated.