### PR TITLE
Homogenize maven-compiler-plugin settings

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -12,7 +12,6 @@
   <url>http://www.georchestra.org</url>
   <properties>
     <aspectj.version>1.7.0.RC1</aspectj.version>
-    <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <roo.version>1.1.5.RELEASE</roo.version>
     <slf4j.version>1.6.4</slf4j.version>
@@ -459,16 +458,6 @@
         <version>2.6</version>
         <configuration>
           <packagingExcludes>manager/node_modules/**</packagingExcludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
       <plugin>

--- a/epsg-extension/pom.xml
+++ b/epsg-extension/pom.xml
@@ -33,15 +33,6 @@
 	</dependencies>
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<encoding>UTF-8</encoding>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -262,14 +262,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <!-- http://mojo.codehaus.org/exec-maven-plugin/ -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     </site>
   </distributionManagement>
   <properties>
+    <java.version>1.8</java.version>
     <gt.version>9.2</gt.version>
     <spring.version>2.5.6.SEC01</spring.version>
     <security.version>2.0.5.RELEASE</security.version>
@@ -91,6 +92,15 @@
          <artifactId>dependency-check-maven</artifactId>
          <version>3.2.1</version>
        </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-antrun-plugin</artifactId>
@@ -142,12 +152,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.2</version>
-          <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
-            <encoding>UTF-8</encoding>
-          </configuration>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -14,7 +14,6 @@
     <spring.version>4.3.13.RELEASE</spring.version>
     <security.version>4.2.3.RELEASE</security.version>
     <maven.test.skip>false</maven.test.skip>
-    <java.version>1.8</java.version>
   </properties>
   <dependencies>
     <dependency>
@@ -167,16 +166,6 @@
   <build>
     <finalName>ROOT-${server}</finalName>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>


### PR DESCRIPTION
maven-compiler-plugin was defined in several pom
files with different plugin version and Java version.

This patch defines the plugin version in the root pom's
pluginManagement section and its configuration in the
root pom's plugins section for all modules.