### PR TITLE
extractorapp: Fix reprojection issues with WFS extractions

### DIFF
--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/ExtractorController.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/ExtractorController.java
@@ -49,7 +49,6 @@ import org.georchestra.extractorapp.ws.extractor.task.ExecutionMetadata;
 import org.georchestra.extractorapp.ws.extractor.task.ExecutionPriority;
 import org.georchestra.extractorapp.ws.extractor.task.ExtractionManager;
 import org.georchestra.extractorapp.ws.extractor.task.ExtractionTask;
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -273,15 +272,6 @@ public class ExtractorController implements ServletContextAware {
     private void doExtraction(boolean testing, HttpServletRequest request, HttpServletResponse response) throws Exception {
         String postData = FileUtils.asString(request.getInputStream());
         String reponseData = "";
-
-        String sessionId;
-        try {
-            JSONObject jso = new JSONObject(postData);
-            sessionId = (String) jso.get("sessionid");
-        } catch (Exception e) {
-            LOG.debug("Unable to decode the sessionid sent by the client: " + e.getMessage());
-            sessionId = null;
-        }
 
         UUID requestUuid = UUID.randomUUID();
 

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
@@ -321,9 +321,7 @@ public class WfsExtractor {
         return features;
     }
 
-	/* This method is default for testing purposes */
-    Query createQuery (ExtractorLayerRequest request, FeatureType schema) throws IOException, TransformException,
-            FactoryException {
+    private Query createQuery (ExtractorLayerRequest request, FeatureType schema) throws TransformException, FactoryException{
 
         final Filter filter;
         final String[] properties;

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/WfsExtractor.java
@@ -80,6 +80,8 @@ public class WfsExtractor {
 
     protected static final Log LOG = LogFactory.getLog(WcsExtractor.class.getPackage().getName());
 
+    private static final FilterFactory2 filterFactory = CommonFactoryFinder.getFilterFactory2 (GeoTools.getDefaultHints ());
+    
     /**
      * Enumerate general types of geometries we accept. Multi/normal is ignored
      * because shapefiles are always multigeom
@@ -320,7 +322,6 @@ public class WfsExtractor {
                 bbox = request._bbox.transform (schema.getCoordinateReferenceSystem (), true, 10);
             }
 
-            FilterFactory2 filterFactory = CommonFactoryFinder.getFilterFactory2 (GeoTools.getDefaultHints ());
             String propertyName = schema.getGeometryDescriptor ().getLocalName ();
             PropertyName geomProperty = filterFactory.property (propertyName);
             Geometry bboxGeom = new GeometryFactory ().toGeometry (bbox);

--- a/extractorapp/src/main/resources/api-1.0.yaml
+++ b/extractorapp/src/main/resources/api-1.0.yaml
@@ -1,0 +1,331 @@
+openapi: 3.0.0
+# Added by API Auto Mocking Plugin
+servers:
+  - description: Default Server
+    url: https://georchestra.mydomain.org/extractorapp/
+info:
+  version: "1.0.0"
+  title: 'Extractorapp 1.0 API'
+  description: Extractorapp 1.0 API
+
+tags: 
+  - name: Jobs
+    description: Jobs tasks
+  - name: Extractor
+    description: extractor tasks
+  
+paths:
+  /jobs/list:
+    get:
+      tags: 
+        - Jobs
+      summary: List current tasks
+      operationId: listTasks
+      parameters:
+        - $ref: '#/components/parameters/sec-username'
+        - $ref: '#/components/parameters/sec-roles'
+        - $ref: '#/components/parameters/sec-orgname'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskList'
+                
+  /extractor/package:
+    get:
+      tags: 
+        - Extractor
+      summary: ''
+      operationId: getExtractionResults
+      parameters: 
+        - $ref: '#/components/parameters/uuid'
+        - $ref: '#/components/parameters/sec-username'
+        - $ref: '#/components/parameters/sec-roles'
+        - $ref: '#/components/parameters/sec-orgname'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/zip:
+              schema:
+                $ref: '#/components/schemas/ZipFile'
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+  
+  /extractor/initiate:
+    post:
+      tags: 
+        - Extractor
+      summary: 'Initiate an extraction for the provided layers and their settings'
+      operationId: extract
+      parameters:
+        - $ref: '#/components/parameters/sec-username'
+        - $ref: '#/components/parameters/sec-roles'
+        - $ref: '#/components/parameters/sec-orgname'
+      requestBody:
+        $ref: '#/components/requestBodies/ExtractRequestBody'
+      responses:
+        200:
+          description: "Extraction started"
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ExtractResponse'
+
+  /extractor/tasks:
+    get:
+      tags: 
+        - Extractor
+      summary: 'Lists the tasks waiting in the extraction queue'
+      operationId: getTaskQueue
+      parameters:
+        - $ref: '#/components/parameters/sec-username'
+        - $ref: '#/components/parameters/sec-roles'
+        - $ref: '#/components/parameters/sec-orgname'
+      responses:
+        200:
+          description: "Task queue"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskQueue'
+  
+  /extractor/task/{uuid}:
+    parameters:
+    - name: uuid
+      in: path
+      description: Task identifier
+      required: true
+      schema:
+        type: string
+        format: uuid
+    put:
+      tags: 
+        - Extractor
+      description: Analyzes the changes required in the task described in the parameter. 
+                   This method supposes that only one change is done in one call.
+      operationId: updateTask
+      parameters:
+        - $ref: '#/components/parameters/sec-username'
+        - $ref: '#/components/parameters/sec-roles'
+        - $ref: '#/components/parameters/sec-orgname'
+      requestBody:
+        content:
+          application:json:
+            schema:
+              $ref: '#/components/schemas/TaskDescriptor'
+      responses:
+        200:
+          description: "Task updated, no content"
+
+components:
+  parameters:
+    uuid:
+      in: query
+      name: uuid
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Unique extraction identifier
+    sec-username:
+      in: header
+      name: sec-username
+      schema:
+        type: string
+    sec-roles:
+      in: header
+      name: sec-roles
+      schema:
+        type: string
+      example: ROLE_SUPERUSER, ROLE_ADMINISTRATOR
+    sec-orgname:
+      in: header
+      name: sec-orgname
+      schema:
+        type: string
+  
+  requestBodies:
+    ExtractRequestBody:
+      description: request to initiate an extraction
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExtractRequest'
+  schemas:
+    ExtractRequest:
+      type: object
+      properties:
+        emails:
+          type: array
+          items:
+            type: string
+          example: [psc@georchestra.org, user@example.com]
+        globalProperties:
+          $ref: '#/components/schemas/ExtractionOptions'
+        layers:
+          $ref: '#/components/schemas/ExtractorLayer'
+          
+    ExtractResponse:
+      type: object
+      xml: 
+        name: response
+      properties:
+        success:
+          type: boolean
+        link:
+          type: string
+          format: url
+          example: 'https://georchestra.mydomain.org/extractorapp/extractor/package?uuid={requestUuid}'
+        emails:
+          type: string
+          example: '[psc@georchestra.org, user@example.com]'
+        
+    BoundingBox:
+      description: '[minx, miny, maxx, maxy]'
+      type: array
+      items:
+        type: number
+        format: double
+      example:
+        [-180, -90, 180, 90]
+
+    ReferencedBoundingBox:
+      type: object
+      properties:
+        srs:
+          type: string
+          example: 'EPSG:4326'
+        value:
+          $ref: '#/components/schemas/BoundingBox'
+            
+    ExtractionOptions:
+      type: object
+      properties:
+        projection:
+          type: string
+          example: 'EPSG:4326'
+        vectorFormat:
+          type: string
+          enum: [shp, mif, tab, kml]
+        rasterFormat:
+          type: string
+          enum: [jpeg2000, jp2, jp2ecw, jp2k, geotiff, gtiff, geotif, gtif, png, gif, jpeg, tiff, tif, ecw]
+        bbox:
+          $ref: '#/components/schemas/ReferencedBoundingBox'
+        resolution:
+          type: number
+          format: double
+
+    ExtractorLayer:
+      type: object
+      required:
+        - layerName
+        - owsUrl
+        - owsType
+      properties:
+        layerName:
+          type: string
+          example: roads
+        owsUrl:
+          type: string
+          format: url
+          example: https://georchestra.mydomain.org/services/geoserver/ows
+        owsType:
+          type: string
+          enum: [WFS, WCS]
+        format:
+          type: string
+          enum: [shp, mif, tab, kml, jpeg2000, jp2, jp2ecw, jp2k, geotiff, gtiff, geotif, gtif, png, gif, jpeg, tiff, tif, ecw]
+        namespace:
+          type: string
+          example: georchestra
+        isoMetadataURL:
+          type: string
+          format: url
+        projection:
+          type: string
+          example: 'EPSG:4326'
+        bbox:
+          $ref: '#/components/schemas/ReferencedBoundingBox'
+        resolution:
+          type: number
+          format: double
+
+    ZipFile:
+      type: string
+      format: binary
+      
+    ExecutionState:
+      type: string 
+      enum: [WAITING, RUNNING, PAUSED, COMPLETED, CANCELLED]
+    ExecutionPriority:
+      type: string 
+      enum: [LOW, MEDIUM, HIGH]
+
+    TaskList:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskInfo'
+    TaskInfo:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        state:
+          $ref: '#/components/schemas/ExecutionState'
+        priority:
+          $ref: '#/components/schemas/ExecutionPriority'
+        
+    TaskQueue:
+      type: object
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskDescriptor'
+    TaskDescriptor:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        requestor:
+          type: string
+        priority:
+          type: integer
+          format: int32
+        status:
+          $ref: '#/components/schemas/ExecutionState'
+        request_ts:
+          type: string
+          format: date_time
+        begin_ts:
+          type: string
+          format: date_time
+        end_ts:
+          type: string
+          format: date_time
+        spec:
+          $ref: '#/components/schemas/ExtractRequest'
+
+  securitySchemes:
+    password:
+      type: oauth2
+      flows:
+        password:
+          tokenUrl: 'http://example.com/oauth/token'
+          scopes:
+            write: allows modifying resources
+            read: allows reading resources


### PR DESCRIPTION
Fixes #1906 
The WFS DataStore on the GeoTools version used (9.2) does not handle reprojection, so it's done in-process