### PR TITLE
root pom - renaming sentry profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -798,12 +798,12 @@
   </reporting>
   <profiles>
     <profile>
-      <id>sentry-log4j</id>
+      <id>sentry-spring</id>
       <dependencies>
         <dependency>
           <groupId>io.sentry</groupId>
-          <artifactId>sentry-log4j</artifactId>
-          <version>1.6.7</version>
+          <artifactId>sentry-spring</artifactId>
+          <version>1.7.27</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
The main motivation is that using log4j to send logs to sentry might not
be the best way of integrating sentry. We want to just send the
exceptions actually, sentry does not need to get the whole logs.

The caveat of this approach is that it requires to define an extra bean
to the spring XML configuration (see
https://docs.sentry.io/clients/java/integrations/#spring). Using the
log4j1 module only needed to modify the log4j configuration.

Also moving to the new version of sentry-spring (1.7.27)