### PR TITLE
Harmonize uid check regexp - accept dot and dash in the frontend (#2448)

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -321,7 +321,8 @@ public final class NewAccountFormController {
 		if (validation.validateUserFieldWithSpecificMsg("uid", formBean.getUid(), result)) {
 			// A valid user identifier (uid) can only contain characters, numbers, hyphens or dot.
 			// It must begin with a character.
-			Pattern regexp = Pattern.compile("[a-zA-Z][a-zA-Z0-9.-]*");
+			// keep in sync with the regexp in webapp/manager/app/templates/userForm.tpl.html
+			Pattern regexp = Pattern.compile("[a-zA-Z][a-zA-Z0-9\\.\\-]*");
 			Matcher m = regexp.matcher(formBean.getUid());
 			if(!m.matches())
 				result.rejectValue("uid", "uid.error.invalid", "required");

--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -322,7 +322,7 @@ public final class NewAccountFormController {
 			// A valid user identifier (uid) can only contain characters, numbers, hyphens or dot.
 			// It must begin with a character.
 			// keep in sync with the regexp in webapp/manager/app/templates/userForm.tpl.html
-			Pattern regexp = Pattern.compile("[a-zA-Z][a-zA-Z0-9\\.\\-]*");
+			Pattern regexp = Pattern.compile("[a-zA-Z][a-zA-Z0-9_\\.\\-]*");
 			Matcher m = regexp.matcher(formBean.getUid());
 			if(!m.matches())
 				result.rejectValue("uid", "uid.error.invalid", "required");

--- a/console/src/main/webapp/manager/app/templates/userForm.tpl.html
+++ b/console/src/main/webapp/manager/app/templates/userForm.tpl.html
@@ -108,8 +108,8 @@
           {{model.uid}} (<a href="javascript:void(0)" ng-click="view.edit_login=!view.edit_login">change</a>)
         </div>
         <div class="col-sm-8" ng-if="view.edit_login">
-          <!-- Server validation should match this pattern: /^[a-z]+\w*$/ -->
-          <input ng-model="model.uid" class="form-control" id="uid" placeholder="{{'user.login' | translate}}" ng-required="required.uid" ng-pattern="'^[a-z]+\\\\w*$'">
+          <!-- Server validation is in java/org/georchestra/console/ws/newaccount/NewAccountFormController.java -->
+          <input ng-model="model.uid" class="form-control" id="uid" placeholder="{{'user.login' | translate}}" ng-required="required.uid" ng-pattern="'^[a-zA-Z][a-zA-Z0-9\\\\.\\\\-]*$'">
         </div>
       </div>
 

--- a/console/src/main/webapp/manager/app/templates/userForm.tpl.html
+++ b/console/src/main/webapp/manager/app/templates/userForm.tpl.html
@@ -109,7 +109,7 @@
         </div>
         <div class="col-sm-8" ng-if="view.edit_login">
           <!-- Server validation is in java/org/georchestra/console/ws/newaccount/NewAccountFormController.java -->
-          <input ng-model="model.uid" class="form-control" id="uid" placeholder="{{'user.login' | translate}}" ng-required="required.uid" ng-pattern="'^[a-zA-Z][a-zA-Z0-9\\\\.\\\\-]*$'">
+          <input ng-model="model.uid" class="form-control" id="uid" placeholder="{{'user.login' | translate}}" ng-required="required.uid" ng-pattern="/^[a-z][a-z0-9_\\\\.\\\\-]*$/i">
         </div>
       </div>
 


### PR DESCRIPTION
while here properly escape dot and dash in the serverside validation.

i'm not 100% sure about escaping - at the end of a class.. but pretty sure dot needs to be escaped, otherwise the regexp reduces to `[a-z].*` i think...