### PR TITLE
console - terms should open in another tab/window

### DIFF
--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -106,7 +106,7 @@ phone.label=Phone
 phone.placeholder=Phone
 phone.error.nonNumeric=The phone number should only contain digits
 privacyPolicyAgreed.label=Conditions
-privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}">conditions</a>
+privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
 recaptcha_response_field.error.required=Required
 recaptcha.incorrect=Incorrect, please try again

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -102,7 +102,7 @@ phone.label=Telefon
 phone.placeholder=Telefon
 phone.error.nonNumeric=Die Telefonnummer sollte nur Ziffern enthalten
 privacyPolicyAgreed.label=Conditions
-privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}">conditions</a>
+privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
 recaptcha_response_field.error.required=Notwendig
 recaptcha.incorrect=Falsch, bitte versuchen es noch einmal

--- a/console/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -100,7 +100,7 @@ phone.label=Teléfono
 phone.placeholder=Teléfono
 phone.error.nonNumeric=El número de teléfono solo puede contener dígitos
 privacyPolicyAgreed.label=Condiciones
-privacyPolicyAgreed.checkboxLabel=Leí y acepto las <a href="{0}">condiciones</a>
+privacyPolicyAgreed.checkboxLabel=Leí y acepto las <a href="{0}" target="_blank">condiciones</a>
 privacyPolicyAgreed.error.notChecked=Por favor, aceptar las condiciones para crear la cuenta
 postalAddress.label=Dirección postal
 postalAddress.placeholder=Dirección postal

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -106,7 +106,7 @@ phone.label=Téléphone
 phone.placeholder=Téléphone
 phone.error.nonNumeric=Le numéro de téléphone doit contenir uniquement des chiffres
 privacyPolicyAgreed.label=Conditions
-privacyPolicyAgreed.checkboxLabel=J''ai lu et j''accepte les <a href="{0}">conditions</a>
+privacyPolicyAgreed.checkboxLabel=J''ai lu et j''accepte les <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Veuillez accepter les conditions afin de créer le compte
 recaptcha_response_field.error.required=Cochez la case
 recaptcha.incorrect=Erreur. Réessayez


### PR DESCRIPTION
A user reported he lost the information he entered in the form when clicking the link.
This fixes it.