### PR TITLE
Extractorapp - Fix exception when setting publicUrl property

### DIFF
--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/ExtractorController.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/ExtractorController.java
@@ -81,6 +81,7 @@ public class ExtractorController implements ServletContextAware {
     private AbstractEmailFactory emailFactory;
     private ServletContext servletContext;
     private String servletUrl;
+    private String publicUrl;
     private String extractionFolderPrefix;
     private boolean remoteReproject = true;
     private boolean useCommandLineGDAL = false;
@@ -95,6 +96,7 @@ public class ExtractorController implements ServletContextAware {
     private @Autowired DataSource dataSource;
 
     public void validateConfig() throws PropertyVetoException, MalformedURLException {
+        setSecureHostAndServletUrl(this.publicUrl);
         if (extractionManager == null) {
             throw new AssertionError("A extractionManager needs to be defined in spring configuration");
         }
@@ -360,8 +362,11 @@ public class ExtractorController implements ServletContextAware {
      * Each instance of {link} will be replaced with the extraction bundle URL
      */
 
-    public void setPublicUrl(String rawPublicUrl) throws MalformedURLException {
+    public void setPublicUrl(String publicUrl) {
+        this.publicUrl = publicUrl;
+    }
 
+    public void setSecureHostAndServletUrl(String rawPublicUrl) throws MalformedURLException {
         // extract hostname to set set secureHost
         URL publicURL = new URL(rawPublicUrl);
         this.secureHost = publicURL.getHost();

--- a/extractorapp/src/test/java/org/georchestra/extractorapp/ws/extractor/ExtractorControllerTest.java
+++ b/extractorapp/src/test/java/org/georchestra/extractorapp/ws/extractor/ExtractorControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -18,6 +19,7 @@ import java.util.Date;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javax.servlet.ServletContext;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -29,10 +31,16 @@ public class ExtractorControllerTest {
 	private static final String UUID_PARAM = "uuid";
 
 	private ExtractorController ec;
+	private MockServletContext ctx;
 
 	@Before
 	public void setUp() {
+		ctx = new MockServletContext();
+		ctx.setContextPath("/extractorapp/");
+
 		ec = new ExtractorController();
+		ec.setServletContext(ctx);
+		ec.setPublicUrl("https://georchestra.mydomain.org");
 	}
 
 	@After


### PR DESCRIPTION
Bug introduced by https://github.com/georchestra/georchestra/commit/156e342b0260d3ea79bc9de059027a2a247d071a#diff-cb3d8cd657ccafb05e41f9f2cf21a7d8L103.

Note: here we rename the setPublicUrl method since in reality it sets the secureHost and the servletUrl properties, not the publicUrl property.