### PR TITLE
Security-proxy - rewrite cookie management

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
@@ -29,8 +29,10 @@ public class HeaderNames {
     public static final String SEC_USERNAME = "sec-username";
     public static final String SEC_ROLES = "sec-roles";
     public static final String REFERER_HEADER_NAME = "Referer";
-    static final String IMP_ROLES = "imp-roles";
-    static final String IMP_USERNAME = "imp-username";
+    public static final String IMP_ROLES = "imp-roles";
+    public static final String IMP_USERNAME = "imp-username";
+    // note: JSESSIONID is strictly speaking not a Header,
+    // but usual part of the the Cookie / Set-Cookie header
     public static final String JSESSION_ID = "JSESSIONID";
     public static final String SET_COOKIE_ID = "Set-Cookie";
     public static final String COOKIE_ID = "Cookie";

--- a/security-proxy/src/main/webapp/WEB-INF/web.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/web.xml
@@ -56,6 +56,10 @@
   </servlet-mapping>
   <session-config>
     <session-timeout>1440</session-timeout>
+    <cookie-config>
+        <http-only>true</http-only>
+        <secure>true</secure>
+    </cookie-config>
   </session-config>
 
   <servlet-mapping>

--- a/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
@@ -1,18 +1,29 @@
 package org.georchestra.security;
 
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.junit.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.Collections;
-
+import static org.georchestra.security.HeaderNames.COOKIE_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.message.BasicHeader;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * @author Jesse on 4/24/2014.
@@ -87,6 +98,97 @@ public class HeadersManagementStrategyTest {
         headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true);
         assertTrue(hasHeader("sec-username", proxyRequest));
         assertEquals(proxyRequest.getHeaders("sec-username")[0].getValue(), "jeichar");
+    }
+
+    @Test
+    public void testHandleRequestCookies() throws URISyntaxException {
+        String cookie = "JSESSIONID=node0aaaaddddddazaaaadudududu.node0; _ga=GA1.3.1524586053.1570800882; _gid=GA1.3.1833230840.1570800882; _gat=1";
+        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
+        headerManagement
+                .setHeaderProviders(Collections.<HeaderProvider>singletonList(new SecurityRequestHeaderProvider()));
+        MockHttpServletRequest originalRequest = new MockHttpServletRequest();
+        originalRequest.addHeader(COOKIE_ID, cookie);
+        HttpRequestBase proxyRequest = Mockito.mock(HttpRequestBase.class);
+        Mockito.when(proxyRequest.getURI()).thenReturn(new URI("https://www.georchestra.org/console/newPassword"));
+
+        headerManagement.handleRequestCookies(originalRequest, proxyRequest, new StringBuilder());
+    }
+
+    @Test
+    public void testHandleResponseCookiesSeveralParameters() {
+        String setCookie = "JSESSIONID=node0aaaaaaaaaaaaaaaaaaaaaaaa.node0;Path=/console;Secure;HttpOnly";
+        String requestUri = "/console/newPassword";
+        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
+        HttpSession session = new MockHttpSession();
+        Header setCookieHeader = new BasicHeader(HeaderNames.SET_COOKIE_ID, setCookie);
+
+        headerManagement.handleResponseCookies(requestUri, new MockHttpServletResponse(),
+                new Header[] { setCookieHeader }, session);
+
+        Map<String, String> jSessionIds = (Map<String, String>) session.getAttribute(HeaderNames.JSESSION_ID);
+        assertTrue("Unexpected JsessionId map in session",
+                jSessionIds.get("/console").contentEquals("JSESSIONID=node0aaaaaaaaaaaaaaaaaaaaaaaa.node0"));
+    }
+
+    @Test
+    public void testHandleResponseCookiesNoParams() {
+        String setCookie = "JSESSIONID=node0aaaaaaaaaaaaaaaaaaaaaaaa.node0";
+        String requestUri = "/console/newPassword";
+        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
+        HttpSession session = new MockHttpSession();
+        Header setCookieHeader = new BasicHeader(HeaderNames.SET_COOKIE_ID, setCookie);
+
+        headerManagement.handleResponseCookies(requestUri, new MockHttpServletResponse(),
+                new Header[] { setCookieHeader }, session);
+
+        Map<String, String> jSessionIds = (Map<String, String>) session.getAttribute(HeaderNames.JSESSION_ID);
+        assertTrue("jSessionIds map expected to be unset", jSessionIds == null);
+    }
+
+    @Test
+    public void testHandleResponseCookiesOnlyPath() {
+        String setCookie = "JSESSIONID=node0aaaaaaaaaaaaaaaaaaaaaaaa.node0;Path=/console";
+        String requestUri = "/console/newPassword";
+        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
+        HttpSession session = new MockHttpSession();
+        Header setCookieHeader = new BasicHeader(HeaderNames.SET_COOKIE_ID, setCookie);
+
+        headerManagement.handleResponseCookies(requestUri, new MockHttpServletResponse(),
+                new Header[] { setCookieHeader }, session);
+
+        Map<String, String> jSessionIds = (Map<String, String>) session.getAttribute(HeaderNames.JSESSION_ID);
+        assertTrue("Unexpected JsessionId map in session",
+                jSessionIds.get("/console").contentEquals("JSESSIONID=node0aaaaaaaaaaaaaaaaaaaaaaaa.node0"));
+
+    }
+
+    @Test
+    public void testHandleResponseCookiesPathDoesNotMatch() {
+        String setCookie = "custom_key=custom_value;Path=/myconsole_is_elsewhere";
+        String setCookie2 = "JSESSIONID=aaaaaa.node0;Path=/myconsole_is_elsewhere";
+        String requestUri = "/console/newPassword";
+        HeadersManagementStrategy headerManagement = new HeadersManagementStrategy();
+        HttpSession session = new MockHttpSession();
+        Header setCookieHeader = new BasicHeader(HeaderNames.SET_COOKIE_ID, setCookie);
+        Header setCookieHeader2 = new BasicHeader(HeaderNames.SET_COOKIE_ID, setCookie2);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        headerManagement.handleResponseCookies(requestUri, response, new Header[] { setCookieHeader, setCookieHeader2 },
+                session);
+
+        // In the session map, the JSESSIONID should still be indexed by the original
+        // path
+        Map<String, String> jSessionIds = (Map<String, String>) session.getAttribute(HeaderNames.JSESSION_ID);
+        assertTrue("Unexpected JsessionId map in session",
+                jSessionIds.get("/myconsole_is_elsewhere").contentEquals("JSESSIONID=aaaaaa.node0"));
+        // The other custom cookie should be rewritten so that the path corresponds
+        // to the "visible" path configured in the SP's targets-mappings.properties
+        // file.
+        String setCookieReceived = (String) response.getHeaderValue(HeaderNames.SET_COOKIE_ID);
+        // The other cookie should be rewritten before being sent to the client
+        // with the actual path (here: /console)
+        assertTrue("Unexpected Set-Cookie header in the actual response",
+                setCookieReceived.equals("custom_key=custom_value;Path=/console"));
     }
 
 }


### PR DESCRIPTION
Cookie management was kind of undocumented in the SP, and required a rework, because the code was unreadable at least to me:

When hitting a security-proxified webapp, some cookies can be retrieved, but they should not be transmitted "as is" to the client without some checks:

* We need to extract the jsessionid and avoid transmitting it to the client, but instead keeping it in the user's session (as a hashmap, indexed by the cookie path => JSESSIONID=value) for further requests to the same webapp by the same user. Transmitting it to the client could invalidate the previous JSESSIONID used by the SP (e.g. if no path limits the scope of the cookie. This does not seem to be the case on the georchestra webapps I could test, but since this was a precaution in the current version of the code, I preferred to keep it). Here is what this PR aims to introduce as changes:

* The other cookies should not harm and can be probably transmitted "as is", but an extra precaution is taken so that the scope (Path=/...) is limited to the concerned proxified webapp.

* Onto the SP, one can configure the cookie sent for keeping the session with the HttpOnly flag, so that we make sure that any JS code cannot mangle (remove / edit) the session client-side (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies)

* I took the opportunity to use slf4j instead of commons-logging / log4j1 as it simplifies the log.*() calls and string formatting into the `HeadersManagementStrategy` class.

Instead of parsing cookies using regex and/or String.split(), I have preferred introducing the use of the HttpCookie class https://docs.oracle.com/javase/7/docs/api/java/net/HttpCookie.html. The main regret I have in regards to this class is that there is no way to get back the "Set-Cookie: ..." value, which would have been useful in our case. That is why I allowed myself to mangle the cookie path using a regex ... I did not take the time to check, maybe Spring has a better class for this.

Tests:
* utests added
* mainly runtime tested onto dev.geo2france.fr, but would definitely require more thorough tests, especially in regards to using other servlet containers (e.g. tomcat).
