### PR TITLE
Following PR #2578. Commiting a fix and additional comment

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -61,13 +61,6 @@
   <bean id="localeResolver" class="org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver" />
 
   <bean id="localeChangeInterceptor" class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor"/>
-
-  <bean id="urlBasedViewResolver" class="org.springframework.web.servlet.view.UrlBasedViewResolver"
-        p:viewClass="org.springframework.web.servlet.view.InternalResourceView"
-        p:prefix="/WEB-INF/view/jsp/"
-        p:suffix=".jsp"
-        p:order="1">
-  </bean>
   
   <bean id="errorHandlerResolver" class="org.jasig.cas.web.FlowExecutionExceptionResolver"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casGenericSuccess.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casGenericSuccess.jsp
@@ -19,7 +19,11 @@
 
 --%>
 <jsp:directive.include file="includes/top-noheader.jsp" />
-
+<%--
+We could use ${publicURl} but right now, the property loader (PropertiesFactoryBean in
+spring-configuration/propertyFileConfigurer.xml) can't handle nested var in properties file. The solution could be the
+use of PropertySourcesPlaceholderConfigurer but at the moment it does not work well with the cas.
+--%>
 <spring:eval expression="@propertyConfigurer.getProperty('scheme')" var="scheme"/>
 <spring:eval expression="@propertyConfigurer.getProperty('domainName')" var="domainName"/>
 


### PR DESCRIPTION
Thanks to @cmangeat . We found out that UrlBasedViewResolver was not
used anymore in cas. So removing this stuff for more clarity.

Also Adding some comment about why we are not using `publicUrl` property
in jsp pages.