### PR TITLE
Allow an administrator to set the login field readonly on the account…

### DIFF
--- a/console/src/main/webapp/WEB-INF/tags/input.tag
+++ b/console/src/main/webapp/WEB-INF/tags/input.tag
@@ -7,6 +7,7 @@
 <%@attribute name="cssClass" required="false" type="java.lang.String"%>
 <%@attribute name="label" required="false" type="java.lang.String"%>
 <%@attribute name="required" required="false" type="java.lang.Boolean"%>
+<%@attribute name="readonly" required="false" type="java.lang.Boolean"%>
 <%@attribute name="onchange" required="false" type="java.lang.String"%>
 <%@attribute name="onkeyup" required="false" type="java.lang.String"%>
 <%@attribute name="appendIcon" required="false" type="java.lang.String"%>
@@ -20,7 +21,7 @@
 			<c:if test="${not empty appendIcon}">
 				<div class="input-group">
 			</c:if>
-				<form:input path="${path}" size="30" maxlength="80" cssClass="${empty cssClass ? 'form-control' : cssClass}" onkeyup="${onkeyup}" onchange="${onchange}" />
+				<form:input path="${path}" size="30" maxlength="80" readonly="${empty readonly ? 'false' : readonly}" cssClass="${empty cssClass ? 'form-control' : cssClass}" onkeyup="${onkeyup}" onchange="${onchange}" />
 			<c:if test="${not empty appendIcon}">
 					<span class="input-group-addon"><i class="glyphicon glyphicon-${appendIcon}"></i></span>
 				</div>

--- a/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
@@ -146,7 +146,7 @@
 
             <fieldset>
                 <legend><s:message code="createAccountForm.fieldset.credentials"/></legend>
-                <t:input path="uid" required="${uidRequired}" readonly="<%= userCantChooseUid %>" appendIcon="user">
+                <t:input path="uid" required="${uidRequired}" readonly="<%= readonlyUid %>" appendIcon="user">
                     <jsp:attribute name="label"><s:message code="uid.label" /></jsp:attribute>
                 </t:input>
                 <t:password path="password" required="${passwordRequired}" spanId="pwdQuality" appendIcon="lock" onblur="passwordOnBlur();" onchange="cleanConfirmPassword();feedbackPassStrength('pwdQuality', value);" onkeypress="cleanConfirmPassword();" onkeyup="feedbackPassStrength('pwdQuality', value);">

--- a/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
@@ -146,7 +146,7 @@
 
             <fieldset>
                 <legend><s:message code="createAccountForm.fieldset.credentials"/></legend>
-                <t:input path="uid" required="${uidRequired}" appendIcon="user">
+                <t:input path="uid" required="${uidRequired}" readonly="<%= userCantChooseUid %>" appendIcon="user">
                     <jsp:attribute name="label"><s:message code="uid.label" /></jsp:attribute>
                 </t:input>
                 <t:password path="password" required="${passwordRequired}" spanId="pwdQuality" appendIcon="lock" onblur="passwordOnBlur();" onchange="cleanConfirmPassword();feedbackPassStrength('pwdQuality', value);" onkeypress="cleanConfirmPassword();" onkeyup="feedbackPassStrength('pwdQuality', value);">

--- a/console/src/main/webapp/WEB-INF/views/header.jsp
+++ b/console/src/main/webapp/WEB-INF/views/header.jsp
@@ -6,6 +6,7 @@
 <%
 String headerHeight = "90";
 String headerUrl = "/header/";
+Boolean userCantChooseUid = false;
 
 try {
   ApplicationContext ctx = RequestContextUtils.getWebApplicationContext(request);
@@ -13,6 +14,7 @@ try {
         && (((GeorchestraConfiguration) ctx.getBean(GeorchestraConfiguration.class)).activated())) {
         headerHeight = ctx.getBean(GeorchestraConfiguration.class).getProperty("headerHeight");
         headerUrl = ctx.getBean(GeorchestraConfiguration.class).getProperty("headerUrl");
+        userCantChooseUid = Boolean.parseBoolean(ctx.getBean(GeorchestraConfiguration.class).getProperty("userCantChooseUid"));
   }
 } catch (Exception e) {}
 %>

--- a/console/src/main/webapp/WEB-INF/views/header.jsp
+++ b/console/src/main/webapp/WEB-INF/views/header.jsp
@@ -6,7 +6,7 @@
 <%
 String headerHeight = "90";
 String headerUrl = "/header/";
-Boolean userCantChooseUid = false;
+Boolean readonlyUid = false;
 
 try {
   ApplicationContext ctx = RequestContextUtils.getWebApplicationContext(request);
@@ -14,7 +14,7 @@ try {
         && (((GeorchestraConfiguration) ctx.getBean(GeorchestraConfiguration.class)).activated())) {
         headerHeight = ctx.getBean(GeorchestraConfiguration.class).getProperty("headerHeight");
         headerUrl = ctx.getBean(GeorchestraConfiguration.class).getProperty("headerUrl");
-        userCantChooseUid = Boolean.parseBoolean(ctx.getBean(GeorchestraConfiguration.class).getProperty("userCantChooseUid"));
+        readonlyUid = Boolean.parseBoolean(ctx.getBean(GeorchestraConfiguration.class).getProperty("readonlyUid"));
   }
 } catch (Exception e) {}
 %>


### PR DESCRIPTION
… creation page (#2104)

setting `userCantChooseUid=true` in `console.properties` makes the field readonly.

A bit rough around the edges since my JSP isnt that good, but does what's expected, tested both with/without setting the parameter in `console.properties`. This is only a part of #2104...