### PR TITLE
GS - overriding version numbers provided by spring-boot

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -18,6 +18,11 @@
     <marlin.version>0.7.5-Unsafe</marlin.version>
     <gs.spring.version>4.3.7.RELEASE</gs.spring.version>
     <server>generic</server>
+    <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
+    <hibernate.version>3.6.0.Final</hibernate.version>
+    <spring.version>4.3.7.RELEASE</spring.version>
+    <commons-beanutils.version>1.8.0</commons-beanutils.version>
+    <commons-digester.version>1.7</commons-digester.version>
   </properties>
   <modules>
     <module>geoserver-submodule/src/web/core</module>


### PR DESCRIPTION
After #2405, some too recent versions of hibernate and other libraries are used, which breaks geofence.

Overriding the versions so that we can find back a stable state for GF.

The main problematic version bump in our case is in regards to hibernate (3.6.0.Final -> 5.0.12.Final).

Only major versions of the libs have been modified, not the minor ones (except commons-beanutils, which is present twice anyway).

Tests: runtime tested in a local docker compo.
Fixes #2488 