### PR TITLE
so to avoid filename to be encoded twice a different way (once ' ' to '%…

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/GeotoolsFeatureReader.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/upload/GeotoolsFeatureReader.java
@@ -307,8 +307,7 @@ public class GeotoolsFeatureReader implements FeatureGeoFileReader {
 
         ShapefileDataStoreFactory storeFactory = new ShapefileDataStoreFactory();
 
-        FileDataStore store = storeFactory
-                .createDataStore(file.toURI().toURL());
+        FileDataStore store = storeFactory.createDataStore(file.toURL());
 
         String typeName = FilenameUtils.getBaseName(file.getAbsolutePath());
 


### PR DESCRIPTION
…20', once no encoding 'type name')