### PR TITLE
GS - adding a profile for vectortiles plugin

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -984,6 +984,16 @@
       </dependencies>
     </profile>
     <profile>
+      <id>vectortiles</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.extension</groupId>
+          <artifactId>gs-vectortiles</artifactId>
+          <version>${gs.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>debianPackage</id>
       <properties>
         <server>generic</server>


### PR DESCRIPTION
Asked by a customer, this optionally lets the possibility to include the gs-vectoriles plugin in the generated GS webapp.

Tests: Only at compilation level.
