### PR TITLE
console - Editing an org - do not change the logo if empty

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/editorgdetails/EditOrgDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/editorgdetails/EditOrgDetailsFormController.java
@@ -116,7 +116,9 @@ public class EditOrgDetailsFormController {
         }
 
         OrgExt orgExt = modifyOrgExt(orgsDao.findExtById(formBean.getId()), formBean);
-        orgExt.setLogo(transformLogoFileToBase64(logo));
+        if (!logo.isEmpty()) {
+            orgExt.setLogo(transformLogoFileToBase64(logo));
+        }
         orgsDao.update(orgExt);
         model.addAttribute("success", true);
 


### PR DESCRIPTION
The current code always tries to change the logo in the LDAP, even if
Spring receives an empty file. So when a user change a field but without
sending a logo, it discards the jpegPhoto attribute of the organisation.

Skipping the setLogo() logic when the received file is empty.

Tests:
* no test added
* utest ok
* IT ok
* runtime tested via JDWP and java code switching directly from
  Eclipse.