### PR TITLE
Console - enhance email template by adding orgs to new users

### DIFF
--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -112,7 +112,7 @@ public class EmailFactory {
         email.set("name", userName);
         email.set("uid", uid);
         email.set("email", userEmail);
-        email.set("orgs", userOrg);
+        email.set("org", userOrg);
         email.send();
     }
 
@@ -150,6 +150,9 @@ public class EmailFactory {
         email.set("name", userName);
         email.set("uid", uid);
         email.set("email", userEmail);
+        if (userOrg == null) {
+            userOrg = "None";
+        }
         email.set("org", userOrg);
         email.send();
     }
@@ -256,5 +259,9 @@ public class EmailFactory {
 
     public void setInstanceName(String instanceName) {
         this.instanceName = instanceName;
+    }
+
+    public void setAdministratorEmail(String administratorEmail) {
+        this.administratorEmail = administratorEmail;
     }
 }

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -151,7 +151,7 @@ public class EmailFactory {
         email.set("uid", uid);
         email.set("email", userEmail);
         if (userOrg == null) {
-            userOrg = "None";
+            userOrg = "";
         }
         email.set("org", userOrg);
         email.send();

--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -156,9 +156,9 @@ public final class NewAccountFormController {
 
     @InitBinder
     public void initForm(WebDataBinder dataBinder) {
-        dataBinder.setAllowedFields("firstName", "surname", "email", "phone", "org", "title",
-                "description", "uid", "password", "confirmPassword", "privacyPolicyAgreed", "createOrg", "orgName",
-                "orgShortName", "orgAddress", "orgType", "orgCities", "orgDescription", "orgUrl", "orgLogo",
+        dataBinder.setAllowedFields("firstName", "surname", "email", "phone", "org", "title", "description", "uid",
+                "password", "confirmPassword", "privacyPolicyAgreed", "createOrg", "orgName", "orgShortName",
+                "orgAddress", "orgType", "orgCities", "orgDescription", "orgUrl", "orgLogo",
                 "recaptcha_response_field");
     }
 


### PR DESCRIPTION
Add org of the user when new user register (see also [datadir](https://github.com/georchestra/datadir/pull/171)). Having Org in your template is nor mandatory. If it's present it will be populated accordingly 