### PR TITLE
analytics - Use only one comma-separated list of excluded users as property

### DIFF
--- a/analytics/src/main/java/org/georchestra/analytics/StatisticsController.java
+++ b/analytics/src/main/java/org/georchestra/analytics/StatisticsController.java
@@ -37,7 +37,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
 import org.georchestra.analytics.util.QueryBuilder;
-import org.georchestra.commons.configuration.GeorchestraConfiguration;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
@@ -164,9 +163,6 @@ import com.google.common.annotations.VisibleForTesting;
         + "related to users and groups, and their use of the infrastructure.")
 public class StatisticsController {
 
-    @Autowired
-	private GeorchestraConfiguration georConfig;
-
 	@Autowired
 	private DataSource dataSource;
 
@@ -220,14 +216,6 @@ public class StatisticsController {
 	}
 
 	// Getter and setter for unit tests
-
-	public GeorchestraConfiguration getGeorConfig() {
-		return georConfig;
-	}
-
-	public void setGeorConfig(GeorchestraConfiguration georConfig) {
-		this.georConfig = georConfig;
-	}
 
 	public @VisibleForTesting void setDataSource(DataSource ds) {
 		this.dataSource = ds;

--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -57,8 +57,13 @@
         file:${georchestra.datadir}/analytics/analytics.properties"
         ignore-resource-not-found="true" ignore-unresolvable="true" />
 
+    <!-- Takes care of converting a comma-separated list into a Collection or an Array.
+         Used in statisticsController bean with the excludedUsers property -->
+    <bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean" />
+
     <bean id="statisticsController" class="org.georchestra.analytics.StatisticsController">
         <constructor-arg name="localTimezone" value="${localTimezone:Europe/Paris}"/>
+        <property name="excludedUsers" value="${excludedUsers,geoserver_privileged_user}"/>
     </bean>
 
     <bean id="georchestraConfiguration" class="org.georchestra.commons.configuration.GeorchestraConfiguration">

--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -63,7 +63,7 @@
 
     <bean id="statisticsController" class="org.georchestra.analytics.StatisticsController">
         <constructor-arg name="localTimezone" value="${localTimezone:Europe/Paris}"/>
-        <property name="excludedUsers" value="${excludedUsers,geoserver_privileged_user}"/>
+        <property name="excludedUsers" value="${excludedUsers:geoserver_privileged_user}"/>
     </bean>
 
     <bean id="georchestraConfiguration" class="org.georchestra.commons.configuration.GeorchestraConfiguration">

--- a/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerTest.java
+++ b/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import javax.sql.DataSource;
 
 import org.georchestra.analytics.StatisticsController.GRANULARITY;
-import org.georchestra.commons.configuration.GeorchestraConfiguration;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -53,9 +52,6 @@ public class StatisticsControllerTest {
 		this.ctrl = new StatisticsController("UTC");
 		this.mockMvc = standaloneSetup(ctrl).build();
 		ctrl.setDataSource(mockDS);
-
-		GeorchestraConfiguration georConfig = Mockito.mock(GeorchestraConfiguration.class);
-		ctrl.setGeorConfig(georConfig);
 	}
 
 	@After


### PR DESCRIPTION
Instead of looking for properties with a suffix (excludedUser1,
excludedUser2, etc.)
Note the use of the ConversionServiceFactoryBean to handle the
conversion from comma separated list to a Collection, here Set<String> (more
at: https://stackoverflow.com/a/29970335/7351594)