### PR TITLE
LDAP - fix pendingorg dn

### DIFF
--- a/ldap/georchestra.ldif
+++ b/ldap/georchestra.ldif
@@ -272,4 +272,4 @@ description: 59107
 member: uid=testpendinguser,ou=pendingusers,dc=georchestra,dc=org
 o: Fictive org pending admin validation
 ou: PENDINGORG
-seeAlso: o=pendingorg,ou=orgs,dc=georchestra,dc=org
+seeAlso: o=pendingorg,ou=pendingorgs,dc=georchestra,dc=org


### PR DESCRIPTION
Currently, the `seeAlso` attribute for `cn=pendingorg,ou=pendingorgs,dc=georchestra,dc=org` points at an non-existing `dn`.

Hoping that the console webapp handles nicely the `seeAlso` attribute renaming ...