### PR TITLE
SP - let the possibility to have a "moved *" HTTP response + a content

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -675,8 +675,8 @@ public class Proxy {
                     finalResponse.setHeader("Location", adjustedLocation.get());
                 } else {
                     finalResponse.sendError(HttpStatus.SC_INTERNAL_SERVER_ERROR, "Unable to proxify redirect URL");
+                    return;
                 }
-                return;
             }
 
             // get content type


### PR DESCRIPTION
The motivation behind this PR is that if a 301 || 302 redirect is sent by an downstream server with a content, the content is not copied (because of the "return" statement), but the header "Content-Length" is. This triggers an actual 500 error from the Jetty hosting the security-proxy with the message "insufficient content written".

Only returning in case of unable to extract the Location header (sendError()), so that we let the possibility to write the content of the downstream http response.


Tests: runtime only as the modified code is pretty hard to instrument :(