### PR TITLE
SP: change for ASYNC apache http client

### DIFF
--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -14,6 +14,7 @@
     <spring.version>4.3.13.RELEASE</spring.version>
     <security.version>4.2.3.RELEASE</security.version>
     <maven.test.skip>false</maven.test.skip>
+    <java.version>1.8</java.version>
   </properties>
   <dependencies>
     <dependency>
@@ -26,6 +27,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.4</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -160,6 +167,16 @@
   <build>
     <finalName>ROOT-${server}</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -1,7 +1,16 @@
 package org.georchestra.security;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.google.common.collect.Maps;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.message.BasicHttpResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.ReflectionUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -9,21 +18,8 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpVersion;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.message.BasicHttpResponse;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.http.HttpMethod;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.util.ReflectionUtils;
-
-import com.google.common.collect.Maps;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ProxyTest {
     private Proxy proxy;
@@ -38,7 +34,7 @@ public class ProxyTest {
         executed = false;
         proxy = new Proxy() {
             @Override
-            protected HttpResponse executeHttpRequest(HttpClient httpclient, HttpRequestBase proxyingRequest) throws IOException {
+            protected HttpResponse executeHttpRequest(CloseableHttpAsyncClient httpclient, HttpRequestBase proxyingRequest) throws IOException {
                 executed = true;
                 return response;
             }


### PR DESCRIPTION
apache client does not implements "should" of https://tools.ietf.org/html/rfc2616#section-8.2.2
thus 414 error from backend server are igrnored as payload stream closing generate 500 error.

where as apache async http client does.

upgrade sp from java 1.7 to 1.8 in order to catch many qualified exception at the same time.

refactor: create http client builder at proxy bean initialisation.