### PR TITLE
console: proper permission check for GDPR delete

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/GDPRAccountWorker.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/GDPRAccountWorker.java
@@ -78,13 +78,15 @@ public class GDPRAccountWorker {
                 account.getUid());
 
         DeletedRecords recs = accountGDPRDao.deleteAccountRecords(account);
-        return DeletedAccountSummary.builder()//
+        DeletedAccountSummary summary = DeletedAccountSummary.builder()//
                 .accountId(recs.getAccountId())//
                 .metadataRecords(recs.getMetadataRecords())//
                 .extractorRecords(recs.getExtractorRecords())//
                 .geodocsRecords(recs.getGeodocsRecords())//
                 .ogcStatsRecords(recs.getOgcStatsRecords())//
                 .build();
+        log.info("GDPR: deleted info summary: {}", summary);
+        return summary;
     }
 
     /**

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/GDPRAccountWorkerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/GDPRAccountWorkerTest.java
@@ -73,7 +73,9 @@ public class GDPRAccountWorkerTest {
             ogcstatsRecords.putAll(DELETED_ACCOUNT_USERNAME, ogcstats);
             metadataRecords.putAll(DELETED_ACCOUNT_USERNAME, md);
             extractorRecords.putAll(DELETED_ACCOUNT_USERNAME, extractor);
-            return new DeletedRecords(account.getUid(), md.size(), extractor.size(), geodocs.size(), ogcstats.size());
+            DeletedRecords summary = new DeletedRecords(account.getUid(), md.size(), extractor.size(), geodocs.size(),
+                    ogcstats.size());
+            return summary;
         }
 
         public @Override void visitGeodocsRecords(@NonNull Account owner, @NonNull Consumer<GeodocRecord> consumer) {


### PR DESCRIPTION
Make sure the controller allows any user to delete his
own GDPR sensitive data.

If a user id is specified, it can only be deleted if the
caller is a super user or the requested user is under delegation
for the caller.