### PR TITLE
send confirmation mail to user on account validation (Fixes #2598)

### DIFF
--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -144,6 +144,7 @@ public class EmailFactory {
 				this.instanceName);
 		email.set("name", userName);
 		email.set("uid", uid);
+		email.set("email", userEmail);
 		email.send();
 	}
 

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -93,7 +93,7 @@ public class EmailFactory {
 	}
 
 	/**
-	 * e-mail to the user to inform the account requires the moderator's singnup
+	 * e-mail to the user to inform the account requires the moderator's validation
 	 */
 	public void sendAccountCreationInProcessEmail(ServletContext servletContext, String recipient,
 												  String userName, String uid) throws MessagingException {

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -427,6 +427,11 @@ public class UsersController {
 		accountDao.update(account, modified, auth.getName());
 
 		if (accountDao.hasUserDnChanged(account, modified)) {
+			// account was validated by a moderator, notify user
+			if (account.isPending() && ! modified.isPending()) {
+				this.emailFactory.sendAccountWasCreatedEmail(request.getSession().getServletContext(),
+						modified.getEmail(), modified.getCommonName(), modified.getUid());
+			}
 			roleDao.modifyUser(account, modified);
 		}
 


### PR DESCRIPTION
The logic could also go into https://github.com/georchestra/georchestra/blob/master/console/src/main/java/org/georchestra/console/ds/AccountDaoImpl.java#L211 - feedback welcome.

If merged, will do a PR on the datadir to amend https://github.com/georchestra/datadir/blob/19.04/console/templates/README.md#console-email-templates to reflect the new behaviour & https://github.com/georchestra/datadir/blob/19.04/console/templates/newaccount-requires-moderation-template.txt#L5 (add email - for the latter, the logic is that the user email might give a clue what org just registered..)

Tested behaving fine on 19.04.