### PR TITLE
fix(console): prevent chrome trying to load invalid image

### DIFF
--- a/console/src/main/webapp/manager/app/components/imageinput/imageinput.tpl.html
+++ b/console/src/main/webapp/manager/app/components/imageinput/imageinput.tpl.html
@@ -16,7 +16,7 @@
     </button>
     <img
       class="preview img-responsive"
-      src="data:image/jpeg;base64,{{imageinput.value}}"
+      ng-src="data:image/jpeg;base64,{{imageinput.value}}"
     />
   </div>
 </div>


### PR DESCRIPTION
Chrome-only bug, due to their aggressive caching policy.