### PR TITLE
atlas - fix properties loading order

### DIFF
--- a/atlas/src/main/resources/camel/atlas_app.xml
+++ b/atlas/src/main/resources/camel/atlas_app.xml
@@ -21,15 +21,10 @@
     <jpa:repositories base-package="org.georchestra.atlas.repository" />
 
     <context:property-placeholder
-      location="file:${georchestra.datadir}/atlas/atlas.properties"
-      ignore-resource-not-found="true" ignore-unresolvable="true" order="1" />
-
-    <context:property-placeholder
-            location="file:${georchestra.datadir}/default.properties"
-            ignore-resource-not-found="true" ignore-unresolvable="true" order="2" />
-
-    <context:property-placeholder location="classpath:atlas.properties"
-      ignore-resource-not-found="true" ignore-unresolvable="true" order="3" />
+      location="file:${georchestra.datadir}/default.properties,
+                classpath:atlas.properties,
+                file:${georchestra.datadir}/atlas/atlas.properties"
+      ignore-resource-not-found="true" ignore-unresolvable="true" />
 
     <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource" destroy-method="close">
         <property name="driverClass" value="org.postgresql.Driver"/>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/2123.

Tests done (with `mvn jetty:run`, and playing with the `psql.url`
property):
- fails when none of the 3 files provides the property
- works when only one file provides the property
- follows the priority order:
  - least priority:   `${georchestra.datadir}/default.properties`
  - middle priority:  `/src/main/resources/atlas.properties`
  - highest priority: `${georchestra.datadir}/atlas/atlas.properties`