### PR TITLE
extractorapp - remove "languages" property that is never used.

### DIFF
--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/AbstractEmailFactory.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/AbstractEmailFactory.java
@@ -47,7 +47,6 @@ public abstract class AbstractEmailFactory {
 	protected String from;
 	protected String bodyEncoding;
 	protected String subjectEncoding;
-	protected String[] languages;
 	protected ExpiredArchiveDaemon expireDeamon;
 	protected String  emailAckTemplateFile;
 	protected String  emailTemplateFile;
@@ -69,7 +68,6 @@ public abstract class AbstractEmailFactory {
             emailHtml = georConfig.getProperty("emailHtml");
             replyTo = georConfig.getProperty("replyTo");
             from = georConfig.getProperty("from");
-            languages = georConfig.getProperty("language").split(",");
             extraKeywordsFile = String.format("i18n/extra_keywords_%s", georConfig.getProperty("language"));
             emailSubject = georConfig.getProperty("emailsubject");
             emailAckTemplateFile = String.format("%s/templates/extractor-email-ack-template.tpl", georConfig.getContextDataDir());
@@ -229,13 +227,6 @@ public abstract class AbstractEmailFactory {
     public void setSubjectEncoding(String subjectEncoding) {
         checkState();
         this.subjectEncoding = subjectEncoding;
-    }
-    public String[] getLanguages() {
-        return languages;
-    }
-    public void setLanguages(String[] languages) {
-        checkState();
-        this.languages = languages;
     }
     public ExpiredArchiveDaemon getExpireDeamon() {
     	return this.expireDeamon;

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/Email.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/Email.java
@@ -52,7 +52,6 @@ public abstract class Email {
     private String from;
     private String bodyEncoding;
     private String subjectEncoding;
-    private String[] languages;
     private String[] recipients;
     private String subject;
     
@@ -62,7 +61,7 @@ public abstract class Email {
             final String emailSubject, final String smtpHost,
             final int smtpPort, final String emailHtml, final String replyTo,
             final String from, final String bodyEncoding,
-            final String subjectEncoding, final String[] languages, GeorchestraConfiguration georConfig) {
+            final String subjectEncoding, GeorchestraConfiguration georConfig) {
 
         this.recipients = recipients;
         this.subject = emailSubject;
@@ -73,7 +72,6 @@ public abstract class Email {
         this.from = from;
         this.bodyEncoding = bodyEncoding;
         this.subjectEncoding = subjectEncoding;
-        this.languages = languages;
         this.georConfig = georConfig;
     }
 

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailDefaultParams.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailDefaultParams.java
@@ -37,7 +37,6 @@ public class EmailDefaultParams {
     private String from;
     private String bodyEncoding;
     private String subjectEncoding;
-    private String[] languages;
     
     private boolean frozen = false;
     
@@ -57,7 +56,6 @@ public class EmailDefaultParams {
         from = defaults.from;
         bodyEncoding = defaults.bodyEncoding;
         subjectEncoding = defaults.subjectEncoding;
-        languages = defaults.languages;
     }
     
     // -------------- Not public API -------------- // 
@@ -156,12 +154,5 @@ public class EmailDefaultParams {
     public void setSubjectEncoding(String subjectEncoding) {
         checkState();
         this.subjectEncoding = subjectEncoding;
-    }
-    public String[] getLanguages() {
-        return languages;
-    }
-    public void setLanguages(String[] languages) {
-        checkState();
-        this.languages = languages;
     }
 }

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryDefault.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryDefault.java
@@ -41,7 +41,7 @@ public class EmailFactoryDefault extends AbstractEmailFactory {
 
         return new Email(request, recipients, emailSubject, this.smtpHost,
                 this.smtpPort, this.emailHtml, this.replyTo, this.from,
-                this.bodyEncoding, this.subjectEncoding, this.languages, this.georConfig) {
+                this.bodyEncoding, this.subjectEncoding, this.georConfig) {
             public void sendDone(List<String> successes, List<String> failures,
                     List<String> oversized, long fileSize)
                     throws MessagingException {

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java
@@ -52,7 +52,7 @@ public class EmailFactoryPigma extends AbstractEmailFactory {
 				this.from,
 				this.bodyEncoding,
 				this.subjectEncoding,
-				this.languages, this.georConfig
+				this.georConfig
 		) {
 			public void sendDone(List<String> successes, List<String> failures,
 		            List<String> oversized, long fileSize) throws MessagingException {

--- a/extractorapp/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/extractorapp/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -57,7 +57,6 @@
         <property name="from" value="psc@georchestra.org"/>
         <property name="bodyEncoding" value="UTF-8"/>
         <property name="subjectEncoding" value="UTF-8"/>
-        <property name="languages" value="en"/>
         <property name="expireDeamon" ref="expire-daemon"/>
         <property name="emailTemplateFile" value="/WEB-INF/templates/extractor-email-template.txt"/>
         <property name="emailAckTemplateFile" value="/WEB-INF/templates/extractor-email-ack-template.txt"/>


### PR DESCRIPTION
I suggest removing this part of the code because it is useless (as far
as I could understand), and it could cause confusion with the
datadir "language" property.