### PR TITLE
gs-printing move to org.geoserver.extension

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -453,7 +453,7 @@
       <id>printing</id>
       <dependencies>
         <dependency>
-          <groupId>org.geoserver.community</groupId>
+          <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-printing</artifactId>
           <version>${gs.version}</version>
         </dependency>


### PR DESCRIPTION
Solve https://github.com/georchestra/georchestra/issues/2633

The gs-printing module moved from community to extension namespace.