### PR TITLE
[WIP] Fixes 2123 (fix properties loading order/conflicts)

### DIFF
--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -69,12 +69,9 @@
 
     <!-- Substitutes any ${...} variables in this (and loaded) spring configuration file
 				with values from the properties file -->
-    <context:property-placeholder location="/WEB-INF/analytics.properties"
-        ignore-resource-not-found="true" ignore-unresolvable="true" order="2" />
-
-    <context:property-placeholder
-        location="file:${georchestra.datadir}/analytics/analytics.properties"
-        ignore-resource-not-found="true" ignore-unresolvable="true" order="1" />
+    <context:property-placeholder location="/WEB-INF/analytics.properties,
+        file:${georchestra.datadir}/analytics/analytics.properties"
+        ignore-resource-not-found="true" ignore-unresolvable="true" />
 
     <bean id="statisticsController" class="org.georchestra.analytics.StatisticsController">
         <constructor-arg name="localTimezone" value="${localTimezone}"/>

--- a/atlas/src/main/resources/camel/atlas_app.xml
+++ b/atlas/src/main/resources/camel/atlas_app.xml
@@ -21,15 +21,10 @@
     <jpa:repositories base-package="org.georchestra.atlas.repository" />
 
     <context:property-placeholder
-      location="file:${georchestra.datadir}/atlas/atlas.properties"
-      ignore-resource-not-found="true" ignore-unresolvable="true" order="1" />
-
-    <context:property-placeholder
-            location="file:${georchestra.datadir}/default.properties"
-            ignore-resource-not-found="true" ignore-unresolvable="true" order="2" />
-
-    <context:property-placeholder location="classpath:atlas.properties"
-      ignore-resource-not-found="true" ignore-unresolvable="true" order="3" />
+      location="file:${georchestra.datadir}/default.properties,
+                classpath:atlas.properties,
+                file:${georchestra.datadir}/atlas/atlas.properties"
+      ignore-resource-not-found="true" ignore-unresolvable="true" />
 
     <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource" destroy-method="close">
         <property name="driverClass" value="org.postgresql.Driver"/>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/2123.

I created a commit per module, in order to ease future fixes if there is a need to.

Done:

- [x] atlas

Modules that do not take `default.properties` into account (see https://github.com/georchestra/georchestra/issues/2123#issuecomment-442622628):

- [x] analytics

Waiting:

- [ ] cas-server-webapp - it's complicated, because the [cas.properties](https://github.com/georchestra/georchestra/blob/master/cas-server-webapp/src/main/filtered-resources/WEB-INF/cas.properties) file is filtered using [maven.filter](https://github.com/georchestra/georchestra/blob/master/config/defaults/cas-server-webapp/maven.filter) from the config module. It's better to wait for #1417 to be solved first.
  One detail: it think the name of the directory "filtered-resources" is somewhat misleading, something like "resources-to-be-filtered" explains better what happens with these files.

To do:

- [ ] console - note that I don't touch the [applicationContext.xml](https://github.com/georchestra/georchestra/blob/master/console/src/main/resources/META-INF/spring/applicationContext.xml) file, see #2294
- [ ] security-proxy
- [ ] geonetwork
- [ ] header
- [ ] extractorapp
- [ ] mapfishapp
- [ ] geowebcache-webapp
- [ ] commons
- [ ] geoserver
- [ ] config
- [ ] epsg-extension
- [ ] geotools
- [ ] ogc-server-statistics
- [ ] root directory
- [ ] docker
- [ ] docs
- [ ] ldap
- [ ] migrations
- [ ] postgresql
- [ ] tests