### PR TITLE
CAS - unzip webapp in docker image

### DIFF
--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -48,6 +48,7 @@
     <spring-security.version>3.2.0.RELEASE</spring-security.version>
     <hibernate.version>4.1.0.Final</hibernate.version>
     <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
+    <context.name>cas</context.name>
     <!-- spring version revert end -->
   </properties>
   <dependencies>
@@ -369,9 +370,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>cas.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                  <directory>${project.build.directory}/${context.name}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/cas-server-webapp/src/docker/Dockerfile
+++ b/cas-server-webapp/src/docker/Dockerfile
@@ -4,15 +4,7 @@ ENV XMS=256M XMX=1G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,gzip,http-forwarded
 
-ADD . /
-
-# Temporary switch to root
-USER root
-
-RUN chown jetty:jetty /etc/georchestra
-
-# Restore jetty user
-USER jetty
+COPY --chown=jetty:jetty . /
 
 VOLUME [ "/tmp", "/run/jetty" ]
 


### PR DESCRIPTION
```
jetty@f61670ded212:/var/lib/jetty/webapps/cas$ ls -al
total 32
drwxr-xr-x 6 jetty jetty 4096 Jun 25 13:52 .
drwxr-xr-x 1 jetty jetty 4096 Jun 25 13:52 ..
drwxr-xr-x 6 jetty jetty 4096 Jun 25 13:52 WEB-INF
drwxr-xr-x 2 jetty jetty 4096 Jun 25 13:52 css
-rw-r--r-- 1 jetty jetty  170 Jun 25 13:52 favicon.ico
drwxr-xr-x 2 jetty jetty 4096 Jun 25 13:52 images
-rw-r--r-- 1 jetty jetty 1069 Jun 25 13:52 index.jsp
drwxr-xr-x 2 jetty jetty 4096 Jun 25 13:52 js
```
Also reduces image size:
```
$ docker images | grep georchestra/cas
georchestra/cas   19.06-SNAPSHOT            286MB
georchestra/cas   19.04                     479MB
georchestra/cas   18.06                     478MB
```