### PR TITLE
pom - Adding jacoco as code coverage tool optionally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -758,6 +758,32 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>jacocoCoverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.4</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- profile which skips dependency plugin execution -->
     <profile>
       <id>generate-site</id>


### PR DESCRIPTION
Some external code analysis tools used in the community (deutsch telekom
do have a SonarQube deployed in their infrastructure, we have a
community Jenkins) can make use of the generated report by Jacoco
to get insights on the code coverage of the solution.

This commit proposes to activate the maven plugin as an optional profile
which can (or not) be activated.

Tested in the security-proxy as:

```
$ mvn clean test -PjacocoCoverage
```

This generates a target/site/jacoco path.

Without:

```
$ mvn clean test
```

No code coverage report is generated, the behaviour is exactly the same
as currently in master.