### PR TITLE
Move console table creations to the right SQL file

### DIFF
--- a/postgresql/04-console.sql
+++ b/postgresql/04-console.sql
@@ -8,6 +8,39 @@ CREATE SCHEMA console;
 
 SET search_path TO console,public,pg_catalog;
 
+CREATE TABLE admin_attachments (
+  id bigserial,
+  content oid,
+  mimetype character varying(255),
+  name character varying(255),
+  CONSTRAINT admin_attachments_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE email_template (
+  id bigserial,
+  content text,
+  name character varying(255),
+  CONSTRAINT email_template_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE admin_emails (
+  id bigserial,
+  body text,
+  date timestamp without time zone,
+  recipient character varying(255),
+  sender text,
+  subject character varying(255),
+  CONSTRAINT admin_emails_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE delegations
+(
+  uid character varying(255) NOT NULL,
+  orgs character varying[],
+  roles character varying[],
+  CONSTRAINT delegations_pkey PRIMARY KEY (uid)
+);
+
 
 CREATE TABLE user_token (
     uid character varying NOT NULL,

--- a/postgresql/05-console-data.sql
+++ b/postgresql/05-console-data.sql
@@ -6,39 +6,6 @@ BEGIN;
 
 SET search_path TO console,public,pg_catalog;
 
-CREATE TABLE admin_attachments (
-  id bigserial,
-  content oid,
-  mimetype character varying(255),
-  name character varying(255),
-  CONSTRAINT admin_attachments_pkey PRIMARY KEY (id)
-);
-
-CREATE TABLE email_template (
-  id bigserial,
-  content text,
-  name character varying(255),
-  CONSTRAINT email_template_pkey PRIMARY KEY (id)
-);
-
-CREATE TABLE admin_emails (
-  id bigserial,
-  body text,
-  date timestamp without time zone,
-  recipient character varying(255),
-  sender text,
-  subject character varying(255),
-  CONSTRAINT admin_emails_pkey PRIMARY KEY (id)
-);
-
-CREATE TABLE delegations
-(
-  uid character varying(255) NOT NULL,
-  orgs character varying[],
-  roles character varying[],
-  CONSTRAINT delegations_pkey PRIMARY KEY (uid)
-);
-
 INSERT INTO email_template (content, name) VALUES ('Bonjour et bienvenue', 'Hello');
 INSERT INTO email_template (content, name) VALUES ('Votre compte a été supprimé', 'Deleted');
 


### PR DESCRIPTION
console-data should only insert sample data..

Unless hibernate in the console backend takes care of creating those ? then why `user_token` is different, and created in `04-console.sql` ?