### PR TITLE
Fixes to ogc-server-statistics to pass all tests

### DIFF
--- a/ogc-server-statistics/pom.xml
+++ b/ogc-server-statistics/pom.xml
@@ -10,6 +10,7 @@
 	<name>ogc-server-statistics</name>
 	<url>http://maven.apache.org</url>
 	<properties>
+        <java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
@@ -19,6 +20,15 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.16</version>
 			</plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>${java.version}</source>
+                <target>${java.version}</target>
+                <encoding>${project.build.sourceEncoding}</encoding>
+              </configuration>
+            </plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/AbstractQueryCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/AbstractQueryCommand.java
@@ -77,31 +77,17 @@ public abstract class AbstractQueryCommand extends AbstractDataCommand implement
         assert this.connection != null: "database connection is null, use setConnection";
 
         // executes the sql statement and  populates the list with the data present in the result set
-        ResultSet rs = null;
-        PreparedStatement pStmt=null;
-        try {
-            pStmt = prepareStatement();
-          
-            rs = pStmt.executeQuery();
-            
-			this.resultList = new LinkedList<Map<String,Object>>();
+        try (PreparedStatement pStmt = prepareStatement()){
+			try (ResultSet rs = pStmt.executeQuery()) {
 
-            while (rs.next()) {
-                this.resultList.add( getRow(rs));
-            }
+				this.resultList = new LinkedList<>();
 
+				while (rs.next()) {
+					this.resultList.add(getRow(rs));
+				}
+			}
         } catch (SQLException e) {
-            
-            throw new DataCommandException(e.getMessage());
-            
-        } finally{
-            try {
-                if(rs != null) rs.close();
-                if(pStmt != null) pStmt.close();
-                
-            } catch (SQLException e1) {
-                throw new DataCommandException(e1.getMessage());
-            } 
+            throw new DataCommandException(e);
         }
 	}
 

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/DataServicesConfiguration.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/DataServicesConfiguration.java
@@ -19,7 +19,9 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 
 /**
  * This Singleton maintains the configuration data required to access to the database where

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/DeleteAllCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/DeleteAllCommand.java
@@ -19,6 +19,8 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -28,7 +30,7 @@ import java.sql.Statement;
  * @author Mauricio Pazos
  *
  */
-final public class DeleteAllCommand extends AbstractDataCommand {
+public final class DeleteAllCommand extends AbstractDataCommand {
 
 	/**
 	 * This method will execute a SQL Delete!
@@ -37,23 +39,10 @@ final public class DeleteAllCommand extends AbstractDataCommand {
 	 */
 	@Override
 	public void execute() throws DataCommandException {
-
-		//PreparedStatement pStmt=null;
-		Statement pStmt=null;
-        try {
-			pStmt = this.connection.createStatement();
-			pStmt.execute("DELETE FROM ogcstatistics.OGC_SERVICES_LOG");
-			
+        try (Statement pStmt = this.connection.createStatement()){
+			pStmt.execute(String.format("DELETE FROM %s", QUALIFIED_TABLE_NAME));
 		} catch (SQLException e) {
-			e.printStackTrace();
 			throw new DataCommandException(e);
-		} finally{
-            try {
-                if(pStmt != null) pStmt.close();
-                
-            } catch (SQLException e1) {
-                throw new DataCommandException(e1.getMessage());
-            } 
 		}
 	}
 }

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/InsertCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/InsertCommand.java
@@ -32,6 +32,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Map;
 
+import org.apache.log4j.Logger;
+
 /**
  * Insert an ogc service log
  * 
@@ -39,67 +41,69 @@ import java.util.Map;
  *
  */
 public final class InsertCommand extends AbstractDataCommand {
+    
+    private static final Logger LOGGER = Logger.getLogger(InsertCommand.class);
 
-	private static final String SQL_INSERT = "INSERT INTO " + QUALIFIED_TABLE_NAME + "(" + USER_COLUMN + ","
-			+ DATE_COLUMN + "," + SERVICE_COLUMN + "," + LAYER_COLUMN + "," + REQUEST_COLUMN + "," + ORG_COLUMN + ","
-			+ SECROLE_COLUMN + ") VALUES (?, ?, ?, ?, ?, ?, string_to_array(?, ','))";
+    private static final String SQL_INSERT = "INSERT INTO " + QUALIFIED_TABLE_NAME + "(" + USER_COLUMN + ","
+	    + DATE_COLUMN + "," + SERVICE_COLUMN + "," + LAYER_COLUMN + "," + REQUEST_COLUMN + "," + ORG_COLUMN + ","
+	    + SECROLE_COLUMN + ") VALUES (?, ?, ?, ?, ?, ?, string_to_array(?, ','))";
 
-	private Map<String, Object> rowValues;
+    private Map<String, Object> rowValues;
 
-	public void setRowValues(final Map<String, Object> ogcServiceLog) {
+    public void setRowValues(final Map<String, Object> ogcServiceLog) {
 
-		this.rowValues = ogcServiceLog;
+	this.rowValues = ogcServiceLog;
+    }
+
+    private PreparedStatement prepareStatement() throws SQLException {
+
+	assert this.connection != null : "database connection is null, use setConnection";
+
+	PreparedStatement pStmt = this.connection.prepareStatement(SQL_INSERT);
+	pStmt.setString(1, (String) this.rowValues.get(USER_COLUMN));
+
+	java.sql.Timestamp sqlDate = new java.sql.Timestamp(
+		((java.util.Date) this.rowValues.get(DATE_COLUMN)).getTime());
+	pStmt.setTimestamp(2, sqlDate);
+	pStmt.setString(3, ((String) this.rowValues.get(SERVICE_COLUMN)).trim());
+	pStmt.setString(4, ((String) this.rowValues.get(LAYER_COLUMN)).trim());
+	pStmt.setString(5, ((String) this.rowValues.get(REQUEST_COLUMN)).trim());
+	pStmt.setString(6, ((String) this.rowValues.get(ORG_COLUMN)).trim());
+	pStmt.setString(7, ((String) this.rowValues.get(SECROLE_COLUMN)).trim());
+
+	return pStmt;
+    }
+
+    @Override
+    public void execute() throws DataCommandException {
+
+	assert this.connection != null : "database connection is null, use setConnection";
+
+	try {
+	    this.connection.setAutoCommit(false);
+	} catch (SQLException e) {
+	    throw new DataCommandException(e);
 	}
 
-	private PreparedStatement prepareStatement() throws SQLException {
-
-		assert this.connection != null : "database connection is null, use setConnection";
-
-		PreparedStatement pStmt = this.connection.prepareStatement(SQL_INSERT);
-		pStmt.setString(1, (String) this.rowValues.get(USER_COLUMN));
-
-		java.sql.Timestamp sqlDate = new java.sql.Timestamp(
-				((java.util.Date) this.rowValues.get(DATE_COLUMN)).getTime());
-		pStmt.setTimestamp(2, sqlDate);
-		pStmt.setString(3, ((String) this.rowValues.get(SERVICE_COLUMN)).trim());
-		pStmt.setString(4, ((String) this.rowValues.get(LAYER_COLUMN)).trim());
-		pStmt.setString(5, ((String) this.rowValues.get(REQUEST_COLUMN)).trim());
-		pStmt.setString(6, ((String) this.rowValues.get(ORG_COLUMN)).trim());
-		pStmt.setString(7, ((String) this.rowValues.get(SECROLE_COLUMN)).trim());
-
-		return pStmt;
+	// executes the sql statement and checks that the update operation will be
+	// inserted one row in the table
+	try (PreparedStatement pStmt = prepareStatement()) {
+	    pStmt.executeUpdate();
+	    this.connection.commit();
+	} catch (SQLException e) {
+	    try {
+		this.connection.rollback();
+	    } catch (SQLException e1) {
+		throw new DataCommandException(e);
+	    }
+	    throw new DataCommandException(e);
+	} finally {
+	    try {
+		this.connection.setAutoCommit(true);
+	    } catch (SQLException e1) {
+		// ignore, it's bad practice to throw exceptions in finally blocks
+		LOGGER.warn("Error rolling back SQL transaction", e1);
+	    }
 	}
-
-	@Override
-	public void execute() throws DataCommandException {
-
-		assert this.connection != null : "database connection is null, use setConnection";
-
-		try {
-			this.connection.setAutoCommit(false);
-		} catch (SQLException e) {
-			throw new DataCommandException(e);
-		}
-
-		// executes the sql statement and checks that the update operation will be
-		// inserted one row in the table
-		try (PreparedStatement pStmt = prepareStatement()) {
-			pStmt.executeUpdate();
-			this.connection.commit();
-		} catch (SQLException e) {
-			try {
-				this.connection.rollback();
-			} catch (SQLException e1) {
-				throw new DataCommandException(e);
-			}
-			throw new DataCommandException(e);
-		} finally {
-			try {
-				this.connection.setAutoCommit(true);
-			} catch (SQLException e1) {
-				e1.printStackTrace();
-				//ignore, it's bad practice to throw exceptions in finally blocks
-			}
-		}
-	}
+    }
 }

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/InsertCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/InsertCommand.java
@@ -19,9 +19,15 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
-import org.georchestra.ogcservstatistics.log4j.OGCServiceParser;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.DATE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.ORG_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.REQUEST_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.SECROLE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.SERVICE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
 
-import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Map;
@@ -34,72 +40,66 @@ import java.util.Map;
  */
 public final class InsertCommand extends AbstractDataCommand {
 
-	private static final String SQL_INSERT= "INSERT INTO ogcstatistics.ogc_services_log(" + OGCServiceParser.USER_COLUMN +
-			"," + OGCServiceParser.DATE_COLUMN +
-			"," + OGCServiceParser.SERVICE_COLUMN +
-			"," + OGCServiceParser.LAYER_COLUMN +
-			"," + OGCServiceParser.REQUEST_COLUMN +
-			"," + OGCServiceParser.ORG_COLUMN +
-			"," + OGCServiceParser.SECROLE_COLUMN +
-			") VALUES (?, ?, ?, ?, ?, ?, string_to_array(?, ','))";
-	
+	private static final String SQL_INSERT = "INSERT INTO " + QUALIFIED_TABLE_NAME + "(" + USER_COLUMN + ","
+			+ DATE_COLUMN + "," + SERVICE_COLUMN + "," + LAYER_COLUMN + "," + REQUEST_COLUMN + "," + ORG_COLUMN + ","
+			+ SECROLE_COLUMN + ") VALUES (?, ?, ?, ?, ?, ?, string_to_array(?, ','))";
+
 	private Map<String, Object> rowValues;
-	
 
 	public void setRowValues(final Map<String, Object> ogcServiceLog) {
-		
+
 		this.rowValues = ogcServiceLog;
 	}
 
 	private PreparedStatement prepareStatement() throws SQLException {
 
-        assert this.connection != null: "database connection is null, use setConnection";
+		assert this.connection != null : "database connection is null, use setConnection";
 
-        PreparedStatement pStmt = this.connection.prepareStatement(SQL_INSERT);
-        pStmt.setString(1, (String)this.rowValues.get(OGCServiceParser.USER_COLUMN));
+		PreparedStatement pStmt = this.connection.prepareStatement(SQL_INSERT);
+		pStmt.setString(1, (String) this.rowValues.get(USER_COLUMN));
 
-		java.sql.Timestamp sqlDate = new java.sql.Timestamp(((java.util.Date) this.rowValues.get(OGCServiceParser.DATE_COLUMN)).getTime());
+		java.sql.Timestamp sqlDate = new java.sql.Timestamp(
+				((java.util.Date) this.rowValues.get(DATE_COLUMN)).getTime());
 		pStmt.setTimestamp(2, sqlDate);
-		pStmt.setString(3, ((String)this.rowValues.get(OGCServiceParser.SERVICE_COLUMN)).trim());
-        pStmt.setString(4, ((String)this.rowValues.get(OGCServiceParser.LAYER_COLUMN)).trim());
-        pStmt.setString(5, ((String)this.rowValues.get(OGCServiceParser.REQUEST_COLUMN)).trim());
-        pStmt.setString(6, ((String)this.rowValues.get(OGCServiceParser.ORG_COLUMN)).trim());
-        pStmt.setString(7, ((String)this.rowValues.get(OGCServiceParser.SECROLE_COLUMN)).trim());
-        
+		pStmt.setString(3, ((String) this.rowValues.get(SERVICE_COLUMN)).trim());
+		pStmt.setString(4, ((String) this.rowValues.get(LAYER_COLUMN)).trim());
+		pStmt.setString(5, ((String) this.rowValues.get(REQUEST_COLUMN)).trim());
+		pStmt.setString(6, ((String) this.rowValues.get(ORG_COLUMN)).trim());
+		pStmt.setString(7, ((String) this.rowValues.get(SECROLE_COLUMN)).trim());
+
 		return pStmt;
 	}
 
 	@Override
 	public void execute() throws DataCommandException {
-		
-        assert this.connection != null: "database connection is null, use setConnection";
 
-        // executes the sql statement and checks that the update operation will be inserted one row in the table
-        PreparedStatement pStmt=null;
-        try {
-        	this.connection.setAutoCommit(false);
-            pStmt = prepareStatement();
-            pStmt.executeUpdate();
-            this.connection.commit();
-        } catch (SQLException e) {
-        	if(this.connection != null){
-        		try {
-					this.connection.rollback();
-				} catch (SQLException e1) {
-					e1.printStackTrace();
-		            throw new DataCommandException(e.getMessage());
-				}
-	            throw new DataCommandException(e.getMessage());
-        	}
-        } finally{
-            try {
-                if(pStmt != null) pStmt.close();
-            	this.connection.setAutoCommit(true);
-                
-            } catch (SQLException e1) {
-                throw new DataCommandException(e1.getMessage());
-            } 
-        }
-		
+		assert this.connection != null : "database connection is null, use setConnection";
+
+		try {
+			this.connection.setAutoCommit(false);
+		} catch (SQLException e) {
+			throw new DataCommandException(e);
+		}
+
+		// executes the sql statement and checks that the update operation will be
+		// inserted one row in the table
+		try (PreparedStatement pStmt = prepareStatement()) {
+			pStmt.executeUpdate();
+			this.connection.commit();
+		} catch (SQLException e) {
+			try {
+				this.connection.rollback();
+			} catch (SQLException e1) {
+				throw new DataCommandException(e);
+			}
+			throw new DataCommandException(e);
+		} finally {
+			try {
+				this.connection.setAutoCommit(true);
+			} catch (SQLException e1) {
+				e1.printStackTrace();
+				//ignore, it's bad practice to throw exceptions in finally blocks
+			}
+		}
 	}
 }

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/LogColumns.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/LogColumns.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.ogcservstatistics.dataservices;
+
+/**
+ * Constants for log's table and column names
+ */
+public final class LogColumns {
+
+	public static final String QUALIFIED_TABLE_NAME = "ogcstatistics.OGC_SERVICES_LOG";
+
+	public static final String DATE_COLUMN = "date";
+	public static final String USER_COLUMN = "user_name";
+	public static final String SERVICE_COLUMN = "service";
+	public static final String LAYER_COLUMN = "layer";
+	public static final String REQUEST_COLUMN = "request";
+	public static final String ORG_COLUMN = "org";
+	public static final String SECROLE_COLUMN = "roles";
+
+	private LogColumns() {
+		// private constructor, force class being purely a utility class
+	}
+}

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveAllCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveAllCommand.java
@@ -37,7 +37,7 @@ final public class RetrieveAllCommand extends AbstractQueryCommand{
 	final static String USER__COLUMN = "user_name";
 	final static String SERVICE_COLUMN = "service";
 	final static String LAYER_COLUMN = "layer";
-	final static String SECROLE_COLUMN = "secrole";
+	final static String SECROLE_COLUMN = "roles";
 
 	
 	final static String SQL = " SELECT "+ DATE_COLUMN+ "," + USER__COLUMN +","+ SERVICE_COLUMN+","+LAYER_COLUMN+","+SECROLE_COLUMN  

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveAllCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveAllCommand.java
@@ -19,6 +19,13 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.DATE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.SECROLE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.SERVICE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -31,31 +38,21 @@ import java.util.Map;
  * @author Mauricio Pazos
  *
  */
-final public class RetrieveAllCommand extends AbstractQueryCommand{
+public final class RetrieveAllCommand extends AbstractQueryCommand{
 
-	final static String DATE_COLUMN = "date";
-	final static String USER__COLUMN = "user_name";
-	final static String SERVICE_COLUMN = "service";
-	final static String LAYER_COLUMN = "layer";
-	final static String SECROLE_COLUMN = "roles";
-
-	
-	final static String SQL = " SELECT "+ DATE_COLUMN+ "," + USER__COLUMN +","+ SERVICE_COLUMN+","+LAYER_COLUMN+","+SECROLE_COLUMN  
-							+ " FROM ogcstatistics.OGC_SERVICES_LOG"
-							+ " ORDER BY "+ DATE_COLUMN+ "," + USER__COLUMN +","+ SERVICE_COLUMN+","+LAYER_COLUMN+","+SECROLE_COLUMN;
+	private static final String SQL = " SELECT "+ DATE_COLUMN+ "," + USER_COLUMN +","+ SERVICE_COLUMN+","+LAYER_COLUMN+","+SECROLE_COLUMN  
+							+ " FROM " + QUALIFIED_TABLE_NAME 
+							+ " ORDER BY "+ DATE_COLUMN+ "," + USER_COLUMN +","+ SERVICE_COLUMN+","+LAYER_COLUMN+","+SECROLE_COLUMN;
  	
 	protected PreparedStatement prepareStatement() throws SQLException{
-
-		PreparedStatement pStmt = this.connection.prepareStatement(SQL);
-		
-		return pStmt;
+		return connection.prepareStatement(SQL);
 	}
 
 	protected Map<String, Object> getRow(ResultSet rs) throws SQLException{
 		
-		Map<String,Object> row = new HashMap<String, Object>(5);
+		Map<String,Object> row = new HashMap<>(5);
 		row.put(DATE_COLUMN, rs.getDate(DATE_COLUMN));
-		row.put(USER__COLUMN, rs.getString(USER__COLUMN));
+		row.put(USER_COLUMN, rs.getString(USER_COLUMN));
 		row.put(SERVICE_COLUMN, rs.getString(SERVICE_COLUMN));
 		row.put(LAYER_COLUMN, rs.getString(LAYER_COLUMN));
 		row.put(SECROLE_COLUMN, rs.getString(SECROLE_COLUMN));

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveLayerConnectionsForUserCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveLayerConnectionsForUserCommand.java
@@ -19,8 +19,8 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
-import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
 import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
 import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
 
 import java.sql.PreparedStatement;

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveLayerConnectionsForUserCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveLayerConnectionsForUserCommand.java
@@ -19,6 +19,10 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -31,11 +35,9 @@ import java.util.Map;
  * @author Mauricio Pazos
  *
  */
-final public class RetrieveLayerConnectionsForUserCommand extends AbstractQueryCommand {
-
-	final static String USER_COLUMN 		= "user_name";
-	final static String LAYER_COLUMN 		= "layer";
-	final static String CONNECTIONS_COLUMN 	= "connections";
+public final class RetrieveLayerConnectionsForUserCommand extends AbstractQueryCommand {
+	
+	private static final String CONNECTIONS_COLUMN 	= "connections";
 
 	/**
 	 * builds the sql query taking into account if a month is or isn't specified.
@@ -49,7 +51,7 @@ final public class RetrieveLayerConnectionsForUserCommand extends AbstractQueryC
 		sql.append(" SELECT ")
 				.append(USER_COLUMN).append(",").append(LAYER_COLUMN )
 				.append(",count(").append(LAYER_COLUMN).append(") as ").append(CONNECTIONS_COLUMN)
-				.append(" FROM ogcstatistics.OGC_SERVICES_LOG");
+				.append(" FROM ").append(QUALIFIED_TABLE_NAME);
 		if(this.month > 0){
 			sql.append(" WHERE EXTRACT(ISOYEAR FROM date) = ? AND EXTRACT(MONTH FROM date) = ?");
 		} else {

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveMostActiveUsers.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveMostActiveUsers.java
@@ -19,6 +19,9 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -32,9 +35,9 @@ import java.util.Map;
  * @author Mauricio Pazos
  *
  */
-final public class RetrieveMostActiveUsers extends AbstractQueryCommand{
-	final static String USER_COLUMN 		= "user_name";
-	final static String CONNECTIONS_COLUMN 	= "connections";
+public final class RetrieveMostActiveUsers extends AbstractQueryCommand{
+
+	private static final String CONNECTIONS_COLUMN 	= "connections";
 	/**
 	 * builds the sql query taking into account if a month is or isn't specified.
 	 * 
@@ -47,7 +50,7 @@ final public class RetrieveMostActiveUsers extends AbstractQueryCommand{
 		sql.append(" SELECT ")
 				.append(USER_COLUMN)
 				.append(",count(").append(USER_COLUMN).append(") as ").append(CONNECTIONS_COLUMN)
-				.append(" FROM ogcstatistics.OGC_SERVICES_LOG");
+				.append(" FROM ").append(QUALIFIED_TABLE_NAME);
 		if(this.month > 0){
 			sql.append(" WHERE EXTRACT(ISOYEAR FROM date) = ? AND EXTRACT(MONTH FROM date) = ?");
 		} else {
@@ -85,7 +88,7 @@ final public class RetrieveMostActiveUsers extends AbstractQueryCommand{
 
 	@Override
 	protected Map<String, Object> getRow(ResultSet rs) throws SQLException {
-		Map<String,Object> row = new HashMap<String, Object>(4);
+		Map<String,Object> row = new HashMap<>(4);
 		row.put(USER_COLUMN, rs.getString(USER_COLUMN));
 		row.put(CONNECTIONS_COLUMN, rs.getInt(CONNECTIONS_COLUMN));
 		

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveMostConsultedLayers.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveMostConsultedLayers.java
@@ -19,8 +19,8 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
-import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
 import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveMostConsultedLayers.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveMostConsultedLayers.java
@@ -19,6 +19,9 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -31,10 +34,9 @@ import java.util.Map;
  * @author Mauricio Pazos
  *
  */
-final public class RetrieveMostConsultedLayers extends AbstractQueryCommand {
-	
-	final static String LAYER_COLUMN 		= "layer";
-	final static String CONNECTIONS_COLUMN 	= "connections";
+public final class RetrieveMostConsultedLayers extends AbstractQueryCommand {
+
+	private static final String CONNECTIONS_COLUMN 	= "connections";
 
 	/**
 	 * builds the sql query taking into account if a month is or isn't specified.
@@ -48,7 +50,7 @@ final public class RetrieveMostConsultedLayers extends AbstractQueryCommand {
 		sql.append(" SELECT ")
 				.append(LAYER_COLUMN)
 				.append(",count(").append(LAYER_COLUMN).append(") as ").append(CONNECTIONS_COLUMN)
-				.append(" FROM ogcstatistics.OGC_SERVICES_LOG");
+				.append(" FROM ").append(QUALIFIED_TABLE_NAME);
 		if(this.month > 0){
 			sql.append(" WHERE EXTRACT(ISOYEAR FROM date) = ? AND EXTRACT(MONTH FROM date) = ?");
 		} else {
@@ -86,7 +88,7 @@ final public class RetrieveMostConsultedLayers extends AbstractQueryCommand {
 
 	@Override
 	protected Map<String, Object> getRow(ResultSet rs) throws SQLException {
-		Map<String,Object> row = new HashMap<String, Object>(4);
+		Map<String,Object> row = new HashMap<>(4);
 		row.put(LAYER_COLUMN, rs.getString(LAYER_COLUMN));
 		row.put(CONNECTIONS_COLUMN, rs.getInt(CONNECTIONS_COLUMN));
 		

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveUserConnectionForLayerCommand.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/dataservices/RetrieveUserConnectionForLayerCommand.java
@@ -19,6 +19,10 @@
 
 package org.georchestra.ogcservstatistics.dataservices;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.QUALIFIED_TABLE_NAME;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -34,9 +38,7 @@ import java.util.Map;
  */
 public final class RetrieveUserConnectionForLayerCommand extends AbstractQueryCommand {
 
-	final static String LAYER_COLUMN 		= "layer";
-	final static String USER_COLUMN 		= "user_name";
-	final static String CONNECTIONS_COLUMN 	= "connections";
+	private static final String CONNECTIONS_COLUMN = "connections";
 	
 	/**
 	 * builds the sql query taking into account if a month is or isn't specified
@@ -47,7 +49,7 @@ public final class RetrieveUserConnectionForLayerCommand extends AbstractQueryCo
 		StringBuilder sql = new StringBuilder();
 
 		sql.append(" SELECT ").append(LAYER_COLUMN ).append(",").append(USER_COLUMN ).append(",count("+USER_COLUMN+") as ").append(CONNECTIONS_COLUMN)
-				.append(" FROM ogcstatistics.OGC_SERVICES_LOG");
+				.append(" FROM ").append(QUALIFIED_TABLE_NAME);
 		if(this.month > 0){
 			sql.append(" WHERE EXTRACT(ISOYEAR FROM date) = ? AND EXTRACT(MONTH FROM date) = ?");
 		} else {
@@ -65,9 +67,9 @@ public final class RetrieveUserConnectionForLayerCommand extends AbstractQueryCo
 	@Override
 	protected PreparedStatement prepareStatement() throws SQLException {
 
-		PreparedStatement pStmt = this.connection.prepareStatement(getSQLStatement());
 		assert year > 0 :"year is expected";
 
+		PreparedStatement pStmt = this.connection.prepareStatement(getSQLStatement());
 		pStmt.setInt(1, this.year);
 
 		//if the month was specified then sets it in the statement
@@ -89,7 +91,7 @@ public final class RetrieveUserConnectionForLayerCommand extends AbstractQueryCo
 	@Override
 	protected Map<String, Object> getRow(ResultSet rs) throws SQLException {
 		
-		Map<String,Object> row = new HashMap<String, Object>(2);
+		Map<String,Object> row = new HashMap<>(3);
 		row.put(LAYER_COLUMN, rs.getString(LAYER_COLUMN));
 		row.put(USER_COLUMN, rs.getString(USER_COLUMN));
 		row.put(CONNECTIONS_COLUMN, rs.getInt(CONNECTIONS_COLUMN));

--- a/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/log4j/OGCServiceParser.java
+++ b/ogc-server-statistics/src/main/java/org/georchestra/ogcservstatistics/log4j/OGCServiceParser.java
@@ -19,6 +19,14 @@
 
 package org.georchestra.ogcservstatistics.log4j;
 
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.DATE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.LAYER_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.ORG_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.REQUEST_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.SECROLE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.SERVICE_COLUMN;
+import static org.georchestra.ogcservstatistics.dataservices.LogColumns.USER_COLUMN;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.text.DateFormat;
@@ -39,15 +47,6 @@ import java.util.Map;
  *
  */
 public final class OGCServiceParser {
-
-	// Key for hashmap that holds logs information
-	public final static String DATE_COLUMN = "date";
-	public final static String USER_COLUMN = "user_name";
-	public final static String SERVICE_COLUMN = "service";
-	public final static String LAYER_COLUMN = "layer";
-	public final static String REQUEST_COLUMN = "request";
-	public final static String ORG_COLUMN = "org";
-	public final static String SECROLE_COLUMN = "roles";
 
 	private static final String SERVICE_KEYWORD = "SERVICE=";
 	private static final String REQUEST_KEYWORD = "REQUEST=";

--- a/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/calculations/OGCServiceStatisticsTest.java
+++ b/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/calculations/OGCServiceStatisticsTest.java
@@ -6,6 +6,7 @@ package org.georchestra.ogcservstatistics.calculations;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -14,10 +15,12 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.georchestra.ogcservstatistics.OGCServStatisticsException;
-import org.georchestra.ogcservstatistics.calculations.OGCServiceStatistics;
+import org.georchestra.ogcservstatistics.dataservices.DataCommandException;
 import org.georchestra.ogcservstatistics.dataservices.DataServicesConfiguration;
 import org.georchestra.ogcservstatistics.dataservices.DeleteAllCommand;
 import org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter;
+import org.georchestra.ogcservstatistics.log4j.OGCServicesAppender;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 
@@ -33,52 +36,44 @@ import org.junit.Test;
  */
 public class OGCServiceStatisticsTest {
 
-	private final static Logger LOGGER = Logger.getLogger( OGCServiceStatisticsTest.class);
+	//There's no logger configured for this package, use OGCServicesAppender's
+	private final static Logger LOGGER = Logger.getLogger( OGCServicesAppender.class);
+	
 	private final static Date time = Calendar.getInstance().getTime();
 	
-	static{
+	public static @BeforeClass void initialize() throws ClassNotFoundException, SQLException, DataCommandException {
 		// WARNING: because this test will delete all log before execute the test method
 		// you should configure a test table in the log4j.properties file
 		final String file = "src/test/resources/org/georchestra/ogcservstatistics/log4j.properties";
 		OGCServiceStatistics.configure(file);
 
-		try {
-			// the log table Initialize
-			
-			DeleteAllCommand cmd = new DeleteAllCommand();
-			cmd.setConnection(DataServicesConfiguration.getInstance().getConnection());
-			cmd.execute();
-			
-			// add the initial logs
+		// the log table Initialize
 
-			// user101: one request layer1 (WFS) and two for layer2 (using WFS and WMS) 
-			String request;
-			String [] roles = null;
-			
-			request = "http://www.someserver.com/wfs.cgi&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=layer1&FILTER=<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>10 10<gml:lowerCorner><gml:upperCorner>20 20</gml:upperCorner></gml:Envelope></Within></Filter>";
-			LOGGER.info(OGCServiceMessageFormatter.format("user101", request,"",roles));
-			
-			request = "http://www.someserver.com/wfs.cgi&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=layer2&FILTER=<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>10 10<gml:lowerCorner><gml:upperCorner>20 20</gml:upperCorner></gml:Envelope></Within></Filter>";
-			LOGGER.info(OGCServiceMessageFormatter.format("user102", request,"",roles));
-			
-			request = "http://www.someserver.com/geoserver/wms?SERVICE=WMS&LAYERS=layer2&TRANSPARENT=true&VERSION=1.1.1&FORMAT=image%2Fpng&REQUEST=GetMap&STYLES=&SRS=EPSG%3A2154&BBOX=358976.61292821,6395407.8064641,430656.57422103,6467087.7677569&WIDTH=512&HEIGHT=512";
-			LOGGER.info(OGCServiceMessageFormatter.format("user101", request,"",roles));
-			
-			// user102: one request layer1 using WFS and other using WMS
-			request = "http://www.someserver.com/wfs.cgi&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=layer1&FILTER=<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>10 10<gml:lowerCorner><gml:upperCorner>20 20</gml:upperCorner></gml:Envelope></Within></Filter>";
-			LOGGER.info(OGCServiceMessageFormatter.format("user101", request,"",roles));
-			
-			request = "http://www.someserver.com/geoserver/wms?SERVICE=WMS&LAYERS=layer1&TRANSPARENT=true&VERSION=1.1.1&FORMAT=image%2Fpng&REQUEST=GetMap&STYLES=&SRS=EPSG%3A2154&BBOX=358976.61292821,6395407.8064641,430656.57422103,6467087.7677569&WIDTH=512&HEIGHT=512";
-			LOGGER.info(OGCServiceMessageFormatter.format("user101", request,"",roles));
-			
-			
-			
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	
-	
-	
+		DeleteAllCommand cmd = new DeleteAllCommand();
+		cmd.setConnection(DataServicesConfiguration.getInstance().getConnection());
+		cmd.execute();
+
+		// add the initial logs
+
+		// user101: one request layer1 (WFS) and two for layer2 (using WFS and WMS)
+		String request;
+		String[] roles = new String[] {"ROLE1", "ROLE2"};
+
+		request = "http://www.someserver.com/wfs.cgi&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=layer1&FILTER=<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>10 10<gml:lowerCorner><gml:upperCorner>20 20</gml:upperCorner></gml:Envelope></Within></Filter>";
+		LOGGER.info(OGCServiceMessageFormatter.format("user101", request, "", roles));
+
+		request = "http://www.someserver.com/wfs.cgi&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=layer2&FILTER=<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>10 10<gml:lowerCorner><gml:upperCorner>20 20</gml:upperCorner></gml:Envelope></Within></Filter>";
+		LOGGER.info(OGCServiceMessageFormatter.format("user102", request, "", roles));
+
+		request = "http://www.someserver.com/geoserver/wms?SERVICE=WMS&LAYERS=layer2&TRANSPARENT=true&VERSION=1.1.1&FORMAT=image%2Fpng&REQUEST=GetMap&STYLES=&SRS=EPSG%3A2154&BBOX=358976.61292821,6395407.8064641,430656.57422103,6467087.7677569&WIDTH=512&HEIGHT=512";
+		LOGGER.info(OGCServiceMessageFormatter.format("user101", request, "", roles));
+
+		// user102: one request layer1 using WFS and other using WMS
+		request = "http://www.someserver.com/wfs.cgi&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=layer1&FILTER=<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>10 10<gml:lowerCorner><gml:upperCorner>20 20</gml:upperCorner></gml:Envelope></Within></Filter>";
+		LOGGER.info(OGCServiceMessageFormatter.format("user101", request, "", roles));
+
+		request = "http://www.someserver.com/geoserver/wms?SERVICE=WMS&LAYERS=layer1&TRANSPARENT=true&VERSION=1.1.1&FORMAT=image%2Fpng&REQUEST=GetMap&STYLES=&SRS=EPSG%3A2154&BBOX=358976.61292821,6395407.8064641,430656.57422103,6467087.7677569&WIDTH=512&HEIGHT=512";
+		LOGGER.info(OGCServiceMessageFormatter.format("user101", request, "", roles));
 	}
 	
 	/**

--- a/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/log4j/DisableLoggingTest.java
+++ b/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/log4j/DisableLoggingTest.java
@@ -5,56 +5,54 @@ package org.georchestra.ogcservstatistics.log4j;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.apache.log4j.PropertyConfigurator;
 import org.georchestra.ogcservstatistics.calculations.OGCServiceStatistics;
-import org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-
 /**
- * Test case for activated key. It is configured in false to avoid the insertion of log messages
+ * Test case for deactivated appender, set to false to avoid the insertion of
+ * log messages
  * 
  * @author Mauricio Pazos
  *
  */
 public class DisableLoggingTest {
 
-	
-	private static final Logger LOGGER = Logger.getLogger(OGCServicesAppenderTest.class);
+    private Logger LOGGER;
 
+    public static @BeforeClass void initialize() {
+	// activated=false in the porperties files
+	String file = "src/test/resources/org/georchestra/ogcservstatistics/log4j-disable.properties";
+	OGCServiceStatistics.configure(file);
+    }
 
-	static{
-		// activated=false in the porperties files
-		String file = "src/test/resources/org/georchestra/ogcservstatistics/log4j-disable.properties";
-		PropertyConfigurator.configure(file);
-	}
+    public @Before void before() {
+	LOGGER = Logger.getLogger(OGCServicesAppenderTest.class.getName());
+    }
 
-	/**
-	 * the following log message is not inserted
-	 * @throws Exception
-	 */
-	@Test
-	public void testOGCOperationLogging() throws Exception {
-		
-		List<Map<String, Object>> logList = OGCServiceStatistics.list();
-		final int logSizeBefore = logList.size();
+    /**
+     * the following log message is not inserted
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testOGCOperationLogging() throws Exception {
+	List<Map<String, Object>> logList = OGCServiceStatistics.list();
+	final int logSizeBefore = logList.size();
 
-		final Date time = Calendar.getInstance().getTime();
+	final String request = "http://www.someserver.com/geoserver/wfs/WfsDispatcher?REQUEST=DescribeFeatureType&TYPENAME=ign%3Acommune&SERVICE=WFS&VERSION=1.0.0";
+	String[] roles = {};
+	String ogcServiceMessage = OGCServiceMessageFormatter.format("userNoInsert!", request, "", roles);
 
-		final String  request = "http://www.someserver.com/geoserver/wfs/WfsDispatcher?REQUEST=DescribeFeatureType&TYPENAME=ign%3Acommune&SERVICE=WFS&VERSION=1.0.0";
-		String [] roles = null;
-		String ogcServiceMessage = OGCServiceMessageFormatter.format("userNoInsert!",request,"",roles);
+	LOGGER.info(ogcServiceMessage);
 
-		LOGGER.info(ogcServiceMessage);
+	logList = OGCServiceStatistics.list();
+	assertEquals(logSizeBefore, logList.size());
+    }
 
-		logList = OGCServiceStatistics.list();
-		assertEquals(logList.size(), logSizeBefore );
-	}
-	
 }

--- a/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/log4j/OGCServiceParserTest.java
+++ b/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/log4j/OGCServiceParserTest.java
@@ -1,16 +1,21 @@
 package org.georchestra.ogcservstatistics.log4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.UnsupportedEncodingException;
+import java.text.ParseException;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.georchestra.ogcservstatistics.util.Utility;
 import org.junit.Test;
 
 public class OGCServiceParserTest {
 	@Test
-	public void testParseRequest() throws Exception {
+	public void testParseRequestMatchingOGCServiceParam() throws Exception {
 		String[] REQUESTS_TO_BE_PARSED = {
 				"anonymousUser|2013/12/18 12:18:00|http://localhost/geoserver?SERVICE=WmTS&REQUEST=GeTTILE",
 				"anonymousUser|2013/12/18 12:21:00|http://localhost/mapserver?SeRVICE=WMS&REQUEsT=GETStyles",
@@ -67,6 +72,46 @@ public class OGCServiceParserTest {
 		assertEquals(1, logEntries.size());
 		assertEquals("getcoverage", logEntries.get(0).get("request"));
 		assertEquals("", logEntries.get(0).get("layer"));
+	}
+
+	public @Test void postWcsDescribeCoverage() throws UnsupportedEncodingException, ParseException {
+		testResourceRequest("postWcsDescribeCoverage.txt", "WCS");
+	}
+
+	public @Test void postWcsGetCoverage() throws UnsupportedEncodingException, ParseException {
+		testResourceRequest("postWcsGetCoverage.txt", "WCS");
+	}
+
+	public @Test void postWfsDelete() throws UnsupportedEncodingException, ParseException {
+		testResourceRequest("postWfsDelete.txt", "WFS");
+	}
+
+	public @Test void postWfsGetFeature() throws UnsupportedEncodingException, ParseException {
+		testResourceRequest("postWfsGetFeature.txt", "WFS");
+	}
+
+	public @Test void postWfsInsert() throws UnsupportedEncodingException, ParseException {
+		testResourceRequest("postWfsInsert.txt", "WFS");
+	}
+
+	public @Test void postWfsUpdate() throws UnsupportedEncodingException, ParseException {
+		testResourceRequest("postWfsUpdate.txt", "WFS");
+	}
+
+	private void testResourceRequest(final String resourceName, final String expectedService) throws UnsupportedEncodingException, ParseException {
+		String request = Utility.loadRequest(resourceName);
+		String user = "user";
+		Date time = new Date();
+		String org = "c2c";
+		String[] roles = new String[] { "ROLE1", "ROLE2" };
+
+		String formattedMessage = OGCServiceMessageFormatter.format(user, time, request, org, roles);
+
+		List<Map<String, Object>> logEntries = OGCServiceParser.parseLog(formattedMessage);
+		assertNotNull(logEntries);
+		assertEquals(1, logEntries.size());
+		Map<String, Object> entry = logEntries.get(0);
+		assertEquals(expectedService, entry.get("service"));
 	}
 
 }

--- a/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/log4j/OGCServicesAppenderTest.java
+++ b/ogc-server-statistics/src/test/java/org/georchestra/ogcservstatistics/log4j/OGCServicesAppenderTest.java
@@ -14,16 +14,14 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
-import org.georchestra.ogcservstatistics.util.Utility;
-
 import org.apache.log4j.Logger;
-import org.apache.log4j.PropertyConfigurator;
 import org.georchestra.ogcservstatistics.OGCServStatisticsException;
 import org.georchestra.ogcservstatistics.calculations.OGCServiceStatistics;
 import org.georchestra.ogcservstatistics.dataservices.DataServicesConfiguration;
 import org.georchestra.ogcservstatistics.dataservices.DeleteAllCommand;
-import org.georchestra.ogcservstatistics.log4j.OGCServiceMessageFormatter;
-import org.georchestra.ogcservstatistics.log4j.OGCServicesAppender;
+import org.georchestra.ogcservstatistics.util.Utility;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -42,26 +40,29 @@ import org.junit.Test;
  */
 public class OGCServicesAppenderTest {
 
-	
-	private static final Logger LOGGER = Logger.getLogger(OGCServicesAppenderTest.class.getName());
-	
-	static{
-		// WARNING: because this test will delete all log before execute the test method
-		// you should configure a test table in the log4j.properties file
-		
-		String file = "src/test/resources/org/georchestra/ogcservstatistics/log4j.properties";
-		PropertyConfigurator.configure(file);
-		try {
-			DeleteAllCommand cmd = new DeleteAllCommand();
-			Connection connection = DataServicesConfiguration.getInstance().getConnection();
-			cmd.setConnection(connection);
-			cmd.execute();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+    private Logger LOGGER;
 
+    public static @BeforeClass void initialize() {
+	// WARNING: because this test will delete all log before execute the test method
+	// you should configure a test table in the log4j.properties file
+
+	String file = "src/test/resources/org/georchestra/ogcservstatistics/log4j.properties";
+	OGCServiceStatistics.configure(file);
+	try {
+	    DeleteAllCommand cmd = new DeleteAllCommand();
+	    Connection connection = DataServicesConfiguration.getInstance().getConnection();
+	    cmd.setConnection(connection);
+	    cmd.execute();
+	} catch (Exception e) {
+	    e.printStackTrace();
 	}
-	
+
+    }
+
+    public @Before void before() {
+	LOGGER = Logger.getLogger(OGCServicesAppenderTest.class.getName());
+    }
+
 	/**
 	 * tests that exists the {@link OGCServicesAppender}
 	 */

--- a/ogc-server-statistics/src/test/resources/org/georchestra/ogcservstatistics/log4j-disable.properties
+++ b/ogc-server-statistics/src/test/resources/org/georchestra/ogcservstatistics/log4j-disable.properties
@@ -24,12 +24,15 @@
 # hierarchy.
 # test log4j.rootLogger=INFO, OGCSERVICES
 log4j.rootLogger= INFO, OGCSERVICES
-
+#set log4j.reset to true to force PropertyConfigurator reset the loggers/appenders
+#hierarchy before configuration, otherwise DisableLoggingTest will fail if other tests
+#were run before 
+log4j.reset = true
 log4j.appender.OGCSERVICES=org.georchestra.ogcservstatistics.log4j.OGCServicesAppender
 log4j.appender.OGCSERVICES.activated=false
 log4j.appender.OGCSERVICES.jdbcURL=jdbc:postgresql://localhost:5432/testdb
 log4j.appender.OGCSERVICES.databaseUser=postgres
-log4j.appender.OGCSERVICES.databasePassword=holapostgres
+log4j.appender.OGCSERVICES.databasePassword=geo123
 
 # test cases require bufferSize = 1 to avoid that the assertions fail
 log4j.appender.OGCSERVICES.bufferSize=1

--- a/ogc-server-statistics/src/test/resources/org/georchestra/ogcservstatistics/log4j.properties
+++ b/ogc-server-statistics/src/test/resources/org/georchestra/ogcservstatistics/log4j.properties
@@ -28,14 +28,13 @@ log4j.rootLogger=INFO
 log4j.logger.OGCServiceMessageFormatter=DEBUG, REQUEST_FILE
 log4j.logger.org.georchestra.ogcservstatistics.log4j=INFO, OGCSERVICES
 
-
 # -----------------------------------------------------------------------------------
 # database appender
 log4j.appender.OGCSERVICES=org.georchestra.ogcservstatistics.log4j.OGCServicesAppender
 log4j.appender.OGCSERVICES.activated=true 
 log4j.appender.OGCSERVICES.jdbcURL=jdbc:postgresql://localhost:5432/testdb
 log4j.appender.OGCSERVICES.databaseUser=postgres
-log4j.appender.OGCSERVICES.databasePassword=admin
+log4j.appender.OGCSERVICES.databasePassword=geo123
 # test cases require bufferSize = 1 to avoid that the assertions fail
 log4j.appender.OGCSERVICES.bufferSize=1
 
@@ -49,7 +48,7 @@ log4j.appender.OGCSERVICES.bufferSize=1
 # file appender RollingFileAppender
 log4j.appender.REQUEST_FILE=org.apache.log4j.RollingFileAppender
 log4j.appender.REQUEST_FILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.REQUEST_FILE.File=ogcservstatistics.log
+log4j.appender.REQUEST_FILE.File=target/ogcservstatistics.log
 # Print the date in ISO 8601 format
 log4j.appender.REQUEST_FILE.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 


### PR DESCRIPTION
This pull request fixes #2076 

There were two major errors:
- `RetrieveAllCommand` had a hardcoded column name `secrole` instead of `roles`, which directly prevented all online tests from running.

- After fixing that, most tests failed because OGCServiceParser couldn't parse the service name, especially out of the HTTP POST requests log messages. Fixed using regular expressions.

The only test passing was OGCServiceParserTest, but test cases for the failing messages, which were added.
