### PR TITLE
ldapadmin - ensures that mvn clean removes previous JS builds

### DIFF
--- a/ldapadmin/pom.xml
+++ b/ldapadmin/pom.xml
@@ -417,6 +417,9 @@
             <fileset>
               <directory>${project.basedir}/node</directory>
             </fileset>
+            <fileset>
+              <directory>${project.basedir}/src/main/webapp/console/public</directory>
+            </fileset>
           </filesets>
         </configuration>
       </plugin>


### PR DESCRIPTION
Related to another issues with JS minifications / node & npmjs /
maven-frontend-plugin. After a `mvn clean process-resources` I was able to build a libraries.js with the expected size (if src/main/webapp/console/public/libraries.js is 1,124,823 bytes, then something went wrong with the JS minification and some code is missing ; expected size as of today / 16.12 branch: 1,286,819 bytes).
