### PR TITLE
mapfishapp - revert org.json to the version print-lib depends on

### DIFF
--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -14,6 +14,12 @@
     <maven.test.skip>false</maven.test.skip>
     <!-- Override parent version with 2.1.1-georchestra. Revisit. -->
     <mapfish.version>2.1.1-georchestra</mapfish.version>
+    <!-- 
+    	downgrade parent's 20180813 version or org.mapfish.print.servlet.MapPrinterServlet.getInfo
+    	throws java.lang.NoSuchMethodError: org.json.JSONWriter.<init>(Ljava/io/Writer;)V 
+    -->
+    <json.version>20080701</json.version>
+    
     <server>generic</server>
   </properties>
   <dependencies>


### PR DESCRIPTION
Fixes #2493 

Downgrade parent's `20180813` version or `org.mapfish.print.servlet.MapPrinterServlet.getInfo`
throws `java.lang.NoSuchMethodError: org.json.JSONWriter.<init>(Ljava/io/Writer;)V`

Confirmed maps are printable again.