### PR TITLE
Upgrade to geotools 21.3 and more dependency cleanup

### DIFF
--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -19,10 +19,12 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>extjs</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.tuckey</groupId>
       <artifactId>urlrewritefilter</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -96,7 +98,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-image</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
@@ -105,64 +106,16 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-imageio-ext-gdal</artifactId>
-      <version>${gt.version}</version>
-      <exclusions>
-        <!-- This should be provided by the system because highly dependent of the compiled version -->
-        <!-- of underlying native GDAL/OGR library                                                  -->
-        <exclusion>
-          <groupId>it.geosolutions.imageio-ext</groupId>
-          <artifactId>imageio-ext-gdal-bindings</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools.xsd</groupId>
-      <artifactId>gt-xsd-wfs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-wms</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-xml</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools.xsd</groupId>
       <artifactId>gt-xsd-kml</artifactId>
-      <version>${gt.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xerces</groupId>
-          <artifactId>xercesImpl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis-xerces</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools.ogc</groupId>
-      <artifactId>net.opengis.wfs</artifactId>
-      <version>${gt.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.geotools</groupId>
-          <artifactId>gt2-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- geotools - handles ESPG -->
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-epsg-hsql</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xpp3</groupId>
-      <artifactId>xpp3</artifactId>
-      <version>1.1.3.4.O</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>
@@ -189,28 +142,11 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-pool</groupId>
-      <artifactId>commons-pool</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-collections</groupId>
-          <artifactId>commons-collections</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>xerces</groupId>
-          <artifactId>xercesImpl</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -226,14 +162,6 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
     </dependency>
     <dependency>
       <groupId>org.georchestra</groupId>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -14,8 +14,6 @@
     <maven.test.skip>false</maven.test.skip>
     <!-- Override parent version with 2.1.1-georchestra. Revisit. -->
     <mapfish.version>2.1.1-georchestra</mapfish.version>
-    <!-- Use 21-SNAPSHOT until 21.3 is released with the fix for KML import -->
-    <gt.version>21-SNAPSHOT</gt.version>
     <!--
     	downgrade parent's 20180813 version or org.mapfish.print.servlet.MapPrinterServlet.getInfo
     	throws java.lang.NoSuchMethodError: org.json.JSONWriter.<init>(Ljava/io/Writer;)V
@@ -105,7 +103,6 @@
     <dependency>
       <groupId>org.geotools.xsd</groupId>
       <artifactId>gt-xsd-kml</artifactId>
-      <version>${gt.version}</version>
     </dependency>
 
     <dependency>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -34,6 +34,7 @@
     <dependency>
       <groupId>org.tuckey</groupId>
       <artifactId>urlrewritefilter</artifactId>
+      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -49,6 +50,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>
@@ -113,6 +115,7 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-epsg-hsql</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -128,10 +131,12 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <!-- geOrchestra commons -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <skipUT>false</skipUT>
     <!-- flag to disable integration tests -->
     <skipIT>false</skipIT>
-    <gt.version>21.2</gt.version>
+    <gt.version>21.3</gt.version>
     <guava.version>23.5-jre</guava.version>
     <lombok.version>1.18.4</lombok.version>
     <postgres.version>42.2.5</postgres.version>
@@ -88,7 +88,6 @@
     <developerConnection>scm:git:git@github.com:georchestra/georchestra.git</developerConnection>
   </scm>
   <modules>
-    <!-- <module>gt-ogr</module> now the geotools implementation is used -->
     <module>ogc-server-statistics</module>
     <module>commons</module>
   </modules>
@@ -418,13 +417,28 @@
         <version>${gt.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-xml</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geotools.xsd</groupId>
         <artifactId>gt-xsd-wfs</artifactId>
         <version>${gt.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geotools.xsd</groupId>
+        <artifactId>gt-xsd-kml</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools.xsd</groupId>
         <artifactId>gt-xsd-gml3</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-image</artifactId>
         <version>${gt.version}</version>
       </dependency>
       <dependency>
@@ -436,6 +450,19 @@
         <groupId>org.geotools</groupId>
         <artifactId>gt-cql</artifactId>
         <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-imageio-ext-gdal</artifactId>
+        <version>${gt.version}</version>
+        <exclusions>
+          <!-- This should be provided by the system because highly dependent of the compiled version -->
+          <!-- of underlying native GDAL/OGR library                                                  -->
+          <exclusion>
+            <groupId>it.geosolutions.imageio-ext</groupId>
+            <artifactId>imageio-ext-gdal-bindings</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -520,18 +520,6 @@
         <artifactId>commons-net</artifactId>
         <version>3.6</version>
       </dependency>
-      <dependency>
-        <!-- beware of upgrading this dependency, any version higher than 2.4.0 breaks mapfishapp's WMCDocServiceTest.testXEEOnExtractRealFileName()
-          which checks for XML External Entity (XXE) attacks -->
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>xalan</groupId>
-        <artifactId>xalan</artifactId>
-        <version>2.7.2</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Fixes #2682

Upgrade the GT dependency version on the root pom, and make mapfishapp use it instead of being stuck at 21.2-SNAPSHOT as mentioned in the related issue.

Also clean up the dependencies in mapfishapp and extractorapp, removing unnecessary ones and marking some at `runtime` scope, given they're needed but not directly used.