### PR TITLE
fixes #2028 (georchestra.datadir default value)

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -208,6 +208,12 @@
           <httpConnector>
             <port>8280</port>
           </httpConnector>
+          <systemProperties>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+          </systemProperty>
+        </systemProperties>
         </configuration>
       </plugin>
     </plugins>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -329,6 +329,12 @@
                     <httpConnector>
                         <port>8291</port>
                     </httpConnector>
+                    <systemProperties>
+                        <systemProperty>
+                            <name>georchestra.datadir</name>
+                            <value>/etc/georchestra</value>
+                        </systemProperty>
+                    </systemProperties>
                 </configuration>
             </plugin>
 

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -175,6 +175,12 @@
           <httpConnector>
             <port>8181</port>
           </httpConnector>
+          <systemProperties>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -550,6 +550,12 @@
           <httpConnector>
             <port>8286</port>
           </httpConnector>
+          <systemProperties>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -341,6 +341,10 @@
               <name>extractor.storage.dir</name>
               <value>target/</value>
             </systemProperty>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
           </systemProperties>
         </configuration>
       </plugin>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -118,33 +118,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>2.2</version>
-        <configuration>
-          <warSourceDirectory>${gwc.unpack.dir}</warSourceDirectory>
-          <webXml>${basedir}/src/main/webapp/WEB-INF/web.xml</webXml>
-          <filter>${confdir}/${project.artifactId}/maven.filter</filter>
-          <webResources>
-            <resource>
-              <filtering>false</filtering>
-              <directory>src/main/webapp</directory>
-              <excludes>
-                <exclude>gwc.properties</exclude>
-              </excludes>
-            </resource>
-            <resource>
-              <filtering>false</filtering>
-              <directory>${confdir}/${project.artifactId}</directory>
-              <excludes>
-                <exclude>maven.filter</exclude>
-                <exclude>README</exclude>
-              </excludes>
-            </resource>
-          </webResources>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.mortbay.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <version>7.5.0.v20110901</version>
@@ -173,7 +146,7 @@
             <contextPath>/gwc</contextPath>
             <descriptor>${basedir}/src/main/webapp/WEB-INF/web.xml</descriptor>
             <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
-              <resourcesAsCSV>${basedir}/src/main/webapp,${confdir}/${project.artifactId},${gwc.unpack.dir}</resourcesAsCSV>
+              <resourcesAsCSV>${basedir}/src/main/webapp,${gwc.unpack.dir}</resourcesAsCSV>
             </baseResource>
           </webAppConfig>
           <stopKey>GWC_JETTY_STOP</stopKey>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -178,6 +178,12 @@
           </webAppConfig>
           <stopKey>GWC_JETTY_STOP</stopKey>
           <stopPort>8090</stopPort>
+          <systemProperties>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
     </plugins>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -93,6 +93,12 @@
           <httpConnector>
             <port>8285</port>
           </httpConnector>
+          <systemProperties>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/mapfishapp/README.md
+++ b/mapfishapp/README.md
@@ -235,7 +235,11 @@ Clone the [geOrchestra datadir](https://github.com/georchestra/datadir/) into eg
 Once this is done, running mapfishapp is pretty simple with Jetty:
 
     $ cd mapfishapp
-    $ mvn -Dgeorchestra.datadir=/etc/georchestra -Dmapfish-print-config=/etc/georchestra/mapfishapp/print/config.yaml jetty:run
+    $ mvn jetty:run
+
+If you installed the datadir in another directory, eg `/var/tmp/georchestra`, you will have to provide the following options:
+
+    $ mvn -Dgeorchestra.datadir=/var/tmp/georchestra -Dmapfish-print-config=/var/tmp/georchestra/mapfishapp/print/config.yaml jetty:run
 
 Then, point your browser to [http://localhost:8287/mapfishapp/?noheader=true](http://localhost:8287/mapfishapp/?noheader=true).
 

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -246,6 +246,14 @@
               <name>org.geotools.referencing.forceXY</name>
               <value>true</value>
             </systemProperty>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
+            <systemProperty>
+              <name>mapfish-print-config</name>
+              <value>/etc/georchestra/mapfishapp/print/config.yaml</value>
+            </systemProperty>
           </systemProperties>
         </configuration>
       </plugin>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -261,6 +261,12 @@
           <httpConnector>
             <port>8180</port>
           </httpConnector>
+          <systemProperties>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
I created a commit per module, in order to ease future fixes if there is a need to.

## Modules where we modified pom.xml

Some modules directly call `georchestra.datadir` system property in the java code:

- [x] analytics
- [x] atlas
- [x] cas-server-webapp
- [x] console
- [x] security-proxy
- [x] geonetwork - PR proposed in the repository (https://github.com/georchestra/geonetwork/pull/99). We must merge that PR first in order to update the submodule commit hash.

Others depend on the commons module, passing it the `georchestra.datadir` system property (note that the previous list: analytics, atlas, console, security-proxy and cas-server-webapp, also depend on the commons module):

- [x] header
- [x] extractorapp
- [x] mapfishapp (note: we also set the `mapfish-print-config` property)
- [x] geowebcache-webapp (<strike>note: I could not test with jetty:run, due to https://github.com/georchestra/georchestra/issues/2252</strike> - fixed with 79adb5fa6edefda380a16f495462ea97aa35a51a)

## Modules left unmodified

Modules that use the `georchestra.datadir` system property, but that do not include the jetty-maven-plugin in the pom.xml are left as is, since the default system property is intended only for tests purposes using `mvn jetty:run`. That includes the following modules:

- [x] commons
- [x] geoserver

Other modules do not use the `georchestra.datadir` system property, so they do not need it to be set:

- [x] config
- [x] epsg-extension
- [x] geotools
- [x] ogc-server-statistics
- [x] root directory

Other do not have a `pom.xml`, so there is nothing to do:

- [x] docker
- [x] docs
- [x] ldap
- [x] migrations
- [x] postgresql
- [x] tests