### PR TITLE
Common - add log details on database parameters when waiting for connection

### DIFF
--- a/commons/src/main/java/org/georchestra/commons/WaitForDb.java
+++ b/commons/src/main/java/org/georchestra/commons/WaitForDb.java
@@ -25,9 +25,9 @@ public class WaitForDb {
                 break;
             } catch (SQLException e) {
                 System.out.println("------------------------> DB not ready - waiting <---------------------------");
-                System.out.print(" url: ");
+                System.out.print(" url:             ");
                 System.out.println(this.getUrl());
-                System.out.print(" username: ");
+                System.out.print(" username:        ");
                 System.out.println(this.getUsername());
                 System.out.print(" driverClassName: ");
                 System.out.println(this.getDriverClassName());

--- a/commons/src/main/java/org/georchestra/commons/WaitForDb.java
+++ b/commons/src/main/java/org/georchestra/commons/WaitForDb.java
@@ -24,7 +24,13 @@ public class WaitForDb {
                 System.out.println("--------------------------------> DB OK <------------------------------------");
                 break;
             } catch (SQLException e) {
-                System.out.println("---------------------------> DB Not Ready waiting <--------------------------");
+                System.out.println("------------------------> DB not ready - waiting <---------------------------");
+                System.out.print(" url: ");
+                System.out.println(this.getUrl());
+                System.out.print(" username: ");
+                System.out.println(this.getUsername());
+                System.out.print(" driverClassName: ");
+                System.out.println(this.getDriverClassName());
                 try { Thread.sleep(1000l); } catch (InterruptedException e1) {}
             }
         }


### PR DESCRIPTION
Shows

```
------------------------> DB not ready - waiting <---------------------------
 url:             jdbc:postgresql://localhost:5432/georchestra
 username:        georchestra
 driverClassName: org.postgresql.Driver
```

instead of only

```
---------------------------> DB Not Ready waiting <--------------------------
```

I think it's an useful information if you are debugging and wondering why your database is not ready.