### PR TITLE
analytics - fix properties loading order

### DIFF
--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -69,12 +69,9 @@
 
     <!-- Substitutes any ${...} variables in this (and loaded) spring configuration file
 				with values from the properties file -->
-    <context:property-placeholder location="/WEB-INF/analytics.properties"
-        ignore-resource-not-found="true" ignore-unresolvable="true" order="2" />
-
-    <context:property-placeholder
-        location="file:${georchestra.datadir}/analytics/analytics.properties"
-        ignore-resource-not-found="true" ignore-unresolvable="true" order="1" />
+    <context:property-placeholder location="/WEB-INF/analytics.properties,
+        file:${georchestra.datadir}/analytics/analytics.properties"
+        ignore-resource-not-found="true" ignore-unresolvable="true" />
 
     <bean id="statisticsController" class="org.georchestra.analytics.StatisticsController">
         <constructor-arg name="localTimezone" value="${localTimezone}"/>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/2123.

Tests done (with `mvn jetty:run`):
- works when only one file of `/WEB-INF/analytics.properties/` and
  `${georchestra.datadir}/analytics/analytics.properties` exists
- when both files exists:
  - introducing an error in `/WEB-INF/analytics.properties/` properties has no
    consequence, since `${georchestra.datadir}/analytics/analytics.properties`
    is used.
  - introducing an error in
    `${georchestra.datadir}/analytics/analytics.properties` properties breaks
    the application since the erroneous property is used, not the
    `/WEB-INF/analytics.properties/` one.
  - commenting a property in any of the files implies that the other
    file's property is used.