### PR TITLE
SP - following spring-security 3.2.10 bump

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/custom/CustomAuthenticationProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/custom/CustomAuthenticationProvider.java
@@ -39,6 +39,7 @@ import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.DistinguishedName;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
+import org.springframework.ldap.core.support.DefaultDirObjectFactory;
 import org.springframework.ldap.support.LdapUtils;
 import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -214,6 +215,7 @@ public class CustomAuthenticationProvider extends AbstractLdapAuthenticationProv
         env.put(Context.SECURITY_CREDENTIALS, password);
         env.put(Context.INITIAL_CONTEXT_FACTORY,
                 "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.OBJECT_FACTORIES, DefaultDirObjectFactory.class.getName());
 
         try {
             return contextFactory.createContext(env);


### PR DESCRIPTION
The CustomAuthenticationProvider class allows to first try a bind on an
Active Directory, then (if failing) trying another time on the
geOrchestra LDAP server. It is mainly used in the Rennes-Métropole
setup. Following the spring-security version update, the getObject()
method is expecting to return spring-based objects and not the ones from
the official Java API anymore. We then need to configure a specific
factory for this kind of objects so that spring-security based classes
are used.

Tests: runtime tested on Rennes-Métropole