### PR TITLE
SP - do not extra encode path (#2020)

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -876,7 +876,8 @@ public class Proxy {
         if(url.getPort() != -1)
             rawUrl.append(":" + String.valueOf(url.getPort()));
 
-        rawUrl.append(uri.getRawPath()); // Use encoded version from URI class
+        rawUrl.append(uri.getPath()); // Do not URL-encode, and take the request
+        // as it originally comes instead of doing extra-encoding.
 
         if(url.getQuery() != null)
             rawUrl.append("?" + url.getQuery()); // Use already encoded query part

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -138,5 +138,12 @@ public class ProxyTest {
 
         ret = (URI) ReflectionUtils.invokeMethod(m, proxy, new URL("https://sdi.georchestra.org/console/account/recover?email=psc%2Btestuser%40georchestra.org"));
         assertTrue(ret.toString().contains("email=psc%2Btestuser%40georchestra.org"));
+
+        // defunct URLs:
+        // http://localhost:8080/geonetwork/srv/api/0.1/standards/iso19139/codelists/gmd%3ADS_InitiativeTypeCode
+        // SP will re-encode %3A to %253A
+        // see https://github.com/georchestra/georchestra/issues/2020#issuecomment-402449307
+        ret = (URI) ReflectionUtils.invokeMethod(m, proxy, new URL("http://localhost:8080/geonetwork/srv/api/0.1/standards/iso19139/codelists/gmd%3ADS_InitiativeTypeCode"));
+        assertTrue(! ret.toString().contains("%253ADS"));
     }
 }


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/2020#issuecomment-402449307

Tested against:
* http://localhost:8080/geonetwork/srv/api/0.1/standards/iso19139/codelists/gmd%3ADS_InitiativeTypeCode
* http://localhost:8080/geonetwork/catalog/lib/moment+langs.min.js

Both into a jetty and a tomcat container with the SP webapp.
