### PR TITLE
mfapp - print-lib 2.1.2

### DIFF
--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.2</version>
     </dependency>
     <!-- Note: the print module also depends on slf4j -->
     <dependency>


### PR DESCRIPTION
Moving to minor version 2.1.2 for mfprint to fix a race condition encountered by renne-metropole.

Tests: totally untested - compilation OK so far -, a similar fix has been already applied on rennes's portail-test.

