### PR TITLE
console - fixing serialization of cities in Org

### DIFF
--- a/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
+++ b/console/src/main/java/org/georchestra/console/ds/OrgsDao.java
@@ -43,9 +43,11 @@ import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -185,7 +187,8 @@ public class OrgsDao {
                     org.setId(asStringStream(attrs, "cn").collect(joining(",")));
                     org.setName(asStringStream(attrs, "o").collect(joining(",")));
                     org.setShortName(asStringStream(attrs, "ou").collect(joining(",")));
-                    org.setCities(asStringStream(attrs, "description").collect(Collectors.toList()));
+                    org.setCities(asStringStream(attrs, "description").flatMap(Pattern.compile(",")::splitAsStream)
+                            .collect(Collectors.toList()));
                     org.setMembers(asStringStream(attrs, "member").map(raw -> LdapNameBuilder.newInstance(raw))
                             .map(dn -> dn.build()).map(name -> name.getRdn(name.size() - 1).getValue().toString())
                             .collect(Collectors.toList()));

--- a/console/src/test/java/org/georchestra/console/ds/OrgsDaoTest.java
+++ b/console/src/test/java/org/georchestra/console/ds/OrgsDaoTest.java
@@ -16,7 +16,10 @@ import org.springframework.ldap.support.LdapNameBuilder;
 
 import javax.naming.Name;
 import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
 import javax.naming.ldap.LdapName;
 import java.util.Collections;
 import java.util.List;
@@ -179,6 +182,32 @@ public class OrgsDaoTest {
         verify(mockLdapTemplate).modifyAttributes(attributesCaptor.capture());
         assertEquals("uid=momo,ou=users,dc=georchestra,dc=org",
                 attributesCaptor.getValue().getAttributes().get("member").get(0));
+    }
+
+    @Test
+    public void testOrgAttributeMapperCities() throws NamingException {
+        OrgsDao d = new OrgsDao();
+        Attributes orgToDeserialize = new BasicAttributes();
+        orgToDeserialize.put("description", "1,2,3");
+        AttributesMapper<Org> toTest = d.getExtension(new Org()).getAttributeMapper(true);
+
+        Org org = toTest.mapFromAttributes(orgToDeserialize);
+
+        assertTrue("Expected 3 cities", org.getCities().size() == 3);
+    }
+
+    @Test
+    public void testOrgAttributeMapperCitiesMultipleDescAttributes() throws NamingException {
+        OrgsDao d = new OrgsDao();
+        Attributes orgToDeserialize = new BasicAttributes();
+        Attribute desc = new BasicAttribute("description");
+        desc.add("1,2,3");
+        desc.add("4,5,6");
+        orgToDeserialize.put(desc);
+        AttributesMapper<Org> toTest = d.getExtension(new Org()).getAttributeMapper(true);
+
+        Org org = toTest.mapFromAttributes(orgToDeserialize);
+        assertTrue("Expected 6 cities", org.getCities().size() == 6);
     }
 
     private void mockOrgLookupResultDependingOnDn(LdapTemplate mockLdapTemplate, Org returnedOrg, String searchDn) {


### PR DESCRIPTION
This PR aims to fix the JSON format returned for the organizations:

Hitting  `<georchestra>/console/private/orgs/<myorg>` 

returns (in case of multivalued cities) a JSON entry as follows:

```
 "cities":["62270,62178"]
```

Where the UI actually expects:

```
 "cities":["62270","62178"]
```

Tests: 
* Added utests to test the Org Attribute Mapper
* mvn test OK
* mvn verify OK
