### PR TITLE
Remove 'Host' header override when localProxy is true (#2176)

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -664,21 +664,6 @@ public class Proxy {
                 logger.error("Unable to log the request into the statistics logger", e);
             }
 
-            if (localProxy) {
-                //
-                // Hack for geoserver
-                // Should not be here. We must use a ProxyTarget class and
-                // define
-                // if Host header should be forwarded or not.
-                //
-                proxyingRequest.setHeader("Host", request.getHeader("Host"));
-
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Host header set to: " + proxyingRequest.getFirstHeader("Host").getValue()
-                            + " for proxy request.");
-                }
-            }
-
             proxiedResponse = executeHttpRequest(httpclient, proxyingRequest);
             StatusLine statusLine = proxiedResponse.getStatusLine();
             statusCode = statusLine.getStatusCode();


### PR DESCRIPTION
Was apparently a hack for geoserver 7 years ago, and causes wrong
behaviour when one of the SP targets points to an external FQDN

Might cause side effects, but works for me here, and unbreaks critical features (having the header served by a different FQDN, but through the SP)