### PR TITLE
Add ldapPublicKey to the list of objectclass when mapping an ldap use…

### DIFF
--- a/console/src/main/java/org/georchestra/console/ds/AccountDaoImpl.java
+++ b/console/src/main/java/org/georchestra/console/ds/AccountDaoImpl.java
@@ -421,7 +421,7 @@ public final class AccountDaoImpl implements AccountDao {
     private void mapToContext(Account account, DirContextOperations context) {
 
         context.setAttributeValues("objectclass", new String[] { "top", "person", "organizationalPerson",
-                "inetOrgPerson", "shadowAccount", "georchestraUser" });
+                "inetOrgPerson", "shadowAccount", "georchestraUser", "ldapPublicKey" });
 
         // person attributes
         setAccountField(context, UserSchema.SURNAME_KEY, account.getSurname());


### PR DESCRIPTION
…r (fixes #2725)

otherwise, saving an user blows with [LDAP: error code 65 - attribute 'sshPublicKey' not allowed]