### PR TITLE
Fix postgis install & optimize docker image size

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -10,11 +10,12 @@ ENV DEBIAN_FRONTEND=noninteractive \
     POSTGRES_USER=georchestra
 
 RUN apt-get update && \
-    apt-get install -y postgresql-10-postgis-2.4 && \
+    apt-get install -y --no-install-recommends \
+        postgresql-10-postgis-2.4 \
+        postgresql-10-postgis-2.4-scripts && \
     rm -rf /var/lib/apt/lists/*
 
-COPY [0-9][0-9]* fix-owner.sql license.txt logo.png /docker-entrypoint-initdb.d/
-RUN chown -R postgres /docker-entrypoint-initdb.d/
+COPY --chown=postgres [0-9][0-9]* fix-owner.sql license.txt logo.png /docker-entrypoint-initdb.d/
 
 HEALTHCHECK --interval=30s --timeout=30s \
   CMD pg_isready -U $POSTGRES_USER


### PR DESCRIPTION
postgis seems to need the postgresql-10-postgis-2.4-scripts package to enable the create extension command (database init fails otherwise)
Bonus: the COPY --chown  reduces the size of the image