### PR TITLE
geoserver - adding s3-geotiff

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -30,5 +30,11 @@
         <module>geoserver-submodule/src/community/geofence-server</module>
       </modules>
     </profile>
+    <profile>
+      <id>s3-geotiff</id>
+      <modules>
+        <module>geoserver-submodule/src/community/s3-geotiff</module>
+      </modules>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Some versions of the plugin are not available on the boundless maven
repo. Considering building it from the sources to avoid having the build
fail because of the missing dependency.