### PR TITLE
gwc - allow to configure the configuration file directory

### DIFF
--- a/geowebcache-webapp/src/main/webapp/WEB-INF/geowebcache-servlet.xml
+++ b/geowebcache-webapp/src/main/webapp/WEB-INF/geowebcache-servlet.xml
@@ -40,12 +40,18 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
         <constructor-arg ref="gwcTLDispatcher"/>
         <constructor-arg ref="gwcGridSetBroker"/>
         <constructor-arg ref="gwcStorageBroker"/>
-        <constructor-arg ref="gwcXmlConfig"/>
+        <constructor-arg ref="gwcXmlConfigGeorchestra"/>
         <constructor-arg ref="gwcRuntimeStats"/>
         <property name="defaultStorageFinder" ref="gwcDefaultStorageFinder"/>
         <property name="instanceName" value="${instanceName}"/>
         <property name="headerUrl" value="${headerUrl}"/>
         <property name="headerHeight" value="${headerHeight}"/>
+    </bean>
+
+    <!-- The location of a static configuration file for GeoWebCache. -->
+    <bean id="gwcXmlConfigGeorchestra" class="org.geowebcache.config.XMLConfiguration">
+        <constructor-arg ref="gwcAppCtx" />
+        <constructor-arg value="${configurationDir:/tmp/gwc_config}" />
     </bean>
 
     <bean id="gwcURLMangler" class="org.geowebcache.util.GeorchestraURLMangler">


### PR DESCRIPTION
Now, by default, the configuration file will be located in the /tmp/gwc_config/
directory, but it can be overriden by the configurationDir property in
the datadir.

If the configuration directory does not exist, it is created at runtime
(if allowed).
If the configuration file does not exist, it is also created at runtime (if
allowed), as a copy of the template file located in the geowebcache
cache dir (geowebcache.xml).

It's meant to separate data file from configuration files (see
https://github.com/georchestra/georchestra/issues/2555).