### PR TITLE
Add link to org in the list of users in console

### DIFF
--- a/console/src/main/java/org/georchestra/console/dto/SimpleAccount.java
+++ b/console/src/main/java/org/georchestra/console/dto/SimpleAccount.java
@@ -17,7 +17,7 @@ public class SimpleAccount {
     @JsonProperty(UserSchema.ORG_KEY)
     private String orgName;
 
-    @JsonIgnore
+    @JsonProperty(UserSchema.ORG_ID_KEY)
     private String orgId;
 
     @JsonProperty(UserSchema.MAIL_KEY)

--- a/console/src/main/java/org/georchestra/console/dto/UserSchema.java
+++ b/console/src/main/java/org/georchestra/console/dto/UserSchema.java
@@ -58,6 +58,7 @@ public interface UserSchema {
 
 	// Only used in JSON output
 	public static final String ORG_KEY = "org";
+	public static final String ORG_ID_KEY = "orgId";
 
 
 	public static final String[] ATTR_TO_RETRIEVE = {UID_KEY, COMMON_NAME_KEY, SURNAME_KEY, GIVEN_NAME_KEY, STREET_KEY,

--- a/console/src/main/webapp/manager/app/components/users/users.tpl.html
+++ b/console/src/main/webapp/manager/app/components/users/users.tpl.html
@@ -37,7 +37,9 @@
             <a ng-link="user({id: user.uid, tab: 'infos'})">{{::user.sn}} {{::user.givenName}}</a>
           </td>
           <td>{{::user.uid}}</td>
-          <td>{{::user.org}}</td>
+          <td>
+            <a ng-link="org({org: user.orgId, tab: 'infos'})">{{::user.org}}</a>
+          </td>
           <td>{{::user.mail}}</td>
         </tr>
       </tbody>


### PR DESCRIPTION
It requires to add a field (orgId) in the JSON provided at the "private/users"
endpoint, so: changes both in backend and frontend.