### PR TITLE
Send ldap attributes in cas replies

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -61,7 +61,7 @@
                    | set its name to something other than its default name (typically the simple class name).
                    -->
                 <entry key-ref="proxyAuthenticationHandler" value-ref="principalResolver" />
-                <entry key-ref="ldapPasswordHandler" value-ref="principalResolver"/>
+                <entry key-ref="ldapPasswordHandler" value="#{null}"/>
             </map>
         </constructor-arg>
 
@@ -107,7 +107,15 @@
         <constructor-arg value="${ldap.authn.roleSearchFilter}" />
         <constructor-arg value="${ldap.authn.roleRoleAttribute}" />
         <constructor-arg value="${ldap.authn.pendingRoleName}" />
-
+        <property name="principalAttributeMap">
+          <map>
+            <entry key="mail" value="mail" />
+            <entry key="uid" value="uid" />
+            <entry key="memberOf" value="memberOf" />
+            <entry key="sn" value="sn" />
+            <entry key="givenName" value="givenName" />
+          </map>
+        </property>
     </bean>
 
     <!--
@@ -190,7 +198,17 @@
     <util:list id="registeredServicesList">
         <bean class="org.jasig.cas.services.RegexRegisteredService"
             p:id="0" p:name="HTTP and IMAP" p:description="Allows HTTP(S) and IMAP(S) protocols"
-            p:serviceId="^(https?|imaps?)://.*" p:evaluationOrder="10000001" />
+            p:serviceId="^(https?|imaps?)://.*" p:evaluationOrder="10000001">
+            <property name="allowedAttributes">
+              <list>
+                <value>uid</value>
+                <value>mail</value>
+                <value>memberOf</value>
+                <value>sn</value>
+                <value>givenName</value>
+              </list>
+            </property>
+        </bean>
         <!--
         Use the following definition instead of the above to further restrict access
         to services within your domain (including sub domains).

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/2.0/casServiceValidationSuccess.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/2.0/casServiceValidationSuccess.jsp
@@ -19,20 +19,52 @@
 
 --%>
 <%@ page session="false" contentType="application/xml; charset=UTF-8" %>
+<%@ page import="java.util.Map.Entry" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-	<cas:authenticationSuccess>
-		<cas:user>${fn:escapeXml(assertion.primaryAuthentication.principal.id)}</cas:user>
+    <cas:authenticationSuccess>
+        <cas:user>${fn:escapeXml(assertion.primaryAuthentication.principal.id)}</cas:user>
         <c:if test="${not empty pgtIou}">
-        		<cas:proxyGrantingTicket>${pgtIou}</cas:proxyGrantingTicket>
+            <cas:proxyGrantingTicket>${pgtIou}</cas:proxyGrantingTicket>
         </c:if>
         <c:if test="${fn:length(assertion.chainedAuthentications) > 1}">
-		  <cas:proxies>
-            <c:forEach var="proxy" items="${assertion.chainedAuthentications}" varStatus="loopStatus" begin="0" end="${fn:length(assertion.chainedAuthentications)-2}" step="1">
-			     <cas:proxy>${fn:escapeXml(proxy.principal.id)}</cas:proxy>
-            </c:forEach>
-		  </cas:proxies>
+            <cas:proxies>
+                <c:forEach var="proxy" items="${assertion.chainedAuthentications}" varStatus="loopStatus" begin="0"
+                           end="${fn:length(assertion.chainedAuthentications)-2}" step="1">
+                    <cas:proxy>${fn:escapeXml(proxy.principal.id)}</cas:proxy>
+                </c:forEach>
+            </cas:proxies>
         </c:if>
-	</cas:authenticationSuccess>
+
+        <c:if test="${fn:length(assertion.primaryAuthentication.principal.attributes) > 0}">
+            <cas:attributes>
+                <c:forEach var="attr"
+                           items="${assertion.primaryAuthentication.principal.attributes}"
+                           varStatus="loopStatus" begin="0"
+                           end="${fn:length(assertion.primaryAuthentication.principal.attributes)}"
+                           step="1">
+                   	<%-- ${attr.value['class'].simpleName} fails for List: use scriptlet instead --%>
+                   	<%
+                   	    Entry entry = (Entry) pageContext.getAttribute("attr");
+                   	    Object value = entry.getValue();
+                   	    pageContext.setAttribute("isAString", value instanceof String);
+                   	%>
+                    <c:choose>
+                        <%-- it's a String, output it once --%>
+                        <c:when test="${isAString}">
+                            <cas:${fn:escapeXml(attr.key)}>${fn:escapeXml(attr.value)}</cas:${fn:escapeXml(attr.key)}>
+                        </c:when>
+                        <%-- if attribute is multi-valued, list each value under the same attribute name --%>
+                        <c:otherwise>
+                            <c:forEach var="attrval" items="${attr.value}">
+                                <cas:${fn:escapeXml(attr.key)}>${fn:escapeXml(attrval)}</cas:${fn:escapeXml(attr.key)}>
+                            </c:forEach>
+                        </c:otherwise>
+                    </c:choose>
+                </c:forEach>
+            </cas:attributes>
+        </c:if>
+
+    </cas:authenticationSuccess>
 </cas:serviceResponse>


### PR DESCRIPTION
Probably not to merge as-is - needs discussion. But generally i dislike putting all apps behind the SP and hacking them to auth users based on headers, when the said apps have support for CAS, so let's try to improve this. Most bits come from @pierrejego , thanks :)

With this PR i can connect a drupal8 (using CAS 3.0) and a nextcloud (using CAS 2.0) to my CAS, nextcloud needs the casServiceValidationSuccess.jsp chunk (diff is large but that's mostly reindentation, and upstream code for 3.0) so that attributes are appended to the reply as it's done in 3.0, without it the user is authenticated by nextcloud but i cant map cas attributes to nextcloud profile fields (email, displayname..).

For some reason groups don't work yet, `memberOf` seems empty (thus not added in the reply), i think this is because it's an OpenLDAP operational attribute, but @pierrejego told me he managed to make it work. Having LDAP groups sent this way would be a huge improvement.

Removing the `principalResolver` from `ldapPasswordHandler` is awkward but seems required per https://apereo.github.io/cas/4.2.x/installation/Configuring-Principal-Resolution.html#principalresolver-vs-authenticationhandler

Of course we could send more user attributes...