### PR TITLE
19.06: Fix spring config ref elements that contained local instead of bean

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -108,7 +108,7 @@
   <bean id="loginFlowHandlerMapping" class="org.springframework.webflow.mvc.servlet.FlowHandlerMapping"
         p:flowRegistry-ref="loginFlowRegistry" p:order="2">
     <property name="interceptors">
-      <ref local="localeChangeInterceptor" />
+      <ref bean="localeChangeInterceptor" />
     </property>
   </bean>
 
@@ -135,7 +135,7 @@
   <bean id="logoutFlowHandlerMapping" class="org.springframework.webflow.mvc.servlet.FlowHandlerMapping"
         p:flowRegistry-ref="logoutFlowRegistry" p:order="3">
     <property name="interceptors">
-      <ref local="localeChangeInterceptor" />
+      <ref bean="localeChangeInterceptor" />
     </property>
   </bean>
 
@@ -175,7 +175,7 @@
   <bean id="viewFactoryCreator" class="org.springframework.webflow.mvc.builder.MvcViewFactoryCreator">
     <property name="viewResolvers">
       <util:list>
-        <ref local="viewResolver"/>
+        <ref bean="viewResolver"/>
       </util:list>
     </property>
   </bean>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/auditTrailContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/auditTrailContext.xml
@@ -45,22 +45,22 @@
 
   <util:map id="auditActionResolverMap">
     <entry key="AUTHENTICATION_RESOLVER">
-      <ref local="authenticationActionResolver" />
+      <ref bean="authenticationActionResolver" />
     </entry>
     <entry key="CREATE_TICKET_GRANTING_TICKET_RESOLVER">
-      <ref local="ticketCreationActionResolver" />
+      <ref bean="ticketCreationActionResolver" />
     </entry>
     <entry key="DESTROY_TICKET_GRANTING_TICKET_RESOLVER">
       <bean class="com.github.inspektr.audit.spi.support.DefaultAuditActionResolver" />
     </entry>
     <entry key="GRANT_SERVICE_TICKET_RESOLVER">
-      <ref local="ticketCreationActionResolver" />
+      <ref bean="ticketCreationActionResolver" />
     </entry>
     <entry key="GRANT_PROXY_GRANTING_TICKET_RESOLVER">
-      <ref local="ticketCreationActionResolver" />
+      <ref bean="ticketCreationActionResolver" />
     </entry>
     <entry key="VALIDATE_SERVICE_TICKET_RESOLVER">
-      <ref local="ticketValidationActionResolver" />
+      <ref bean="ticketValidationActionResolver" />
     </entry>
   </util:map>
   
@@ -69,19 +69,19 @@
       <bean class="org.jasig.cas.audit.spi.CredentialsAsFirstParameterResourceResolver" />
     </entry>
     <entry key="CREATE_TICKET_GRANTING_TICKET_RESOURCE_RESOLVER">
-      <ref local="returnValueResourceResolver" />
+      <ref bean="returnValueResourceResolver" />
     </entry>
     <entry key="DESTROY_TICKET_GRANTING_TICKET_RESOURCE_RESOLVER">
-      <ref local="ticketResourceResolver" />
+      <ref bean="ticketResourceResolver" />
     </entry>
     <entry key="GRANT_SERVICE_TICKET_RESOURCE_RESOLVER">
       <bean class="org.jasig.cas.audit.spi.ServiceResourceResolver" />
     </entry>
     <entry key="GRANT_PROXY_GRANTING_TICKET_RESOURCE_RESOLVER">
-      <ref local="returnValueResourceResolver" />
+      <ref bean="returnValueResourceResolver" />
     </entry>
     <entry key="VALIDATE_SERVICE_TICKET_RESOURCE_RESOLVER">
-      <ref local="ticketResourceResolver" />
+      <ref bean="ticketResourceResolver" />
     </entry>
   </util:map>
       

--- a/geowebcache-webapp/src/main/webapp/WEB-INF/acegi-config.xml
+++ b/geowebcache-webapp/src/main/webapp/WEB-INF/acegi-config.xml
@@ -92,7 +92,7 @@
         <property name="allowIfAllAbstainDecisions" value="false" />
         <property name="decisionVoters">
             <list>
-                <ref local="roleVoter" />
+                <ref bean="roleVoter" />
             </list>
         </property>
     </bean>


### PR DESCRIPTION
Fixes #2461 on master (19.06-SNAPSHOT)

Spring 4.x removed the local attribute from `<ref/>`, but
some were still being used making the app fail to start.

This patch replaces the remaining `<ref local="..."/>`
by `<ref bean="..."/>`.