### PR TITLE
Remove validation related PENDING role in CAS

### DIFF
--- a/cas-server-webapp/src/main/java/org/georchestra/cas/ldap/GeorchestraLdapAuthenticationHandler.java
+++ b/cas-server-webapp/src/main/java/org/georchestra/cas/ldap/GeorchestraLdapAuthenticationHandler.java
@@ -41,7 +41,7 @@ import org.ldaptive.SearchResult;
 import org.ldaptive.auth.Authenticator;
 
 /**
- * Extends Ldap authentication handler by checking whether the user is pending or valid.
+ * Extends Ldap authentication handler by checking whether the user has at least one role.
  *
  * @author Jesse on 6/26/2014.
  */
@@ -52,7 +52,6 @@ public class GeorchestraLdapAuthenticationHandler extends LdapAuthenticationHand
     private String baseDn;
     private String roleSearchFilter;
     private String roleRoleAttribute;
-    private String pendingRoleName;
 
     private DefaultConnectionFactory connectionFactory;
 
@@ -76,9 +75,6 @@ public class GeorchestraLdapAuthenticationHandler extends LdapAuthenticationHand
         this.roleRoleAttribute = roleRoleAttribute;
     }
 
-    public void setPendingRoleName(String pendingRoleName) {
-        this.pendingRoleName = pendingRoleName;
-    }
     /**
      * Creates a new authentication handler that delegates to the given authenticator.
      *
@@ -89,15 +85,13 @@ public class GeorchestraLdapAuthenticationHandler extends LdapAuthenticationHand
                                                 @NotNull String adminPassword,
                                                 @NotNull String baseDn,
                                                 @NotNull String roleSearchFilter,
-                                                @NotNull String roleRoleAttribute,
-                                                @NotNull String pendingRoleName) {
+                                                @NotNull String roleRoleAttribute) {
         super(authenticator);
         this.adminUser = adminUser;
         this.adminPassword = adminPassword;
         this.baseDn = baseDn;
         this.roleSearchFilter = roleSearchFilter;
         this.roleRoleAttribute = roleRoleAttribute;
-        this.pendingRoleName = pendingRoleName;
     }
 
     @Override
@@ -117,14 +111,6 @@ public class GeorchestraLdapAuthenticationHandler extends LdapAuthenticationHand
 
             if (result.getEntries().isEmpty()) {
                 throw new AccountException("User has no roles.");
-            }
-            for (LdapEntry entry : result.getEntries()) {
-                final Collection<String> roleNames = entry.getAttribute(this.roleRoleAttribute).getStringValues();
-                for (String name : roleNames) {
-                    if (name.equals(this.pendingRoleName)) {
-                        throw new AccountException("User is still a pending user.");
-                    }
-                }
             }
         } catch (LdapException e) {
             throw new PreventedException("Unexpected LDAP error", e);

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -38,7 +38,6 @@ ldap.admin.username=cn=admin,dc=georchestra,dc=org
 ldap.admin.password=secret
 ldap.authn.roleSearchFilter=(member=uid={1},ou=users,dc=georchestra,dc=org)
 ldap.authn.roleRoleAttribute=cn
-ldap.authn.pendingRoleName=PENDING
 
 # See http://www.ldaptive.org/ for information about ldap parameters
 ldap.connectTimeout=30000

--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -106,7 +106,6 @@
         <constructor-arg value="${ldap.authn.roleSearchBaseDn}" />
         <constructor-arg value="${ldap.authn.roleSearchFilter}" />
         <constructor-arg value="${ldap.authn.roleRoleAttribute}" />
-        <constructor-arg value="${ldap.authn.pendingRoleName}" />
 
     </bean>
 


### PR DESCRIPTION
Before bccbe8b1b9b00ef3e5c6b0802ed2a1ef4d6edeee, the pending users (new
LDAP users waiting for a validation of their account) were stored in
ou=users,dc=georchestra,dc=org, and were assigned the "PENDING" role.
CAS had to check if a user had this role or not before conceding
authentication (pending users are not allowed to authenticate).

But since that commit, pending users are now stored in
ou=pendingusers,dc=georchestra,dc=org, while CAS is looking
into ou=users,dc=georchestra,dc=org. So, there is no more need to check
if a user is pending or not.