### PR TITLE
Remove a hardcoded /geoserver/wms and reuse GEOSERVER_WMS_URL

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_ows.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_ows.js
@@ -621,14 +621,14 @@ GEOR.ows = (function() {
         hydrateLayerRecord: function(record, options) {
             var url = record.get('layer').url,
                 layername = record.get('name');
-            if (!options.useMainService && url.indexOf("geoserver/wms") > 0) {
+            if (!options.useMainService && url.indexOf(GEOR.config.GEOSERVER_WMS_URL) > 0) {
                 // try to use virtual service instead of main service
                 var nsalias,
                     t = layername.split(':');
                 if (t.length > 1) {
                     nsalias = t.shift();
                     layername = t.shift();
-                    url = url.replace("geoserver/wms", "geoserver/"+nsalias+"/wms");
+                    url = url.replace(GEOR.config.GEOSERVER_WMS_URL, GEOR.config.GEOSERVER_WMS_URL.split('/')[1]+"/"+nsalias+"/wms");
                 }
             }
             GEOR.waiter.show();


### PR DESCRIPTION
Saw this one when poking at something else there, but i havent been able to trigger the codepaths that lead to this code being called. Also, it's a bit awkward to reuse GEOSERVER_WMS_URL which is supposed to be used only if OSM_AS_OVMAP is false, but oh well..