### PR TITLE
[sec-proxy] pass scheme to HttpHost constructor (fixes #2603)

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -787,7 +787,7 @@ public class Proxy {
         };
 
         HttpAsyncRequestProducer producer = new BasicAsyncRequestProducer(
-                new HttpHost(proxyingRequest.getURI().getHost(), proxyingRequest.getURI().getPort()),
+                new HttpHost(proxyingRequest.getURI().getHost(), proxyingRequest.getURI().getPort(), proxyingRequest.getURI().getScheme()),
                 proxyingRequest);
 
         httpclient.execute(producer, consumer, null);


### PR DESCRIPTION
without that, an https:// target in the security proxy configuration
would be queried as plain http://, which might lead to 301 redirection
loops if there's a forced redirect from http to https in the target
configuration.