### PR TITLE
Wip Fix/ldap org rename (#2270)

### DIFF
--- a/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
+++ b/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
@@ -20,6 +20,9 @@
 package org.georchestra.console.ds;
 
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.georchestra.console.dto.Org;
 import org.georchestra.console.dto.OrgExt;
 import org.georchestra.console.dto.ReferenceAware;
@@ -42,6 +45,7 @@ import javax.naming.directory.BasicAttributes;
 import javax.naming.ldap.LdapName;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -50,6 +54,7 @@ import java.util.List;
  */
 public class OrgsDao {
 
+    private static final Log LOG = LogFactory.getLog(OrgsDao.class.getName());
     private LdapTemplate ldapTemplate;
     private Name orgSearchBaseDN;
     private Name userSearchBaseDN;
@@ -175,7 +180,9 @@ public class OrgsDao {
         if (newName.compareTo(org.getReference().getDn()) != 0) {
             this.ldapTemplate.rename(org.getReference().getDn(), newName);
         }
-        this.ldapTemplate.rebind(newName, null, buildAttributes(org));
+        DirContextOperations context = this.ldapTemplate.lookupContext(newName);
+        mapToContext(org, context);
+        this.ldapTemplate.modifyAttributes(context);
     }
 
     public void update(OrgExt orgExt){
@@ -183,7 +190,9 @@ public class OrgsDao {
         if (newName.compareTo(orgExt.getReference().getDn()) != 0) {
             this.ldapTemplate.rename(orgExt.getReference().getDn(), newName);
         }
-        this.ldapTemplate.rebind(newName, null, buildAttributes(orgExt));
+        DirContextOperations context = this.ldapTemplate.lookupContext(newName);
+        mapToContext(orgExt, context);
+        this.ldapTemplate.modifyAttributes(context);
     }
 
     public void delete(Org org){
@@ -272,6 +281,48 @@ public class OrgsDao {
         return attrs;
     }
 
+    private void mapToContext(Org org, DirContextOperations context) {
+        context.setAttributeValues("objectClass", new String[] { "top", "groupOfMembers" });
+
+        // mandatory attrs
+        context.setAttributeValue("cn", org.getId());
+        context.setAttributeValue("ou", org.getShortName());
+        context.setAttributeValue("seeAlso", LdapNameBuilder.newInstance(this.orgSearchBaseDN + "," + this.basePath)
+                .add("o", org.getId()).build().toString());
+
+        // optional attrs ?
+        setOrgField(context, "o", org.getName());
+        setOrgField(context, "businessCategory", org.getStatus());
+
+        if(org.getMembers() != null && org.getMembers().size() > 0) {
+            List<String> membersDn = new ArrayList<String>();
+            for (String member : org.getMembers())
+                membersDn.add(buildUserDN(member).toString());
+            context.setAttributeValues("member", membersDn.toArray());
+        }
+
+        // todo: properly handle existing attrs ?
+        if(org.getCities() != null) {
+            StringBuilder buffer = new StringBuilder();
+            List<String> descriptions = new ArrayList<String>();
+            int maxFieldSize = 1000;
+
+            for (String city : org.getCities()) {
+                if (buffer.length() > maxFieldSize) {
+                    descriptions.add(buffer.substring(1));
+                    buffer = new StringBuilder();
+                }
+                buffer.append("," + city);
+            }
+            if (buffer.length() > 0)
+                descriptions.add(buffer.substring(1));
+
+            if(descriptions.size() > 0)
+                context.setAttributeValues("description", descriptions.toArray());
+        }
+    }
+
+
     private Attributes buildAttributes(OrgExt org) {
         Attributes attrs = new BasicAttributes();
         BasicAttribute ocattr = new BasicAttribute("objectclass");
@@ -288,6 +339,31 @@ public class OrgsDao {
             attrs.put("destinationIndicator", org.getNumericId().toString());
 
         return attrs;
+    }
+
+    private void mapToContext(OrgExt org, DirContextOperations context) {
+        context.setAttributeValues("objectClass", new String[] { "top", "organization" });
+        context.setAttributeValue("o", org.getId());
+        setOrgField(context, "businessCategory", org.getOrgType());
+        setOrgField(context, "postalAddress", org.getAddress());
+        setOrgField(context, "destinationIndicator", org.getNumericId().toString());
+    }
+
+    private void setOrgField(DirContextOperations context, String fieldName, Object value) {
+        if ((value instanceof String && !StringUtils.isEmpty(value.toString()))
+             || (!(value instanceof String) && value != null)) {
+            context.setAttributeValue(fieldName, value);
+        } else {
+            Object[] values = context.getObjectAttributes(fieldName);
+            if (values != null) {
+                if (values.length == 1) {
+                    LOG.info("Removing attribute " + fieldName);
+                    context.removeAttributeValue(fieldName, values[0]);
+                } else {
+                    LOG.error("Multiple values encountered for field " + fieldName + ", expected a single value");
+                }
+            }
+        }
     }
 
     public String[] getOrgTypeValues() {

--- a/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
+++ b/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
@@ -346,7 +346,8 @@ public class OrgsDao {
         context.setAttributeValue("o", org.getId());
         setOrgField(context, "businessCategory", org.getOrgType());
         setOrgField(context, "postalAddress", org.getAddress());
-        setOrgField(context, "destinationIndicator", org.getNumericId().toString());
+        if(org.getNumericId() != null)
+            setOrgField(context, "destinationIndicator", org.getNumericId().toString());
     }
 
     private void setOrgField(DirContextOperations context, String fieldName, Object value) {

--- a/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
+++ b/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
@@ -172,13 +172,17 @@ public class OrgsDao {
 
     public void update(Org org){
         Name newName = buildOrgDN(org.getId());
-        this.ldapTemplate.rename(org.getReference().getDn(), newName);
+        if (newName.compareTo(org.getReference().getDn()) != 0) {
+            this.ldapTemplate.rename(org.getReference().getDn(), newName);
+        }
         this.ldapTemplate.rebind(newName, null, buildAttributes(org));
     }
 
     public void update(OrgExt orgExt){
         Name newName = buildOrgExtDN(orgExt.getId());
-        this.ldapTemplate.rename(orgExt.getReference().getDn(), newName);
+        if (newName.compareTo(orgExt.getReference().getDn()) != 0) {
+            this.ldapTemplate.rename(orgExt.getReference().getDn(), newName);
+        }
         this.ldapTemplate.rebind(newName, null, buildAttributes(orgExt));
     }
 

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/orgs/OrgsController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/orgs/OrgsController.java
@@ -192,15 +192,15 @@ public class OrgsController {
     /**
      * Create a new org based on JSON document sent by browser. JSON document may contain following keys :
      *
-     * * 'name' (mandatory)
-     * * 'shortName'
+     * * 'name'
+     * * 'shortName' (mandatory)
      * * 'cities' as json array ex: [654,865498,98364,9834534,984984,6978984,98498]
      * * 'status'
      * * 'type'
      * * 'address'
      * * 'members' as json array ex: ["testadmin", "testuser"]
      *
-     * All fields are optional except 'name' which is used to generate organization identifier.
+     * All fields are optional except 'shortName' which is used to generate organization identifier.
      *
      * A new JSON document will be return to browser with a complete description of created org. @see updateOrgInfos()
      * for JSON format.
@@ -213,14 +213,14 @@ public class OrgsController {
         JSONObject json = this.parseRequest(request);
 
         // Validate request against required fields for admin part
-        if (!this.validation.validateOrgField("name", json))
-            throw new IOException("required field : name");
+        if (!this.validation.validateOrgField("shortName", json))
+            throw new IOException("required field : shortName");
 
         Org org = new Org();
         OrgExt orgExt = new OrgExt();
 
-        // Generate string identifier based on name
-        String id = this.orgDao.generateId(json.getString(Org.JSON_NAME));
+        // Generate string identifier based on shortName
+        String id = this.orgDao.generateId(json.getString(Org.JSON_SHORT_NAME));
         org.setId(id);
         orgExt.setId(id);
 
@@ -418,7 +418,7 @@ public class OrgsController {
      */
     private void updateFromRequest(Org org, JSONObject json){
         try{
-            org.setId(json.getString(Org.JSON_NAME));
+            org.setId(json.getString(Org.JSON_SHORT_NAME));
         } catch (JSONException ex){}
         try{
             org.setName(json.getString(Org.JSON_NAME));
@@ -462,7 +462,7 @@ public class OrgsController {
      */
     private void updateFromRequest(OrgExt orgExt, JSONObject json){
         try{
-            orgExt.setId(json.getString(Org.JSON_NAME));
+            orgExt.setId(json.getString(Org.JSON_SHORT_NAME));
         } catch (JSONException ex){}
         try{
             orgExt.setOrgType(json.getString(OrgExt.JSON_ORG_TYPE));


### PR DESCRIPTION
Partly fixes #2270, still need to work on the move from `rebind` to `modifyAttributes` but that pile of design pattern is a bit out of my comfort zone.

- i think it's been settled in the past that the `shortName` was the **key** for the dn in the `ou=orgs` branch, at least that's what we use in the sample ldap (cf https://github.com/georchestra/georchestra/blob/18.06/ldap/georchestra.ldif#L226, dn is `dn: cn=psc`, not `dn: cn=Project Steering Commitee`) - and it avoids all kinds of problems with spaces/special chars. 0e4f0ad fixes that & the surrounding comments/checks. As it's been wrong for the past releases, maybe a trivial shell or python script fixing the DIT would be needed.
- 56362af avoids uselessly calling the MODRDN operation if the dn didnt change.