### PR TITLE
security-proxy: Allow semicolons in URLs

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -16,14 +16,14 @@
 
 	<bean id="allowSemicolonHttpFirewall" class="org.springframework.security.web.firewall.StrictHttpFirewall">
 		<!-- 
-			Set allowSemicolon = true to avoid errors 
+			Allows configuring the allowSemicolon StrictHttpFirewall property to avoid errors 
 		    like 'the request was rejected because the URL contained a potentially malicious String ";"'
 		    ";" in URL's come in the form http://<domain>/<path>;jsessionid=xxxx OR in static resource 
 		    URLs (e.g to reference bundles of JS files (minified on the fly)). 
 		    In general, proxied applications are discouraged to disclose jsessionid this way, and shall use a cookie instead.
 		    Some applications like though can't be modified to use cookies, hence this configuration.
 		 --> 
-	  	<property name="allowSemicolon" value="true"/> 
+	  	<property name="allowSemicolon" value="${allowSemicolon:false}"/> 
 	</bean> 
 	<s:http-firewall ref="allowSemicolonHttpFirewall"/>
 

--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -14,6 +14,19 @@
     <context:property-placeholder location="file:${georchestra.datadir}/default.properties, file:${georchestra.datadir}/security-proxy/security-proxy.properties"
         ignore-resource-not-found="true" ignore-unresolvable="true" />
 
+	<bean id="allowSemicolonHttpFirewall" class="org.springframework.security.web.firewall.StrictHttpFirewall">
+		<!-- 
+			Set allowSemicolon = true to avoid errors 
+		    like 'the request was rejected because the URL contained a potentially malicious String ";"'
+		    ";" in URL's come in the form http://<domain>/<path>;jsessionid=xxxx OR in static resource 
+		    URLs (e.g to reference bundles of JS files (minified on the fly)). 
+		    In general, proxied applications are discouraged to disclose jsessionid this way, and shall use a cookie instead.
+		    Some applications like though can't be modified to use cookies, hence this configuration.
+		 --> 
+	  	<property name="allowSemicolon" value="true"/> 
+	</bean> 
+	<s:http-firewall ref="allowSemicolonHttpFirewall"/>
+
     <s:http entry-point-ref="casProcessingFilterEntryPoint" request-matcher="regex" realm="${realmName:georchestra}" disable-url-rewriting="true">
         <s:custom-filter ref="trustAnotherProxy" before="PRE_AUTH_FILTER" />
         <s:custom-filter ref="basicAuthChallengeByUserAgent" before="CAS_FILTER" />


### PR DESCRIPTION
Configure org.springframework.security.web.firewall.StrictHttpFirewall"
with allowSemicolon = true to avoid errors
like 'the request was rejected because the URL contained a potentially malicious String ";"'

";" in URL's come in the form http://<domain>/<path>;jsessionid=xxxx
In general, proxied applications are discouraged to disclose jsessionid this way,
and shall use a cookie instead.
Some applications like CKAN though can't be modified to use cookies, hence this configuration.