### PR TITLE
console - add default values to properties in integration tests

### DIFF
--- a/console/src/it/java/org/georchestra/console/dao/AdvancedDelegationDaoIT.java
+++ b/console/src/it/java/org/georchestra/console/dao/AdvancedDelegationDaoIT.java
@@ -55,8 +55,8 @@ public class AdvancedDelegationDaoIT {
 
     private @Autowired ComboPooledDataSource ds;
 
-    private @Value("${dataSource.maxPoolSize}") int maxConnections;
-    private @Value("${dataSource.timeout}") int timeoutMillis;
+    private @Value("${dataSource.maxPoolSize:10}") int maxConnections;
+    private @Value("${dataSource.timeout:1000}") int timeoutMillis;
 
     public @Before void before() {
         assertThat(timeoutMillis, Matchers.greaterThan(0));


### PR DESCRIPTION
Maybe it's not required for the tests to work, but it does not hurt to
set a default value.