### PR TITLE
console: add organization info to CSV users export

### DIFF
--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersExportTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersExportTest.java
@@ -1,24 +1,96 @@
 package org.georchestra.console.ws.backoffice.users;
 
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.ACCOUNT;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.ANNIVERSARY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.ASSISTANT_NAME;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.ASSISTANT_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BDAY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BILLING_INFO;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_ADDRESS;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_ADDR_POBOX;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_ADDR_STREET;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_ADDR_STREET2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_ADDR_STREET3;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_CITY;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_COUNTRY;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_FAX;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_PC;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_PHONE2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.BIZ_STATE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.CALLBACK;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.CAR_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.CATEGORIES;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.CHILDREN;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.COMPANY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.COMPANY_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.DEPARTMENT;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.DIRECTORY_SERVER;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.EMAIL;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.EMAIL2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.EMAIL3;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.FIRST_NAME;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.GENDER;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOBBY;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_ADDRESS;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_CITY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_COUNTRY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_FAX;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_PC;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_PHONE2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_POBOX;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_STATE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_STREET;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_STREET2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.HOME_STREET3;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.INITIALS;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.INTERNET_FREE_BUSY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.ISDN;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.JOB_TITLE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.KEYWORDS;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.LANG;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.LAST_NAME;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.LOCATION;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.MANAGER_NAME;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.MIDDLE_NAME;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.MILEAGE;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.MOBILE_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.NOTES;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OFFICE_LOCATION;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.ORG_ID;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_ADDR;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_CITY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_COUNTRY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_FAX;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_PC;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_POBOX;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_ST;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_ST2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_ST3;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.OTHER_STATE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.PAGER;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.PRIORITY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.PRIVATE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.PROFESSION;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.RADIO_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.REFERRED_BY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.SENSITIVITY;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.SPOUSE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.SUFFIX;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.TELEX;
 import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.TITLE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.TTY_PHONE;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.USER1;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.USER2;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.USER3;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.USER4;
+import static org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField.WEBPAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.eq;
@@ -32,13 +104,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.georchestra.console.dao.AdvancedDelegationDao;
 import org.georchestra.console.ds.AccountDao;
 import org.georchestra.console.ds.AccountDaoImpl;
+import org.georchestra.console.ds.OrgsDao;
 import org.georchestra.console.dto.AccountImpl;
+import org.georchestra.console.dto.orgs.Org;
+import org.georchestra.console.dto.orgs.OrgExt;
 import org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +129,8 @@ public class UsersExportTest {
     private UsersExport us;
 
     private AccountImpl account1, account2;
+    private Org org1, org2;
+    private OrgExt orgExt1;
 
     private static final String headers = "First Name,Middle Name,Last Name,Title,Suffix,Initials,Web Page,Gender,Birthday,Anniversary,"
             + "Location,Language,Internet Free Busy,Notes,E-mail Address,E-mail 2 Address,E-mail 3 Address,Primary Phone,Home Phone,"
@@ -66,60 +144,163 @@ public class UsersExportTest {
 
     @Before
     public void setUp() throws Exception {
-        AccountDao mockedDao = mock(AccountDao.class);
+        AccountDao accDao = mock(AccountDao.class);
+        OrgsDao orgDao = mock(OrgsDao.class);
+
         account1 = new AccountImpl();
         account1.setUid("pmauduit");
+        account1.setOrg("c2c");
         account1.setCommonName("Pierre");
         account1.setSurname("Mauduit");
         account1.setEmail("abc@example.com");
 
+        org1 = new Org();
+        org1.setId("c2c");
+        org1.setName("CampToCamp");
+
         account2 = new AccountImpl();
         account2.setUid("jdoe");
+        account2.setOrg("org2");
         account2.setCommonName("John");
         account2.setSurname("Doe");
         account2.setEmail("jdoe@example.com");
+
+        org2 = new Org();
+        org2.setId("org2");
+        org2.setName("Org2");
+
+        when(orgDao.findByCommonNameWithExt(eq(account1))).thenReturn(org1);
+        when(orgDao.findByCommonNameWithExt(eq(account2))).thenReturn(org2);
 
         Authentication auth = mock(Authentication.class);
         Collection<GrantedAuthority> authorities = Collections.singleton(AdvancedDelegationDao.ROLE_SUPERUSER);
         doReturn(authorities).when(auth).getAuthorities();
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        when(mockedDao.findByUID(eq(account1.getUid()))).thenReturn(account1);
-        when(mockedDao.findByUID(eq(account2.getUid()))).thenReturn(account2);
+        when(accDao.findByUID(eq(account1.getUid()))).thenReturn(account1);
+        when(accDao.findByUID(eq(account2.getUid()))).thenReturn(account2);
 
-        UserInfoExporter exporter = new UserInfoExporterImpl(mockedDao);
+        UserInfoExporterImpl exporter = new UserInfoExporterImpl(accDao);
+        CSVAccountExporter csvAccountExporter = new CSVAccountExporter();
+        csvAccountExporter.setOrgsDao(orgDao);
+
+        exporter.setCSVAccountExporter(csvAccountExporter);
         us = new UsersExport(exporter);
     }
 
     @Test
     public void testGetUsersAsCsv() throws Exception {
         String s = us.getUsersAsCsv("[\"pmauduit\"]");
-        String res = "Pierre,,Mauduit,,,,,,,,,,,,abc@example.com,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"
-                + ",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
-        String[] splitted = s.split("\r\n");
+        String expected = "Pierre,,Mauduit,,,,,,,,,,,,abc@example.com,,,,,,,,,,,,,,,,,,,,,,,,,,,,CampToCamp,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
 
+        String[] splitted = s.split("\r\n");
+        System.err.println(splitted[1]);
         assertFalse("The CSV contains \"null\", unexpected", s.contains("null"));
         assertTrue("The CSV should contain \"abc@example.com\"", s.contains("abc@example.com"));
         assertEquals("The CSV should have the headers", splitted[0], headers);
-        assertEquals("The CSV payoad should match entry data", splitted[1], res);
+        assertEquals("The CSV payoad should match entry data", expected, splitted[1]);
+    }
+
+    @Test
+    public void testCsvValueExtract() throws Exception {
+        setUpAllMappedFields();
+        // mapped fields
+        assertEquals(account1.getCommonName(), FIRST_NAME.apply(account1, org1));
+        assertEquals(account1.getSurname(), LAST_NAME.apply(account1, org1));
+        assertEquals(account1.getTitle(), TITLE.apply(account1, org1));
+        assertEquals(orgExt1.getDescription(), NOTES.apply(account1, org1));
+        assertEquals(account1.getEmail(), EMAIL.apply(account1, org1));
+        assertEquals(account1.getPhone(), PHONE.apply(account1, org1));
+        assertEquals(account1.getMobile(), MOBILE_PHONE.apply(account1, org1));
+        assertEquals(account1.getHomePostalAddress(), HOME_ADDRESS.apply(account1, org1));
+        assertEquals(account1.getLocality(), HOME_CITY.apply(account1, org1));
+        assertEquals(account1.getManager(), MANAGER_NAME.apply(account1, org1));
+        assertEquals(account1.getPostalAddress(), BIZ_ADDRESS.apply(account1, org1));
+        assertEquals(account1.getStreet(), BIZ_ADDR_STREET.apply(account1, org1));
+        assertEquals(account1.getPostOfficeBox(), BIZ_ADDR_POBOX.apply(account1, org1));
+        String cities = org1.getCities().stream().collect(Collectors.joining(","));
+        assertEquals(cities, BIZ_CITY.apply(account1, org1));
+        assertEquals(account1.getFacsimile(), BIZ_FAX.apply(account1, org1));
+        assertEquals(org1.getName(), COMPANY.apply(account1, org1));
+        assertEquals(account1.getDescription(), JOB_TITLE.apply(account1, org1));
+        assertEquals(account1.getPostalCode(), BIZ_PC.apply(account1, org1));
+        assertEquals(account1.getStateOrProvince(), BIZ_COUNTRY.apply(account1, org1));
+        assertEquals(account1.getRegisteredAddress(), OTHER_ADDR.apply(account1, org1));
+        assertEquals(account1.getPhysicalDeliveryOfficeName(), OTHER_ST.apply(account1, org1));
+
+        // unmapped fields
+        assertNull(MIDDLE_NAME.apply(account1, org1));
+        assertNull(SUFFIX.apply(account1, org1));
+        assertNull(INITIALS.apply(account1, org1));
+        assertNull(WEBPAGE.apply(account1, org1));
+        assertNull(GENDER.apply(account1, org1));
+        assertNull(BDAY.apply(account1, org1));
+        assertNull(ANNIVERSARY.apply(account1, org1));
+        assertNull(LOCATION.apply(account1, org1));
+        assertNull(LANG.apply(account1, org1));
+        assertNull(INTERNET_FREE_BUSY.apply(account1, org1));
+        assertNull(EMAIL2.apply(account1, org1));
+        assertNull(EMAIL3.apply(account1, org1));
+        assertNull(HOME_PHONE.apply(account1, org1));
+        assertNull(HOME_PHONE2.apply(account1, org1));
+        assertNull(PAGER.apply(account1, org1));
+        assertNull(HOME_FAX.apply(account1, org1));
+        assertNull(HOME_STREET.apply(account1, org1));
+        assertNull(HOME_STREET2.apply(account1, org1));
+        assertNull(HOME_STREET3.apply(account1, org1));
+        assertNull(HOME_POBOX.apply(account1, org1));
+        assertNull(HOME_STATE.apply(account1, org1));
+        assertNull(HOME_PC.apply(account1, org1));
+        assertNull(HOME_COUNTRY.apply(account1, org1));
+        assertNull(SPOUSE.apply(account1, org1));
+        assertNull(CHILDREN.apply(account1, org1));
+        assertNull(ASSISTANT_NAME.apply(account1, org1));
+        assertNull(REFERRED_BY.apply(account1, org1));
+        assertNull(COMPANY_PHONE.apply(account1, org1));
+        assertNull(BIZ_PHONE.apply(account1, org1));
+        assertNull(BIZ_PHONE2.apply(account1, org1));
+        assertNull(ASSISTANT_PHONE.apply(account1, org1));
+        assertNull(DEPARTMENT.apply(account1, org1));
+        assertNull(OFFICE_LOCATION.apply(account1, org1));
+        assertNull(ORG_ID.apply(account1, org1));
+        assertNull(PROFESSION.apply(account1, org1));
+        assertNull(ACCOUNT.apply(account1, org1));
+        assertNull(BIZ_ADDR_STREET2.apply(account1, org1));
+        assertNull(BIZ_ADDR_STREET3.apply(account1, org1));
+        assertNull(BIZ_STATE.apply(account1, org1));
+        assertNull(OTHER_PHONE.apply(account1, org1));
+        assertNull(OTHER_FAX.apply(account1, org1));
+        assertNull(OTHER_ST2.apply(account1, org1));
+        assertNull(OTHER_ST3.apply(account1, org1));
+        assertNull(OTHER_POBOX.apply(account1, org1));
+        assertNull(OTHER_CITY.apply(account1, org1));
+        assertNull(OTHER_STATE.apply(account1, org1));
+        assertNull(OTHER_PC.apply(account1, org1));
+        assertNull(OTHER_COUNTRY.apply(account1, org1));
+        assertNull(CALLBACK.apply(account1, org1));
+        assertNull(CAR_PHONE.apply(account1, org1));
+        assertNull(ISDN.apply(account1, org1));
+        assertNull(RADIO_PHONE.apply(account1, org1));
+        assertNull(TTY_PHONE.apply(account1, org1));
+        assertNull(TELEX.apply(account1, org1));
+        assertNull(USER1.apply(account1, org1));
+        assertNull(USER2.apply(account1, org1));
+        assertNull(USER3.apply(account1, org1));
+        assertNull(USER4.apply(account1, org1));
+        assertNull(KEYWORDS.apply(account1, org1));
+        assertNull(MILEAGE.apply(account1, org1));
+        assertNull(HOBBY.apply(account1, org1));
+        assertNull(BILLING_INFO.apply(account1, org1));
+        assertNull(DIRECTORY_SERVER.apply(account1, org1));
+        assertNull(SENSITIVITY.apply(account1, org1));
+        assertNull(PRIORITY.apply(account1, org1));
+        assertNull(PRIVATE.apply(account1, org1));
+        assertNull(CATEGORIES.apply(account1, org1));
     }
 
     @Test
     public void testGetUsersAsCsvAllFields() throws Exception {
-        account1.setTitle("CTO");
-        account1.setPhone("+54 555-111");
-        account1.setMobile("+54 341 555 222");
-        account1.setHomePostalAddress("some address");
-        account1.setManager("Homer");
-        account1.setFacsimile("+54 555 1234");
-        account1.setDescription("description \n with \r\n newlines\n and\n \"escape \"char");
-        account1.setPostalAddress("some postal Address");
-        account1.setStreet("the street name");
-        account1.setPostOfficeBox("the post office box");
-        account1.setPostalCode("2000");
-        account1.setStateOrProvince("Stanta Fe");
-        account1.setRegisteredAddress("the registered address");
-        account1.setPhysicalDeliveryOfficeName("delivery office");
+        setUpAllMappedFields();
 
         String s = us.getUsersAsCsv("[\"pmauduit\"]");
 
@@ -136,14 +317,40 @@ public class UsersExportTest {
         assertEquals(headerNames.get(0), header.get(0));
 
         CSVRecord record = records.get(1);
-        assertCsvRecord(account1, record);
+        assertCsvRecord(account1, org1, record);
+    }
+
+    private void setUpAllMappedFields() {
+        account1.setTitle("CTO");
+        account1.setPhone("+54 555-111");
+        account1.setMobile("+54 341 555 222");
+        account1.setHomePostalAddress("some address");
+        account1.setManager("Homer");
+        account1.setFacsimile("+54 555 1234");
+        account1.setDescription("description \n with \r\n newlines\n and\n \"escape \"char");
+        account1.setPostalAddress("some postal Address");
+        account1.setStreet("the street name");
+        account1.setPostOfficeBox("the post office box");
+        account1.setPostalCode("2000");
+        account1.setStateOrProvince("Stanta Fe");
+        account1.setRegisteredAddress("the registered address");
+        account1.setPhysicalDeliveryOfficeName("delivery office");
+        account1.setLocality("Paris");
+
+        org1.setCities(Arrays.asList("Paris", "Seoul"));
+        orgExt1 = new OrgExt();
+        org1.setOrgExt(orgExt1);
+        orgExt1.setAddress("c2c address");
+        // https://translate.google.com/#view=home&op=translate&sl=fr&tl=ko&text=Camptocamp.org%20a%20pour%20but%20de%20faciliter%20%0Ale%20partage%20d'informations%20entre%20les%20pratiquants%20%0Ade%20sports%20de%20montagne%20et%20de%20contribuer%20%C3%A0%20la%20%0As%C3%A9curit%C3%A9%20des%20activit%C3%A9s%20montagne.
+        orgExt1.setDescription("Camptocamp.org의 목표는\n실무자 간의 정보 공유\n산악 스포츠와에 기여\n산악 활동의 안전.");
+        orgExt1.setUrl("https://www.camptocamp.org/");
     }
 
     @Test
     public void testGetUsersAsCsvMultipleUsers() throws Exception {
-        String s = us.getUsersAsCsv("[\"pmauduit\",\"jdoe\"]");
+        String csv = us.getUsersAsCsv("[\"pmauduit\",\"jdoe\"]");
 
-        CSVParser parser = CSVAccountExporter.FORMAT.parse(new StringReader(s));
+        CSVParser parser = CSVAccountExporter.FORMAT.parse(new StringReader(csv));
         List<String> headerNames = parser.getHeaderNames();
         List<String> expectedHeaders = Arrays.asList(headers.split(","));
         assertEquals(expectedHeaders, headerNames);
@@ -155,32 +362,33 @@ public class UsersExportTest {
         // but just to be sure
         assertEquals(headerNames.get(0), header.get(0));
 
-        assertCsvRecord(account1, records.get(1));
-        assertCsvRecord(account2, records.get(2));
+        assertCsvRecord(account1, org1, records.get(1));
+        assertCsvRecord(account2, org2, records.get(2));
     }
 
-    private void assertCsvRecord(AccountImpl acc, CSVRecord record) {
-        assertField(acc, record, FIRST_NAME);
-        assertField(acc, record, LAST_NAME);
-        assertField(acc, record, TITLE);
-        assertField(acc, record, EMAIL);
-        assertField(acc, record, PHONE);
-        assertField(acc, record, MOBILE_PHONE);
-        assertField(acc, record, HOME_ADDRESS);
-        assertField(acc, record, MANAGER_NAME);
-        assertField(acc, record, BIZ_FAX);
-        assertField(acc, record, JOB_TITLE);
-        assertField(acc, record, BIZ_ADDRESS);
-        assertField(acc, record, BIZ_ADDR_STREET);
-        assertField(acc, record, BIZ_ADDR_POBOX);
-        assertField(acc, record, BIZ_PC);
-        assertField(acc, record, BIZ_COUNTRY);
-        assertField(acc, record, OTHER_ADDR);
-        assertField(acc, record, OTHER_ST);
+    private void assertCsvRecord(AccountImpl acc, Org org, CSVRecord record) {
+        assertField(acc, org, record, FIRST_NAME);
+        assertField(acc, org, record, LAST_NAME);
+        assertField(acc, org, record, TITLE);
+        assertField(acc, org, record, EMAIL);
+        assertField(acc, org, record, PHONE);
+        assertField(acc, org, record, MOBILE_PHONE);
+        assertField(acc, org, record, HOME_ADDRESS);
+        assertField(acc, org, record, MANAGER_NAME);
+        assertField(acc, org, record, BIZ_FAX);
+        assertField(acc, org, record, JOB_TITLE);
+        assertField(acc, org, record, BIZ_ADDRESS);
+        assertField(acc, org, record, BIZ_ADDR_STREET);
+        assertField(acc, org, record, BIZ_ADDR_POBOX);
+        assertField(acc, org, record, BIZ_PC);
+        assertField(acc, org, record, BIZ_COUNTRY);
+        assertField(acc, org, record, OTHER_ADDR);
+        assertField(acc, org, record, OTHER_ST);
+        assertField(acc, org, record, HOME_CITY);
     }
 
-    private void assertField(AccountImpl acc, CSVRecord record, OutlookCSVHeaderField field) {
-        String expected = field.apply(acc);
+    private void assertField(AccountImpl acc, Org org, CSVRecord record, OutlookCSVHeaderField field) {
+        String expected = field.apply(acc, org);
         if (null == expected) {
             expected = "";
         }


### PR DESCRIPTION
Add the following mappings from outlook CSV format
to Account:

`Web Page`:     -> Org.url
`Notes`:        -> Org.description
`Home City`:    -> Account.locality
`Company`:      -> Org.name
`Business City`:-> Org.cities