### PR TITLE
avoid synchronization trouble

### DIFF
--- a/console/src/main/java/org/georchestra/console/dao/AdvancedDelegationDao.java
+++ b/console/src/main/java/org/georchestra/console/dao/AdvancedDelegationDao.java
@@ -1,5 +1,6 @@
 package org.georchestra.console.dao;
 
+import com.mchange.v2.c3p0.ComboPooledDataSource;
 import org.georchestra.console.ds.OrgsDao;
 import org.georchestra.console.dto.Org;
 import org.georchestra.console.model.DelegationEntry;
@@ -30,14 +31,18 @@ public class AdvancedDelegationDao {
     @Autowired
     private OrgsDao orgsDao;
 
+    @Autowired
+    private ComboPooledDataSource ds;
+
     @PostConstruct
     public void init() throws SQLException {
-
+        ds.setTestConnectionOnCheckin(true);
+        ds.setTestConnectionOnCheckout(true);
     }
 
     public List<DelegationEntry> findByOrg(String org) throws SQLException {
         List<DelegationEntry> res = new LinkedList<DelegationEntry>();
-        PreparedStatement byOrgStatement = this.tm.getDataSource().getConnection().prepareStatement(
+        PreparedStatement byOrgStatement = ds.getConnection().prepareStatement(
                 "SELECT uid, array_to_string(orgs, ',') AS orgs, array_to_string(roles, ',') AS roles FROM console.delegations WHERE ? = ANY(orgs)");
         byOrgStatement.setString(1, org);
         return this.parseResults(byOrgStatement.executeQuery());
@@ -45,7 +50,7 @@ public class AdvancedDelegationDao {
 
     public List<DelegationEntry> findByRole(String cn) throws SQLException {
         List<DelegationEntry> res = new LinkedList<DelegationEntry>();
-        PreparedStatement byRoleStatement = this.tm.getDataSource().getConnection().prepareStatement(
+        PreparedStatement byRoleStatement = ds.getConnection().prepareStatement(
                 "SELECT uid, array_to_string(orgs, ',') AS orgs, array_to_string(roles, ',') AS roles FROM console.delegations WHERE ? = ANY(roles)");
         byRoleStatement.setString(1, cn);
         return this.parseResults(byRoleStatement.executeQuery());


### PR DESCRIPTION
and systematically recreate statement not relying on connection validity test