### PR TITLE
Fixes 2224 ({publicUrl} not substituted in extractor-email-ack-template.tpl)

### DIFF
--- a/extractorapp/README.md
+++ b/extractorapp/README.md
@@ -109,7 +109,7 @@ These variables are:
 
 These template variables are defined in extractorapp/src/main/java/extractorapp/ws/EmailFactoryDefault.java
 
-Note that you are free to define your own variables by using a custom EmailFactory, such as extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java.
+Note that you are free to define your own variables by using a custom EmailFactory, such as [extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java](src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java).
 In this case, be sure to specify emailfactory=org.georchestra.extractorapp.ws.EmailFactoryPigma in your_config/extractorapp/maven.filter
 
 

--- a/extractorapp/README.md
+++ b/extractorapp/README.md
@@ -98,7 +98,7 @@ For each extraction job, two emails are sent :
 Templates for these emails can be found in config/defaults/extractorapp/WEB-INF/templates/
 This gives you the opportunity to override them by copying to your own profile.
 
-By default, the ack mail template does not support string substitution, but the second email template does.
+By default, the ack mail template does not support string substitution (apart from `{publicUrl}`, that will be replaced by the instance URL), but the second email template does.
 These variables are:
  * **link** the HTTP link to download the data,
  * **emails** the recipient emails,

--- a/extractorapp/README.md
+++ b/extractorapp/README.md
@@ -109,7 +109,7 @@ These variables are:
 
 These template variables are defined in extractorapp/src/main/java/extractorapp/ws/EmailFactoryDefault.java
 
-Note that you are free to define your own variables by using a custom EmailFactory, such as extractorapp/src/main/java/extractorapp/ws/EmailFactoryPigma.java. 
+Note that you are free to define your own variables by using a custom EmailFactory, such as extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java.
 In this case, be sure to specify emailfactory=org.georchestra.extractorapp.ws.EmailFactoryPigma in your_config/extractorapp/maven.filter
 
 

--- a/extractorapp/README.md
+++ b/extractorapp/README.md
@@ -110,7 +110,7 @@ These variables are:
 These template variables are defined in extractorapp/src/main/java/extractorapp/ws/EmailFactoryDefault.java
 
 Note that you are free to define your own variables by using a custom EmailFactory, such as [extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java](src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java).
-In this case, be sure to specify emailfactory=org.georchestra.extractorapp.ws.EmailFactoryPigma in your_config/extractorapp/maven.filter
+In this case, be sure to specify `emailfactory=org.georchestra.extractorapp.ws.EmailFactoryPigma` in your_config/extractorapp/maven.filter
 
 
 How to run the extractor without Tomcat ?

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryDefault.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryDefault.java
@@ -79,7 +79,13 @@ public class EmailFactoryDefault extends AbstractEmailFactory {
 
             public void sendAck() throws AddressException, MessagingException {
                 LOG.debug("preparing to send extraction acknowledgement email");
-                sendMsg(msgAck);
+                String msg = new String(msgAck);
+                if (msg != null) {
+                    msg = msg.replaceAll("\\{publicUrl\\}", this.georConfig.getProperty("publicUrl"));
+                }
+                // Normalize newlines
+                msg = msg.replaceAll("\n[\n]+", "\n\n");
+                sendMsg(msg);
             }
         };
     }

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java
@@ -75,8 +75,14 @@ public class EmailFactoryPigma extends AbstractEmailFactory {
 		    
 		    public void sendAck() throws AddressException, MessagingException {
 		        LOG.debug("preparing to send extraction ack email");
-				sendMsg(msgAck);
+			String msg = new String(msgAck);
+			if (msg != null) {
+				msg = msg.replaceAll("\\{publicUrl\\}", this.georConfig.getProperty("publicUrl"));
 			}
+			// Normalize newlines
+			msg = msg.replaceAll("\n[\n]+", "\n\n");
+			sendMsg(msg);
+		    }
 		};
 	}
 


### PR DESCRIPTION
Replaces https://github.com/georchestra/georchestra/pull/2276