### PR TITLE
security-proxy: Remove dependency on XStream

### DIFF
--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -58,11 +58,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>1.4.10</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-oxm</artifactId>
     </dependency>

--- a/security-proxy/src/main/java/org/georchestra/security/permissions/UriMatcher.java
+++ b/security-proxy/src/main/java/org/georchestra/security/permissions/UriMatcher.java
@@ -25,12 +25,20 @@ import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Sets;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
+
+import com.google.common.collect.Sets;
 
 /**
  * @author Jesse on 8/15/2014.
  */
+@XmlRootElement(name = "urimatcher")
+@XmlAccessorType(XmlAccessType.NONE)
 public class UriMatcher {
     private int port = -1;
     private String path;
@@ -41,6 +49,13 @@ public class UriMatcher {
     private IpAddressMatcher ipMatcher;
     private String domain;
     private Pattern domainPattern;
+
+    public UriMatcher() {
+        
+    }
+    public UriMatcher(String domain) {
+        this.domain = domain;
+    }
 
     public synchronized void init() throws UnknownHostException {
         this.hostNames = null;
@@ -123,43 +138,39 @@ public class UriMatcher {
     }
 
 
-    public UriMatcher setHost(String host) throws UnknownHostException {
+    public void setHost(String host) throws UnknownHostException {
         this.host = host;
-        return this;
     }
 
-    public UriMatcher setPort(int port) {
+    public void setPort(int port) {
         this.port = port;
-        return this;
     }
 
-    public UriMatcher setPath(String path) {
+    public void setPath(String path) {
         this.path = path;
-        return this;
     }
 
-    public String getHost() {
+    public @XmlElement String getHost() {
         return host;
     }
 
-    public int getPort() {
+    public @XmlElement int getPort() {
         return port;
     }
 
-    public String getDomain() {
+    public @XmlElement String getDomain() {
         return domain;
     }
 
-    public UriMatcher setDomain(String domain) {
+    public void setDomain(String domain) {
         this.domain = domain;
-        return this;
     }
 
-    public String getPath() {
+    public @XmlElement String getPath() {
         return path;
     }
 
-    public String getNetwork() {
+    public @XmlElement String getNetwork() {
         return network;
     }
 

--- a/security-proxy/src/test/java/org/georchestra/security/PermissionsTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/PermissionsTest.java
@@ -1,23 +1,22 @@
 package org.georchestra.security;
 
-import org.georchestra.security.permissions.Permissions;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import org.georchestra.security.permissions.Permissions;
+import org.junit.Test;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
 
 public class PermissionsTest {
 
-    private Permissions load(String permissionsFile) throws IOException, ClassNotFoundException {
+    private Permissions load(String permissionsFile) throws IOException {
         InputStream inStream = this.getClass().getClassLoader().getResource(permissionsFile).openStream();
-        return Permissions.Create(inStream);
+        return Permissions.parse(inStream);
     }
 
     @Test
@@ -47,7 +46,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testAllowBydefault() throws IOException, ClassNotFoundException {
+    public void testAllowBydefault() throws IOException {
         Permissions perm = this.load("test-permissions-allowByDefault.xml");
 
         // Test URL not defined in xml: example.org
@@ -67,7 +66,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testDenyBydefault() throws IOException, ClassNotFoundException {
+    public void testDenyBydefault() throws IOException {
         Permissions perm = this.load("test-permissions-denyByDefault.xml");
 
         // Test URL not defined in xml: example.org
@@ -87,7 +86,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testHost() throws IOException, ClassNotFoundException {
+    public void testHost() throws IOException {
         Permissions perm = this.load("test-permissions-uriMatcher.xml");
 
         // sdi-stable.georchestra.org has same IP address as sdi.georchestra.org
@@ -96,7 +95,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testDomain() throws IOException, ClassNotFoundException {
+    public void testDomain() throws IOException {
         Permissions perm = this.load("test-permissions-uriMatcher.xml");
 
         assertTrue(perm.isDenied(new URL("http://www.google.fr/test.html")));
@@ -107,7 +106,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testNetwork() throws IOException, ClassNotFoundException {
+    public void testNetwork() throws IOException {
         Permissions perm = this.load("test-permissions-uriMatcher.xml");
 
         assertTrue(perm.isDenied(new URL("http://192.168.11.12/geoserver")));
@@ -117,7 +116,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testNetworkIPv6() throws IOException, ClassNotFoundException {
+    public void testNetworkIPv6() throws IOException {
         Permissions perm = this.load("test-permissions-uriMatcher.xml");
         assertTrue(perm.isDenied(new URL("http://www.google.com/geoserver")));
 
@@ -141,12 +140,12 @@ public class PermissionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNetworkBadFormat() throws IOException, ClassNotFoundException {
-        Permissions perm = this.load("test-permissions-network-bad-format.xml");
+    public void testNetworkBadFormat() throws IOException {
+        this.load("test-permissions-network-bad-format.xml");
     }
 
     @Test
-    public void testPort() throws IOException, ClassNotFoundException {
+    public void testPort() throws IOException {
         Permissions perm = this.load("test-permissions-uriMatcher.xml");
 
         assertFalse(perm.isDenied(new URL("http://www.example.org/google.html")));
@@ -156,7 +155,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testDefaultPort() throws IOException, ClassNotFoundException {
+    public void testDefaultPort() throws IOException {
         Permissions perm = this.load("test-permissions-defaultPort.xml");
 
         assertTrue(perm.isDenied(new URL("http://www.example.org/google.html")));
@@ -168,7 +167,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void testPath() throws IOException, ClassNotFoundException {
+    public void testPath() throws IOException {
         Permissions perm = this.load("test-permissions-uriMatcher.xml");
 
         assertTrue(perm.isDenied(new URL("http://www.example.org/search.html")));


### PR DESCRIPTION
XStream is only being used to parse the
Permissions and UriMatcher beans. This patch
removes the dependency in favor of JAXB, which
is an XML to Java binding technology already
provided by the runtime.