### PR TITLE
console - fixing UserDetailsFormController

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -22,6 +22,8 @@ package org.georchestra.console.ws.edituserdetails;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+
 import org.georchestra.console.ds.AccountDao;
 import org.georchestra.console.ds.DataServiceException;
 import org.georchestra.console.ds.DuplicatedEmailException;
@@ -191,9 +193,9 @@ public class EditUserDetailsFormController {
             accountDao.update(account, request.getHeader("sec-username"));
 
             model.addAttribute("success", true);
-            Org org = orgsDao.findByCommonName(account.getOrg());
+            Org org = orgsDao.findByCommonNameWithExt(account);
             model.addAttribute("org", orgToJson(org));
-
+            model.addAttribute("isReferentOrSuperUser", isReferentOrSuperUser(account));
             return "editUserDetailsForm";
 
         } catch (DuplicatedEmailException e) {


### PR DESCRIPTION
There is 2 issues when POST'ing modifications, because the code for the
GET is not in sync with the one for POST:

* Org is added to the model without its orgExt
* the isReferentOrSuperUser is missing

This is causing bugs in the generated web page (missing variables in the
JSP, inducing wrongly generated Javascript).

Tests:
* Utests adapted to check the model variables injection
* utests ok
* IT ok
* runtime tested injecting the modified class directly onto geo2france-dev
