### PR TITLE
Use instancename instead of hardcoded georchestra

### DIFF
--- a/console/src/main/java/org/georchestra/console/mailservice/Email.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/Email.java
@@ -137,6 +137,7 @@ public class Email {
 
 		// Replace {publicUrl} token with the configured public URL
         this.emailBody = this.emailBody.replaceAll("\\{publicUrl\\}", this.georConfig.getProperty("publicUrl"));
+        this.emailBody = this.emailBody.replaceAll("\\{instanceName\\}", this.georConfig.getProperty("instanceName"));
         LOG.debug("body: " + this.emailBody);
 
         final Session session = Session.getInstance(System.getProperties(), null);

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryDefault.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryDefault.java
@@ -59,6 +59,7 @@ public class EmailFactoryDefault extends AbstractEmailFactory {
                 String msg = new String(msgDone);
                 if (msg != null) {
                     msg = msg.replaceAll("\\{publicUrl\\}", this.georConfig.getProperty("publicUrl"));
+                    msg = msg.replaceAll("\\{instanceName\\}", this.georConfig.getProperty("instanceName"));
                     msg = msg.replace("{link}", url);
                     msg = msg.replace("{emails}", Arrays.toString(recipients));
                     msg = msg.replace("{expiry}", String.valueOf(expiry));
@@ -82,6 +83,7 @@ public class EmailFactoryDefault extends AbstractEmailFactory {
                 String msg = new String(msgAck);
                 if (msg != null) {
                     msg = msg.replaceAll("\\{publicUrl\\}", this.georConfig.getProperty("publicUrl"));
+                    msg = msg.replaceAll("\\{instanceName\\}", this.georConfig.getProperty("instanceName"));
                 }
                 // Normalize newlines
                 msg = msg.replaceAll("\n[\n]+", "\n\n");

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/EmailFactoryPigma.java
@@ -78,6 +78,7 @@ public class EmailFactoryPigma extends AbstractEmailFactory {
 			String msg = new String(msgAck);
 			if (msg != null) {
 				msg = msg.replaceAll("\\{publicUrl\\}", this.georConfig.getProperty("publicUrl"));
+				msg = msg.replaceAll("\\{instanceName\\}", this.georConfig.getProperty("instanceName"));
 			}
 			// Normalize newlines
 			msg = msg.replaceAll("\n[\n]+", "\n\n");


### PR DESCRIPTION
In extractorapp and console.

Note that we could also replace "[geOrchestra]" by the instance name in the subjects of the mails, but it requires some code, and it's easy to change directly in the datadir (6 occurrences). So I think we should let it to the platform administrators.