### PR TITLE
Proxy streaming when using async client 

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -1036,12 +1036,6 @@ public class Proxy {
                         String charset = getCharset(s); // extract charset
 
                         if (charset == null) {
-                            logger.trace("unable to find charset from raw ASCII data.  Trying to unzip it");
-
-                            // the charset cannot be found, IE users must be warned
-                            // that the request cannot be fulfilled, nothing good would happen otherwise
-                        }
-                        if (charset == null) {
 
                             logger.debug("unable to find charset so using the first one from the accept-charset request header");
 

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -768,7 +768,6 @@ public class Proxy {
                 try {
                     channel.close();
                     pos.close();
-                    pis.close();
                 } catch (IOException e) {
                 }
             }

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -1042,29 +1042,26 @@ public class Proxy {
                             // that the request cannot be fulfilled, nothing good would happen otherwise
                         }
                         if (charset == null) {
-                            String guessedCharset = null;
+
                             logger.debug("unable to find charset so using the first one from the accept-charset request header");
 
                             String calculateDefaultCharset = calculateDefaultCharset(orignalRequest);
                             if (calculateDefaultCharset != null) {
-                                guessedCharset = calculateDefaultCharset;
-                                logger.debug("hopefully the server responded with this charset: " + calculateDefaultCharset);
+                                charset = calculateDefaultCharset;
+                                logger.debug("hopefully the server responded with this charset: " + charset);
                             } else {
-                                guessedCharset = defaultCharset;
-                                logger.debug("unable to find charset, so using default:" + defaultCharset);
+                                charset = defaultCharset;
+                                logger.debug("unable to find charset, so using default:" + charset);
                             }
-                            String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + guessedCharset;
-                            finalResponse.setHeader("Content-Type", adjustedContentType);
-                            first = false; // we found the encoding, don't try to do it again
-                            finalResponse.setCharacterEncoding(guessedCharset);
 
                         } else {
                             logger.debug("found charset: " + charset);
-                            String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + charset;
-                            finalResponse.setHeader("Content-Type", adjustedContentType);
-                            first = false; // we found the encoding, don't try to do it again
-                            finalResponse.setCharacterEncoding(charset);
+
                         }
+                        String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + charset;
+                        finalResponse.setHeader("Content-Type", adjustedContentType);
+                        finalResponse.setCharacterEncoding(charset);
+                        first = false; // we found the encoding, don't try to do it again
                     }
                 }
 

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -864,9 +864,6 @@ public class Proxy {
                     try {
                         Charset.forName(charset);
                     } catch (Throwable t) {
-                        charset = null;
-                    }
-                    if (charset == null) {
                         charset = defaultCharset;
                     }
                     entity = new UrlEncodedFormEntity(parameters, charset);

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -634,10 +634,8 @@ public class Proxy {
             String reasonPhrase = statusLine.getReasonPhrase();
 
             if (reasonPhrase != null && statusCode >= 400) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("Downstream server returned a status code which could be an error. "
-                            + "Statuscode: " + statusCode + ", reason: " + reasonPhrase);
-                }
+                logger.warn("Downstream server returned a status code which could be an error. "
+                        + "Statuscode: " + statusCode + ", reason: " + reasonPhrase);
 
                 if (statusCode == 401) {
                     //
@@ -742,10 +740,8 @@ public class Proxy {
     }
 
     private Optional<String> adjustLocation(HttpServletRequest request, HttpResponse proxiedResponse) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("adjustLocation called for request: " + request.getRequestURI());
-        }
-        
+        logger.debug("adjustLocation called for request: " + request.getRequestURI());
+
         final String target = findMatchingTarget(request);
         final String locationHeader = extractLocationHeader(proxiedResponse);
         
@@ -760,15 +756,11 @@ public class Proxy {
             final URI baseURI;
             try {
                 baseURI = new URI(baseURL);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("adjustLocation process header: " + locationHeader);
-                }
+                logger.debug("adjustLocation process header: " + locationHeader);
                 URI locationURI = new URI(locationHeader);
                 URI resolvedURI = baseURI.resolve(locationURI);
 
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Test location header: " + resolvedURI.toString() + " against: " + baseURI.toString());
-                }
+                logger.debug("Test location header: " + resolvedURI.toString() + " against: " + baseURI.toString());
                 if (resolvedURI.toString().startsWith(baseURI.toString())) {
                     // proxiedResponse.removeHeader(locationHeader);
                     String resolvedSuffix = resolvedURI.toString().substring(baseURI.toString().length());
@@ -777,9 +769,7 @@ public class Proxy {
                         newLocation += "/";
                     }
                     newLocation += resolvedSuffix;
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("adjustLocation from: " + locationHeader + " to " + newLocation);
-                    }
+                    logger.debug("adjustLocation from: " + locationHeader + " to " + newLocation);
                     adjustedLocation = newLocation;
                 }
             } catch (URISyntaxException e) {
@@ -1005,12 +995,9 @@ public class Proxy {
             // getContentEncoding(proxiedResponse.getAllHeaders());
             String contentEncoding = getContentEncoding(proxiedResponse.getHeaders("Content-Encoding"));
 
-            if (logger.isDebugEnabled()) {
-
-                String cskString = "\tisCharSetKnown=" + isCharsetKnown;
-                String cEString = "\tcontentEncoding=" + contentEncoding;
-                logger.debug("Charset is required so verifying that it has been added to the headers\n" + cskString + "\n" + cEString);
-            }
+            String cskString = "\tisCharSetKnown=" + isCharsetKnown;
+            String cEString = "\tcontentEncoding=" + contentEncoding;
+            logger.debug("Charset is required so verifying that it has been added to the headers\n" + cskString + "\n" + cEString);
 
             if (contentEncoding == null || isCharsetKnown) {
                 // A simple stream can do the job for data that is not in content encoded
@@ -1045,35 +1032,26 @@ public class Proxy {
                     // s has to be long enough to contain the encoding
                     if (s.length() > 200) {
 
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("attempting to read charset from: " + s);
-                        }
+                        logger.trace("attempting to read charset from: " + s);
                         String charset = getCharset(s); // extract charset
 
                         if (charset == null) {
-                            if (logger.isTraceEnabled()) {
-                                logger.trace("unable to find charset from raw ASCII data.  Trying to unzip it");
-                            }
+                            logger.trace("unable to find charset from raw ASCII data.  Trying to unzip it");
 
                             // the charset cannot be found, IE users must be warned
                             // that the request cannot be fulfilled, nothing good would happen otherwise
                         }
                         if (charset == null) {
                             String guessedCharset = null;
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("unable to find charset so using the first one from the accept-charset request header");
-                            }
+                            logger.debug("unable to find charset so using the first one from the accept-charset request header");
+
                             String calculateDefaultCharset = calculateDefaultCharset(orignalRequest);
                             if (calculateDefaultCharset != null) {
                                 guessedCharset = calculateDefaultCharset;
-                                if (logger.isDebugEnabled()) {
-                                    logger.debug("hopefully the server responded with this charset: " + calculateDefaultCharset);
-                                }
+                                logger.debug("hopefully the server responded with this charset: " + calculateDefaultCharset);
                             } else {
                                 guessedCharset = defaultCharset;
-                                if (logger.isDebugEnabled()) {
-                                    logger.debug("unable to find charset, so using default:" + defaultCharset);
-                                }
+                                logger.debug("unable to find charset, so using default:" + defaultCharset);
                             }
                             String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + guessedCharset;
                             finalResponse.setHeader("Content-Type", adjustedContentType);
@@ -1081,9 +1059,7 @@ public class Proxy {
                             finalResponse.setCharacterEncoding(guessedCharset);
 
                         } else {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("found charset: " + charset);
-                            }
+                            logger.debug("found charset: " + charset);
                             String adjustedContentType = proxiedResponse.getEntity().getContentType().getValue() + ";charset=" + charset;
                             finalResponse.setHeader("Content-Type", adjustedContentType);
                             first = false; // we found the encoding, don't try to do it again
@@ -1170,16 +1146,12 @@ public class Proxy {
      */
     private String getContentEncoding(Header[] headers) {
         if (headers == null || headers.length == 0) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("No content-encoding header for this request.");
-            }
+            logger.debug("No content-encoding header for this request.");
             return null;
         }
         for (Header header : headers) {
             String headerName = header.getName();
-            if (logger.isDebugEnabled()) {
-                logger.debug("Check content-encoding against header: " + headerName + " : " + header.getValue());
-            }
+            logger.debug("Check content-encoding against header: " + headerName + " : " + header.getValue());
             if (headerName != null && "Content-Encoding".equalsIgnoreCase(headerName)) {
                 return header.getValue();
             }

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -1078,13 +1078,11 @@ public class Proxy {
     private String calculateDefaultCharset(HttpServletRequest originalRequest) {
         String acceptCharset = originalRequest.getHeader("accept-charset");
 
-        String calculatedCharset = null;
-
         if (acceptCharset != null) {
-            calculatedCharset = acceptCharset.split(",")[0];
+           return acceptCharset.split(",")[0];
         }
 
-        return calculatedCharset;
+        return null;
     }
 
     private IOException close(Closeable stream, IOException... previousExceptions) {

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -762,7 +762,6 @@ public class Proxy {
 
                 logger.debug("Test location header: " + resolvedURI.toString() + " against: " + baseURI.toString());
                 if (resolvedURI.toString().startsWith(baseURI.toString())) {
-                    // proxiedResponse.removeHeader(locationHeader);
                     String resolvedSuffix = resolvedURI.toString().substring(baseURI.toString().length());
                     String newLocation = "/" + target;
                     if(!resolvedSuffix.startsWith("/")) {
@@ -777,6 +776,7 @@ public class Proxy {
             }
         }
         return Optional.ofNullable(adjustedLocation);
+
     }
 
     /**

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -103,7 +103,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
@@ -1030,7 +1029,7 @@ public class Proxy {
                     if (s.length() > 200) {
 
                         logger.trace("attempting to read charset from: " + s);
-                        String charset = getCharset(s); // extract charset
+                        String charset = extractCharsetAsFromXmlNode(s);
 
                         if (charset == null) {
 
@@ -1107,7 +1106,7 @@ public class Proxy {
      * @param header String that should contain the encoding attribute and its value
      * @return the charset. null if not found
      */
-    protected String getCharset(String header) {
+    protected String extractCharsetAsFromXmlNode(String header) {
         Matcher matcher = ENCODING_IN_XML_REGEX_PATTERN.matcher(header);
 
         if (matcher.find()) {

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -396,13 +396,7 @@ public class Proxy {
     }
 
     private String[] splitRequestPath(String requestURI) {
-        String[] requestSegments;
-        if (requestURI.charAt(0) == '/') {
-            requestSegments = StringUtils.split(requestURI.substring(1), '/');
-        } else {
-            requestSegments = StringUtils.split(requestURI, '/');
-        }
-        return requestSegments;
+        return filter(requestURI.split("/"));
     }
 
     /**

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -90,6 +90,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -102,6 +103,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
@@ -1270,40 +1272,27 @@ public class Proxy {
         return false;
     }
 
-    private String[] filter(String[] one) {
-        ArrayList<String> result = new ArrayList<String>();
-
-        for (String string : one) {
-            if (string.length() > 0) {
-                result.add(string);
-            }
-        }
-        return result.toArray(new String[result.size()]);
+    protected String[] filter(String[] one) {
+        return Arrays.stream(one).filter(x -> x.length() > 0).toArray(String[]::new);
     }
 
     /**
-     * Check to see if the call is recursive based on forwardRequestURI
-     * startsWith contextPath
+     * Check to see if the call is recursive based on forwardRequestURI startsWith contextPath.
      */
-    private boolean isRecursiveCallToProxy(String forwardRequestURI, String contextPath) {
-        String[] one = forwardRequestURI.split("/");
-        String[] two = contextPath.split("/");
-
-        one = filter(one);
-        two = filter(two);
+    protected boolean isRecursiveCallToProxy(String forwardRequestURI, String contextPath) {
+        String[] one = filter(forwardRequestURI.split("/"));
+        String[] two = filter(contextPath.split("/"));
 
         if (one.length < two.length) {
             return false;
         }
 
-        boolean match = true;
         for (int i = 0; i < two.length && i < one.length; i++) {
-            String s2 = two[i];
-            String s1 = one[i];
-
-            match &= s2.equalsIgnoreCase(s1);
+            if (!(two[i].equalsIgnoreCase(one[i]))) {
+                return false;
+            }
         }
-        return match;
+        return true;
     }
 
     public void setDefaultTarget(String defaultTarget) {

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -1099,29 +1099,22 @@ public class Proxy {
         return null;
     }
 
+    private static final Pattern ENCODING_IN_XML_REGEX_PATTERN = Pattern.compile("encoding=['\"]([A-Za-z][A-Za-z0-9._-]*)['\"]");
+
     /**
      * Extract the encoding from a string which is the header node of an xml file
      *
      * @param header String that should contain the encoding attribute and its value
      * @return the charset. null if not found
      */
-    private String getCharset(String header) {
-        Pattern pattern = null;
-        String charset = null;
-        try {
-            // use a regexp but we could also use string functions such as indexOf...
-            pattern = Pattern.compile("encoding=(['\"])([A-Za-z]([A-Za-z0-9._]|-)*)");
-        } catch (Exception e) {
-            throw new RuntimeException("expression syntax invalid");
-        }
+    protected String getCharset(String header) {
+        Matcher matcher = ENCODING_IN_XML_REGEX_PATTERN.matcher(header);
 
-        Matcher matcher = pattern.matcher(header);
         if (matcher.find()) {
-            String encoding = matcher.group();
-            charset = encoding.split("['\"]")[1];
+            return matcher.group(1);
         }
 
-        return charset;
+        return null;
     }
 
     /**

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -678,10 +678,10 @@ public class Proxy {
 
             // content type has to be valid
             if (isCharsetRequiredForContentType(contentType)) {
-                doHandleRequestCharsetRequired(request, finalResponse, proxiedResponse, contentType);
+                doHandleRequestCharsetRequired(request, finalResponse, proxiedResponse);
             } else {
                 logger.debug("charset not required for contentType: " + contentType);
-                doHandleRequest(request, finalResponse, proxiedResponse);
+                doHandleRequest(finalResponse, proxiedResponse);
             }
         } catch (IOException | ExecutionException | InterruptedException | TimeoutException e) {
             // connection problem with the host
@@ -775,7 +775,7 @@ public class Proxy {
     /**
      * Direct copy of response
      */
-    private void doHandleRequest(HttpServletRequest request, HttpServletResponse finalResponse, HttpResponse proxiedResponse)
+    private void doHandleRequest(HttpServletResponse finalResponse, HttpResponse proxiedResponse)
             throws IOException {
 
         org.apache.http.StatusLine statusLine = proxiedResponse.getStatusLine();
@@ -950,7 +950,7 @@ public class Proxy {
      * method.
      */
     private void doHandleRequestCharsetRequired(HttpServletRequest originalRequest, HttpServletResponse finalResponse,
-            HttpResponse proxiedResponse, String contentType) {
+            HttpResponse proxiedResponse) {
 
         InputStream streamFromServer = null;
         OutputStream streamToClient = null;
@@ -1004,7 +1004,7 @@ public class Proxy {
                 streamFromServer = new DeflaterInputStream(proxiedResponse.getEntity().getContent());
                 streamToClient = new DeflaterOutputStream(finalResponse.getOutputStream());
             } else {
-                doHandleRequest(originalRequest, finalResponse, proxiedResponse);
+                doHandleRequest(finalResponse, proxiedResponse);
                 return;
             }
 

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -1303,10 +1303,6 @@ public class Proxy {
         this.targets = targets;
     }
 
-    public void setContextpath(String contextpath) {
-        // this.contextpath = contextpath;
-    }
-
     public void setHeaderManagement(HeadersManagementStrategy headerManagement) {
         this.headerManagement = headerManagement;
     }

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -786,7 +786,7 @@ public class Proxy {
 
         HttpAsyncRequestProducer producer = new BasicAsyncRequestProducer(
                 new HttpHost(proxyingRequest.getURI().getHost(), proxyingRequest.getURI().getPort()),
-                new BasicHttpRequest(proxyingRequest.getRequestLine()));
+                proxyingRequest);
 
         httpclient.execute(producer, consumer, null);
 

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -264,8 +264,8 @@ public class ProxyTest {
 
         Proxy toTest = new Proxy();
 
-        assertEquals("UTF-8", toTest.getCharset(toParse));
-        assertEquals("UTF-8", toTest.getCharset(toParse2));
-        assertEquals("Ehj_.-", toTest.getCharset(toParse3));
+        assertEquals("UTF-8", toTest.extractCharsetAsFromXmlNode(toParse));
+        assertEquals("UTF-8", toTest.extractCharsetAsFromXmlNode(toParse2));
+        assertEquals("Ehj_.-", toTest.extractCharsetAsFromXmlNode(toParse3));
     }
 }

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -1,9 +1,5 @@
 package org.georchestra.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.google.common.collect.Maps;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
@@ -18,20 +14,19 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.ReflectionUtils;
 
+import javax.sql.DataSource;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-<<<<<<< HEAD
-import javax.sql.DataSource;
-=======
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
->>>>>>> e965071ae... rewrite filter and array compare method
 
 public class ProxyTest {
     private Proxy proxy;
@@ -219,6 +214,7 @@ public class ProxyTest {
     @Test
     public void isRecursiveCallToProxy() {
         Proxy toTest = new Proxy();
+
         assertFalse(toTest.isRecursiveCallToProxy("/a/b/c", "/a/b/c/d"));
         assertFalse(toTest.isRecursiveCallToProxy("/a/b/c", "/a/b/d"));
         assertFalse(toTest.isRecursiveCallToProxy("", "a"));
@@ -226,5 +222,14 @@ public class ProxyTest {
         assertTrue(toTest.isRecursiveCallToProxy("a/b/c", "/a/b/c"));
         assertTrue(toTest.isRecursiveCallToProxy("a/b/c/d", "/a/b/c"));
     }
-}
 
+    @Test
+    public void isCharsetRequiredForContentType() {
+        Proxy toTest = new Proxy();
+        toTest.setRequireCharsetContentTypes(Arrays.asList(new String[] {"zebu", "long"}));
+
+        assertTrue(toTest.isCharsetRequiredForContentType("Zebu;youpi"));
+        assertTrue(toTest.isCharsetRequiredForContentType("LONG"));
+        assertFalse(toTest.isCharsetRequiredForContentType("ascii;long"));
+    }
+}

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -231,5 +232,27 @@ public class ProxyTest {
         assertTrue(toTest.isCharsetRequiredForContentType("Zebu;youpi"));
         assertTrue(toTest.isCharsetRequiredForContentType("LONG"));
         assertFalse(toTest.isCharsetRequiredForContentType("ascii;long"));
+    }
+
+    @Test
+    public void charsetForName() {
+        assertEquals("US-ASCII", Charset.forName("us-ascii").displayName());
+
+        boolean thrown = false;
+        try {
+            Charset dummy = Charset.forName(null);
+        } catch (Throwable t) {
+            thrown = true;
+        }
+
+        assertTrue(thrown);
+
+        thrown = false;
+        try {
+            Charset dummy = Charset.forName("momo");
+        } catch (Throwable t) {
+            thrown = true;
+        }
+        assertTrue(thrown);
     }
 }

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -25,7 +25,13 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
+<<<<<<< HEAD
 import javax.sql.DataSource;
+=======
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+>>>>>>> e965071ae... rewrite filter and array compare method
 
 public class ProxyTest {
     private Proxy proxy;
@@ -201,4 +207,24 @@ public class ProxyTest {
         assertEquals(expected, values.get(0));
     }
 
+    @Test
+    public void filterOne() {
+        Proxy toTest = new Proxy();
+
+        String[] filtered = toTest.filter(new String[] {"", "here", "", "the", "", "fish"});
+
+        assertArrayEquals(new String[] {"here", "the", "fish"}, filtered);
+    }
+
+    @Test
+    public void isRecursiveCallToProxy() {
+        Proxy toTest = new Proxy();
+        assertFalse(toTest.isRecursiveCallToProxy("/a/b/c", "/a/b/c/d"));
+        assertFalse(toTest.isRecursiveCallToProxy("/a/b/c", "/a/b/d"));
+        assertFalse(toTest.isRecursiveCallToProxy("", "a"));
+        assertTrue(toTest.isRecursiveCallToProxy("/a/b/c/d", ""));
+        assertTrue(toTest.isRecursiveCallToProxy("a/b/c", "/a/b/c"));
+        assertTrue(toTest.isRecursiveCallToProxy("a/b/c/d", "/a/b/c"));
+    }
 }
+

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -255,4 +255,17 @@ public class ProxyTest {
         }
         assertTrue(thrown);
     }
+
+    @Test
+    public void attemptingToReadCharsetFromXml() {
+        String toParse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+        String toParse2 = "<?xml version=\'1.0\' encoding=\'UTF-8\'?>";
+        String toParse3 = "<?xml version=\'1.0\' encoding=\'Ehj_.-\'\"coin\"?>";
+
+        Proxy toTest = new Proxy();
+
+        assertEquals("UTF-8", toTest.getCharset(toParse));
+        assertEquals("UTF-8", toTest.getCharset(toParse2));
+        assertEquals("Ehj_.-", toTest.getCharset(toParse3));
+    }
 }


### PR DESCRIPTION
Dans le cadre d' https://github.com/georchestra/georchestra/pull/2219, nous étions passé d'un client http apache synchrone à un client asynchrone.

Il se trouve que l'implémentation de "base" du client asynchrone apache établit que "Response content is buffered in memory for simplicity.", cf. https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchange.java.

Aussi pour éviter que la mémoire du sp soit épuisée lors de transferts volumineux, on peut affiner l'utilisation que l'on fait du client async, cf. https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchangeStreaming.java.

C'est l'objet de cette PR.

Des améilorations/économies autour de l'utilisation des streams sont probablement possibles.