### PR TITLE
console - fix integration tests

### DIFF
--- a/console/src/it/resources/default-it.properties
+++ b/console/src/it/resources/default-it.properties
@@ -1,0 +1,45 @@
+# This file holds some property shared across all geOrchestra webapps
+# All properties in this file MUST be present. Do not comment any of them, they
+# do not have a default value. Adapt them according to the needs of your
+# instance.
+
+# Scheme of the geOrchestra instance
+# URL must not include the trailing slash
+# Should be https
+scheme=https
+
+# Domain name of the geOrchestra instance
+# URL must not include the trailing slash
+# Once modified, adapt the following files accordingly:
+# - mapfishapp/wfs.servers.json
+# - mapfishapp/wms.servers.json
+# - mapfishapp/wmts.servers.json
+# - mapfishapp/credentials.properties
+# - mapfishapp/print/config.yaml
+# - mapfishapp/js/GEOR_custom.js
+# - cas/cas.properties
+# - ...
+# or replace all the strings with `sed` (see README.md)
+domainName=georchestra.mydomain.org
+
+# Public URL of this geOrchestra instance
+# URL must not include the trailing slash
+# This property MUST be let unmodified. If you need to modify the scheme or the
+# domain name, refer to the "scheme" and "domainName" properties.
+publicUrl=${scheme}://${domainName}
+
+# Name of this geOrchestra instance
+instanceName=geOrchestra
+
+# Default language
+language=en
+
+# Header height (size in px)
+# If different from default value "90", adapt analytics/js/GEOR_custom.js
+# accordingly
+headerHeight=90
+
+# Header URL (can be absolute or relative)
+# If different from default value "/header/", adapt
+# security-proxy/targets-mapping.properties accordingly
+headerUrl=/header/

--- a/console/src/it/resources/webmvc-config-test.xml
+++ b/console/src/it/resources/webmvc-config-test.xml
@@ -36,7 +36,7 @@
 
   <context:annotation-config/>
 
-  <context:property-placeholder location="classpath:/console-it.properties, classpath:/protectedroles-it.properties" ignore-resource-not-found="false" ignore-unresolvable="false" />
+  <context:property-placeholder location="classpath:/default-it.properties, classpath:/console-it.properties, classpath:/protectedroles-it.properties" ignore-resource-not-found="false" ignore-unresolvable="false" />
 
   <context:component-scan base-package="org.georchestra.console"/>
 


### PR DESCRIPTION
Add the default.properties file to console integration tests. It's
needed now that default properties have been removed by
https://github.com/georchestra/georchestra/pull/2558

Fixes #2559