### PR TITLE
use commons-httpclient from atlassian fork to fix #2183

### DIFF
--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>commons-fileupload</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>3.1-atlassian-2</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -980,6 +980,14 @@
       <name>Spring releases</name>
       <url>https://repo.spring.io/release</url>
     </repository>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>atlassian</id>
+      <name>Atlassian Repository</name>
+      <url>https://maven.atlassian.com/3rdparty/</url>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
commons-httpclient is dead upstream and doesnt support SNI,
the atlassian fork added support for it and that fixes mapfishapp
printing https layers served by servers using a cert with SNI.

With this pom.xml bit, the right jar is shipped in the war:
```
-rw-r--r-- 1 landry users 313907 Feb 11 09:33 /home/landry/.m2/repository/commons-httpclient/commons-httpclient/3.1-atlassian-2/commons-httpclient-3.1-atlassian-2.jar
-rw-r--r-- 1 landry users 305001 Sep 11  2017 /home/landry/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar
...
$unzip -l mapfishapp/target/mapfishapp-generic.war |grep commons-http
   313907  2019-02-11 09:33   WEB-INF/lib/commons-httpclient-3.1-atlassian-2.jar

```
PR targetting master but nice to have in 18.12.

For some reason here on my throwaway/testing instance mfapp tells me that the print service isnt available (there's a NPE when hitting `/mapfishapp/pdf`) so i cant really test it, but i've been using this jar in production for the past 6 months.