### PR TITLE
fix calling unknown georConfig property

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
@@ -46,7 +46,7 @@ try {
   GeorchestraConfiguration georConfig = (GeorchestraConfiguration) ctx.getBean(GeorchestraConfiguration.class);
   if (georConfig.activated()) {
     sharedInstanceName = georConfig.getProperty("instance.name");
-    sharedHomepageUrl = georConfig.getProperty("homepage.url");
+    sharedHomepageUrl = georConfig.getProperty("publicUrl");
     headerHeight = georConfig.getProperty("headerHeight");
     headerUrl = georConfig.getProperty("headerUrl");
     sharedLdapadminContextpath = georConfig.getProperty("console.contextpath");

--- a/config/defaults/cas-server-webapp/WEB-INF/view/jsp/default/ui/includes/top-noheader.jsp
+++ b/config/defaults/cas-server-webapp/WEB-INF/view/jsp/default/ui/includes/top-noheader.jsp
@@ -43,7 +43,7 @@ try {
   GeorchestraConfiguration georConfig = (GeorchestraConfiguration) ctx.getBean(GeorchestraConfiguration.class);
   if (georConfig.activated()) {
     sharedInstanceName = georConfig.getProperty("instance.name");
-    sharedHomepageUrl = georConfig.getProperty("homepage.url");
+    sharedHomepageUrl = georConfig.getProperty("publicUrl");
   }
 } catch (Exception e) {
   // ignoring


### PR DESCRIPTION
https://github.com/georchestra/georchestra/blob/18.06/config/defaults/cas-server-webapp/WEB-INF/view/jsp/default/ui/casGenericSuccess.jsp redirects to `sharedHomepageUrl` after a second, but this var gets initialized with an unknown datadir property with https://github.com/georchestra/georchestra/blob/4b68ca7347f57112becf12508dcb89466b57feb1/config/defaults/cas-server-webapp/WEB-INF/view/jsp/default/ui/includes/top-noheader.jsp#L46

As a result, the login page reloads every second.