### PR TITLE
Insert BOM to encode CSV correctly

### DIFF
--- a/console/src/main/webapp/manager/app/components/users/users.es6
+++ b/console/src/main/webapp/manager/app/components/users/users.es6
@@ -96,7 +96,7 @@ class UsersController {
         default:
           mimetype = `text/${fileType}`
       }
-      const blob = new Blob([result.data], { type: mimetype })
+      const blob = new Blob(['\ufeff', result.data], { type: mimetype })
       const a = document.createElement('a')
       a.href = window.URL.createObjectURL(blob)
       a.target = '_blank'


### PR DESCRIPTION
This PR specify the encoding to display specials characters (é,à,ù,...) for **user(s) export only**.

Link to #2737 .