### PR TITLE
Fix for #2305 on 18.06

### DIFF
--- a/console/src/main/java/org/georchestra/console/ds/RoleDaoImpl.java
+++ b/console/src/main/java/org/georchestra/console/ds/RoleDaoImpl.java
@@ -375,10 +375,12 @@ public class RoleDaoImpl implements RoleDao {
 		setAccountField(context, RoleSchema.COMMON_NAME_KEY, role.getName());
 		setAccountField(context, RoleSchema.DESCRIPTION_KEY, role.getDescription());
 		setMemberField(context, RoleSchema.MEMBER_KEY, role.getUserList());
-		if(role.isFavorite())
+		if (role.isFavorite()) {
 			setAccountField(context, RoleSchema.FAVORITE_KEY, RoleSchema.FAVORITE_VALUE);
+		} else {
+			context.removeAttributeValue(RoleSchema.FAVORITE_KEY, RoleSchema.FAVORITE_VALUE);
+		}
 	}
-
 
     private void setMemberField(DirContextOperations context,
             String memberAttr, List<String> users) {


### PR DESCRIPTION
Fix a bug in console role management by which `isFavorite:false` won't be 

Setting a role as favorite works, but setting it back to false
doesn't. This patch fixes the issue. Note though that proper
testing for the fix requires some integration testing infrastructure
which is being worked out on the 18.12 branch as it would
be overkill to include on this one this close to a release.

See #2043