### PR TITLE
proxy, strictly, no entity means no entityEnclosed call

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -774,6 +774,9 @@ public class Proxy {
             @Override
             protected void onResponseReceived(HttpResponse httpResponse) throws HttpException, IOException {
                 this.httpResponse = httpResponse;
+                if (httpResponse.getEntity() == null) {
+                    future.complete(httpResponse);
+                }
             }
 
             @Override


### PR DESCRIPTION
For example, when 204 no  content, entityEnclosed will never be called !

cf. org.apache.http.nio.protocol.AbstractAsyncResponseConsumer

```
public final void responseReceived(HttpResponse response) throws IOException, HttpException {
        this.onResponseReceived(response);
        HttpEntity entity = response.getEntity();
        if (entity != null) {
            this.onEntityEnclosed(entity, this.getContentType(entity));
        }
    }
```