### PR TITLE
console - fix unset property

### DIFF
--- a/console/src/it/resources/webmvc-config-test.xml
+++ b/console/src/it/resources/webmvc-config-test.xml
@@ -82,7 +82,7 @@
     <property name="ldapTemplate" ref="ldapTemplate"/>
     <property name="basePath" value="${baseDN:dc=georchestra,dc=org}"/>
     <property name="orgTypeValues" value="${orgTypeValues:Association,Company,NGO,Individual,Other}"/>
-    <property name="orgSearchBaseDN" value="${orgSearchBaseDN}"/>
+    <property name="orgSearchBaseDN" value="${orgSearchBaseDN:ou=orgs}"/>
     <property name="pendingOrgSearchBaseDN" value="${pendingOrgSearchBaseDN:ou=pendingorgs}"/>
   </bean>
 

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -83,7 +83,7 @@
     <property name="ldapTemplate" ref="ldapTemplate"/>
     <property name="basePath" value="${baseDN:dc=georchestra,dc=org}"/>
     <property name="orgTypeValues" value="${orgTypeValues:Association,Company,NGO,Individual,Other}"/>
-    <property name="orgSearchBaseDN" value="${orgSearchBaseDN}"/>
+    <property name="orgSearchBaseDN" value="${orgSearchBaseDN:ou=orgs}"/>
     <property name="pendingOrgSearchBaseDN" value="${pendingOrgSearchBaseDN:ou=pendingorgs}"/>
   </bean>
 


### PR DESCRIPTION
Now that datadir properties are commented, all properties (but
default.properties) called in placeholders require a default value.