### PR TITLE
Remove epsg-extension from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver
 # Base geOrchestra common modules
 build-deps:
 	mvn -Dmaven.test.failure.ignore clean install --non-recursive
-	mvn clean install -pl commons,epsg-extension,ogc-server-statistics -Dmaven.javadoc.failOnError=false
+	mvn clean install -pl commons,ogc-server-statistics -Dmaven.javadoc.failOnError=false
 
 # all
 all: war-build-georchestra deb-build-georchestra docker-build


### PR DESCRIPTION
After removing the epsg-extension module,
the Makefile wasn't updated accordingly and
hence `make docker-build-georchestra` fails
complaining there's no maven module epsg-extension.