### PR TITLE
analytics - fixing filtering by roles

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8</version>
+      <version>4.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -591,6 +591,97 @@
                 <version>19.0</version>
               </dependency>
             </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>it</id>
+      <properties>
+        <skipIT>false</skipIT>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.31.0</version>
+            <executions>
+              <execution>
+                <id>prepare-containers</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <images>
+                    <image>
+                      <name>georchestra/database</name>
+                      <alias>database</alias>
+                      <run>
+                        <ports>
+                          <port>database_container.port:5432</port>
+                        </ports>
+                        <wait>
+                          <healthy>true</healthy>
+                          <log>(?s)database system is ready to accept connections</log>
+                          <time>20000</time>
+                        </wait>
+                      </run>
+                    </image>
+                  </images>
+                </configuration>
+              </execution>
+              <execution>
+                <id>remove-containers</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.22.1</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <additionalClasspathElements>
+                <additionalClasspathElement>${project.basedir}/src/main/webapp/WEB-INF</additionalClasspathElement>
+                <additionalClasspathElement>${project.basedir}/src/main/webapp/WEB-INF/classes</additionalClasspathElement>
+              </additionalClasspathElements>
+              <environmentVariables>
+                <ldap_port>${ldap_container.port}</ldap_port>
+                <dlJdbcUrlOGC>jdbc:postgresql://localhost:${database_container.port}/georchestra?user=georchestra&amp;password=georchestra</dlJdbcUrlOGC>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>add-test-source</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/it/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/analytics/src/main/java/org/georchestra/analytics/StatisticsController.java
+++ b/analytics/src/main/java/org/georchestra/analytics/StatisticsController.java
@@ -306,15 +306,16 @@ public class StatisticsController {
         }
 
         // not both group and user can be defined at the same time
-        if (input.has("user") && input.has("group")) {
+        if (input.has("user") && input.has("role")) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return null;
         }
-        if (input.has("user"))
+        if (input.has("user")) {
             sqlValues.put("user", input.getString("user"));
-        if (input.has("group"))
-            sqlValues.put("group", "ROLE_" + input.getString("group"));
-
+        }
+        if (input.has("role")) {
+            sqlValues.put("role", "ROLE_" + input.getString("role"));
+        }
         // Compute expression to aggregate dates
         GRANULARITY g = this.guessGranularity((String) sqlValues.get("startDate"), (String) sqlValues.get("endDate"));
         String aggregateDate;
@@ -344,11 +345,12 @@ public class StatisticsController {
                 + "     AND date < CAST({endDate} AS timestamp without time zone) ";
 
         // Handle user and group
-        if (input.has("user"))
+        if (input.has("user")) {
             sql += " AND user_name = {user} ";
-        if (input.has("group"))
-            sql += " AND {group} = ANY (roles) ";
-
+        }
+        if (input.has("role")) {
+            sql += " AND {role} = ANY (roles) ";
+        }
         sql += "GROUP BY to_char(date, {aggregateDateExpression}) "
                 + "ORDER BY to_char(date, {aggregateDateExpression})";
 
@@ -821,5 +823,4 @@ public class StatisticsController {
     private String getEndDate(JSONObject payload) throws JSONException, ParseException {
         return this.getDateField(payload, "endDate");
     }
-
 }

--- a/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerIT.java
+++ b/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerIT.java
@@ -1,33 +1,27 @@
 package org.georchestra.analytics;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.net.URL;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
+@Sql(scripts = "fixtures.sql", config = @SqlConfig(dataSource = "jpaDataSource"))
 @ContextConfiguration(locations = { "classpath:/ws-servlet.xml" })
 public class StatisticsControllerIT {
 
@@ -35,26 +29,7 @@ public class StatisticsControllerIT {
 
     private @Value("${dlJdbcUrlOGC}") String dlJdbcUrlOGC;
 
-    private @Autowired BasicDataSource ds;
-
     protected final Log logger = LogFactory.getLog(getClass().getPackage().getName());
-
-    private static boolean dataLoaded = false;
-
-    public @Before void before() throws Exception {
-        if (!dataLoaded) {
-            URL res = StatisticsControllerIT.class.getResource("fixtures.sql");
-            assertNotNull(res);
-            String fixtures = FileUtils.readFileToString(new File(res.toURI()));
-            Connection c = ds.getConnection();
-            for (String stmt : fixtures.split("\n")) {
-                logger.info(stmt);
-                PreparedStatement ps = c.prepareStatement(stmt);
-                ps.execute();
-            }
-            dataLoaded = true;
-        }
-    }
 
     public @Test void testFilteringByOrg() throws Exception {
         String payload = "{\"service\":\"layersUsage.json\",\"startDate\":\"2019-07-23\","

--- a/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerIT.java
+++ b/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerIT.java
@@ -1,0 +1,84 @@
+package org.georchestra.analytics;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = { "classpath:/ws-servlet.xml" })
+public class StatisticsControllerIT {
+
+    private @Autowired StatisticsController controller;
+
+    private @Value("${dlJdbcUrlOGC}") String dlJdbcUrlOGC;
+
+    private @Autowired BasicDataSource ds;
+
+    protected final Log logger = LogFactory.getLog(getClass().getPackage().getName());
+
+    private static boolean dataLoaded = false;
+
+    public @Before void before() throws Exception {
+        if (!dataLoaded) {
+            URL res = StatisticsControllerIT.class.getResource("fixtures.sql");
+            assertNotNull(res);
+            String fixtures = FileUtils.readFileToString(new File(res.toURI()));
+            Connection c = ds.getConnection();
+            for (String stmt : fixtures.split("\n")) {
+                logger.info(stmt);
+                PreparedStatement ps = c.prepareStatement(stmt);
+                ps.execute();
+            }
+            dataLoaded = true;
+        }
+    }
+
+    public @Test void testFilteringByOrg() throws Exception {
+        String payload = "{\"service\":\"layersUsage.json\",\"startDate\":\"2019-07-23\","
+                + "\"endDate\":\"2019-08-23\",\"role\":\"GT_TELECOM\",\"limit\":10}";
+        HttpServletResponse response = new MockHttpServletResponse();
+
+        String ret = controller.combinedRequests(payload, "json", response);
+
+        JSONObject jsRet = new JSONObject(ret);
+        JSONArray results = jsRet.getJSONArray("results");
+        assertTrue("GT_TELEKOM role should have only one hit in the statistics table",
+                results.length() == 1 && results.getJSONObject(0).getInt("count") == 1);
+    }
+
+    public @Test void testNoFilteringByOrg() throws Exception {
+        String payload = "{\"service\":\"layersUsage.json\",\"startDate\":\"2019-07-23\","
+                + "\"endDate\":\"2019-08-23\",\"limit\":10}";
+        HttpServletResponse response = new MockHttpServletResponse();
+
+        String ret = controller.combinedRequests(payload, "json", response);
+
+        JSONObject jsRet = new JSONObject(ret);
+        JSONArray results = jsRet.getJSONArray("results");
+        assertTrue("With no filter on the role, we expect more than 1 hit in the statistics table",
+                results.length() > 1);
+    }
+}

--- a/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerTest.java
+++ b/analytics/src/test/java/org/georchestra/analytics/StatisticsControllerTest.java
@@ -64,7 +64,7 @@ public class StatisticsControllerTest {
     @Test
     public final void testCombinedRequestsBothUserAndGroupSet() throws Exception {
         JSONObject posted = new JSONObject("{\"user\": \"testadmin\", \"startDate\": \"2015-01-01\", "
-                + "\"group\": \"ADMINISTRATOR\", \"endDate\": \"2015-12-01\" }");
+                + "\"role\": \"ADMINISTRATOR\", \"endDate\": \"2015-12-01\" }");
         // -> 400
         mockMvc.perform(post("/combinedRequests.json").content(posted.toString())).andExpect(status().isBadRequest());
     }

--- a/analytics/src/test/resources/log4j.properties
+++ b/analytics/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=OFF, S
+
+log4j.logger.org.georchestra.analytics=INFO
+
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/analytics/src/test/resources/org/georchestra/analytics/fixtures.sql
+++ b/analytics/src/test/resources/org/georchestra/analytics/fixtures.sql
@@ -1,0 +1,6 @@
+INSERT INTO ogcstatistics.ogc_services_log VALUES ('admin', '2019-08-22 16:44:54.160501', 'WMS', 'fond_gip', 1861, 'getmap', '', '{ROLE_ADMINISTRATOR}');
+INSERT INTO ogcstatistics.ogc_services_log VALUES ('admin', '2019-08-22 17:25:11.305113', 'WMS', 'ign', 541, 'describelayer', '', '{ROLE_ADMINISTRATOR}');
+INSERT INTO ogcstatistics.ogc_services_log VALUES ('admin', '2019-08-22 18:03:25.296614', 'WMS', 'fond_gip', 1620, 'getmap', '', '{ROLE_ADMINISTRATOR}');
+INSERT INTO ogcstatistics.ogc_services_log VALUES ('admin', '2019-08-22 18:19:51.142684', 'WMS', 'fond_gip', 1653, 'getmap', '', '{ROLE_ADMINISTRATOR}');
+INSERT INTO ogcstatistics.ogc_services_log VALUES ('admin', '2019-08-22 19:07:36.502652', 'WMS', 'fond_gip', 295, 'getmap', '', '{ROLE_ADMINISTRATOR}');
+INSERT INTO ogcstatistics.ogc_services_log VALUES ('telek', '2019-08-22 19:21:35.283377', 'WMS', 'fond_gip', 1458, 'getmap', '', '{ROLE_GT_TELECOM}');


### PR DESCRIPTION
See #2685 ;

Note: this PR introduces some integration tests on the analytics webapp, inspired from the ones introduced in 19.04 for the console, but:

* Integration tests follow the same conventions as the regular default maven failsafe plugin (code into src/test instead of src/it)
* The introduced IT makes use of the exact same spring beans configuration as the one used in the webapp in production (ws-servlet.xml)
* We still have to activate the "it" profile to make use of the postgresql docker image.

Tests:

* `mvn test` ok
* `mvn verify -Pit` ok

Credits goes to @groldan for the help !
