### PR TITLE
LDAP - parametrize slapd log level in docker

### DIFF
--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -40,7 +40,7 @@ VOLUME ["/etc/ldap", "/var/lib/ldap"]
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
-CMD [ "sh", "-c", "exec slapd -d 32768 -u ${RUN_AS_UID} -g ${RUN_AS_GID}" ]
+CMD [ "sh", "-c", "exec slapd -d ${SLAPD_LOG_LEVEL:-32768} -u ${RUN_AS_UID} -g ${RUN_AS_GID}" ]
 
 HEALTHCHECK --interval=30s --timeout=10s \
   CMD ldapsearch \

--- a/ldap/docker-compose.yml
+++ b/ldap/docker-compose.yml
@@ -7,5 +7,6 @@ services:
       - SLAPD_DOMAIN=georchestra.org
       - SLAPD_ORGANIZATION=geOrchestra
       - SLAPD_PASSWORD=secret
+      - SLAPD_LOG_LEVEL=32768
     ports:
       - '3899:389'


### PR DESCRIPTION
Allow to configure the log level of slapd (LDPA server) - see http://www.zytrax.com/books/ldap/ch6/#loglevel