### PR TITLE
[WIP] console - relocate the GDPR-related endpoints

### DIFF
--- a/console/src/it/java/org/georchestra/console/integration/UsersIT.java
+++ b/console/src/it/java/org/georchestra/console/integration/UsersIT.java
@@ -166,7 +166,7 @@ public class UsersIT {
     public @Test void testDeleteAccountRecords() throws Exception {
 
         createUser("user1");
-        this.mockMvc.perform(post("/private/users/gdpr/delete?uid=user1"))//
+        this.mockMvc.perform(post("/account/gdpr/delete?uid=user1"))//
                 .andExpect(status().isOk())//
                 .andExpect(content().contentTypeCompatibleWith("application/json"))//
                 // .andDo(print())//
@@ -176,7 +176,7 @@ public class UsersIT {
                 .andExpect(jsonPath("$.geodocs").value(3))//
                 .andExpect(jsonPath("$.ogcStats").value(3));
 
-        this.mockMvc.perform(post("/private/users/gdpr/delete?uid=user1"))//
+        this.mockMvc.perform(post("/account/gdpr/delete?uid=user1"))//
                 .andExpect(status().isOk())//
                 .andExpect(content().contentTypeCompatibleWith("application/json"))//
                 .andExpect(jsonPath("$.account").value("user1"))//

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -491,7 +491,7 @@ public class UsersController {
         ResponseUtil.writeSuccess(response);
     }
 
-    @RequestMapping(method = RequestMethod.POST, value = "/private/users/gdpr/delete", produces = "application/json")
+    @RequestMapping(method = RequestMethod.POST, value = "/account/gdpr/delete", produces = "application/json")
     public ResponseEntity<DeletedUserDataInfo> deleteUserSensitiveData(//
             @RequestParam(required = false, name = "uid") String uid, //
             HttpServletRequest request, //

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersExport.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersExport.java
@@ -65,7 +65,7 @@ public class UsersExport {
      * <a href="https://eugdpr.org/">General Data Protection Regulation</a>)
      * relevant information available on the system.
      */
-    @RequestMapping(method = RequestMethod.GET, value = "/private/users/gdpr/download", produces = "application/zip")
+    @RequestMapping(method = RequestMethod.GET, value = "/account/gdpr/download", produces = "application/zip")
     public void downloadUserData(HttpServletResponse response)
             throws NameNotFoundException, DataServiceException, IOException {
 

--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -220,7 +220,7 @@
               <s:message code="editUserDetailsForm.downloadMsg" />
             </p>
             <p>
-              <a class="btn btn-primary" href="<c:out value="${publicContextPath}/private/users/gdpr/download" />">
+              <a class="btn btn-primary" href="<c:out value="${publicContextPath}/account/gdpr/download" />">
                 <i class="glyphicon glyphicon-download-alt"></i> <s:message code="editUserDetailsForm.download" />
               </a>
             </p>
@@ -246,7 +246,7 @@
 	<%@ include file="validation.jsp" %>
 	<script type="text/javascript">
     (function(){
-      var deleteURI = "<c:out value="${publicContextPath}/private/users/gdpr/delete" />"
+      var deleteURI = "<c:out value="${publicContextPath}/account/gdpr/delete" />"
       $('.gdpr .btn-danger').on('click', function() {
         if (!window.confirm('<s:message code="editUserDetailsForm.deleteConfirm" />')) return false
         fetch(deleteURI, { method: 'POST' })


### PR DESCRIPTION
Some endpoints are protected by the security-proxy, making them unavailable for regular users, yet these users should be able to access them (to retrieve their own data).

Note:

* I found curious that there are no place in the JS code to be modified ? Only the JSP one ?
* I might have missed something: does the controller code has to check if the user doing the request is actually allowed to do so ? It seems to be the case for delete, I'm not quite sure for download ...

Tests:

* `mvn clean test` ok
* `mvn clean verify -Pit` ok
