### PR TITLE
Remove X-Frame-Options http header

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -29,7 +29,7 @@
         <s:custom-filter ref="filterSecurityInterceptor" after="EXCEPTION_TRANSLATION_FILTER" />
         <!--  <s:http-basic />  -->
         <s:headers>
-          <s:frame-options policy="SAMEORIGIN" />
+          <s:frame-options disabled="true"/>
         </s:headers>
         <s:anonymous granted-authority="ROLE_ANONYMOUS" />
         <s:logout logout-success-url="${logout-success-url}" />


### PR DESCRIPTION
This will permit geochestra app to be embed in other app.

Note that X-Frame-Options is _not_ removed from cas, which we
explicitely don't to append.