### PR TITLE
docker - unzip webapps in the container

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -469,9 +469,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.artifactId}.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${project.artifactId}</targetPath>
+                  <directory>${project.build.directory}/${project.artifactId}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -15,8 +15,9 @@
   </description>
   <url>http://www.georchestra.org</url>
   <properties>
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
+    <context.name>${project.artifactId}</context.name>
   </properties>
   <dependencies>
     <dependency>
@@ -469,8 +470,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps/${project.artifactId}</targetPath>
-                  <directory>${project.build.directory}/${project.artifactId}</directory>
+                  <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                  <directory>${project.build.directory}/${context.name}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/analytics/src/docker/Dockerfile
+++ b/analytics/src/docker/Dockerfile
@@ -4,15 +4,7 @@ ENV XMS=256M XMX=1G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
-
-# Temporary switch to root
-USER root
-
-RUN chown jetty:jetty /etc/georchestra
-
-# Restore jetty user
-USER jetty
+COPY --chown=jetty:jetty . /
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -11,7 +11,7 @@
     <name>Atlas Webapp</name>
     <url>http://www.georchestra.org</url>
     <properties>
-        <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+        <packageDatadirScmVersion>master</packageDatadirScmVersion>
         <server>generic</server>
         <context.name>atlas</context.name>
     </properties>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
         <server>generic</server>
+        <context.name>atlas</context.name>
     </properties>
     <dependencies>
         <!-- Camel dependencies -->
@@ -529,14 +530,8 @@
                             <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
                             <resources>
                                 <resource>
-                                    <targetPath>/var/lib/jetty/webapps</targetPath>
-                                    <directory>${project.build.directory}</directory>
-                                    <include>${project.artifactId}.war</include>
-                                </resource>
-                                <resource>
-                                    <targetPath>/etc/georchestra</targetPath>
-                                    <directory>${project.build.directory}/datadir</directory>
-                                    <include>${project.artifactId}/**</include>
+                                    <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                                    <directory>${project.build.directory}/${context.name}</directory>
                                 </resource>
                             </resources>
                             <!-- This will require to set up the docker-hub credentials correctly

--- a/atlas/src/docker/Dockerfile
+++ b/atlas/src/docker/Dockerfile
@@ -4,7 +4,7 @@ ENV XMS=512M XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
+COPY --chown=jetty:jetty . /
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -28,7 +28,7 @@
   <packaging>war</packaging>
   <name>Jasig CAS Web Application</name>
   <properties>
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
 
     <!-- spring version revert start -->

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -13,12 +13,13 @@
   <name>Console</name>
   <url>http://www.georchestra.org</url>
   <properties>
-    <skipIT>true</skipIT> <!-- disable integration tests by default, use the "it" profile to run them 
+    <skipIT>true</skipIT> <!-- disable integration tests by default, use the "it" profile to run them
       which enables them -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <roo.version>1.1.5.RELEASE</roo.version>
     <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
     <server>generic</server>
+    <context.name>${project.artifactId}</context.name>
   </properties>
   <repositories>
     <repository>
@@ -793,9 +794,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.artifactId}.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                  <directory>${project.build.directory}/${context.name}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>
@@ -837,8 +837,8 @@
             </executions>
             <configuration>
               <environmentVariables>
-                <!-- expose these two environment variables for Spring to 
-                  resolve the connection URLs to ldap and psql as the mapped ports set up by 
+                <!-- expose these two environment variables for Spring to
+                  resolve the connection URLs to ldap and psql as the mapped ports set up by
                   docker-maven-plugin bellow -->
                 <pgsqlPort>${database_container.port}</pgsqlPort>
                 <ldapPort>${ldap_container.port}</ldapPort>
@@ -885,8 +885,8 @@
                           <SLAPD_ADDITIONAL_MODULES>groupofmembers,openssh</SLAPD_ADDITIONAL_MODULES>
                         </env>
                         <wait>
-                          <!-- Need to figure out a good way to make sure 
-                            the ldap service is ready before the tests are run. The healthy check seems 
+                          <!-- Need to figure out a good way to make sure
+                            the ldap service is ready before the tests are run. The healthy check seems
                             to be good enough but the tests still can't connect -->
                           <time>20000</time>
                           <!-- <healthy>true</healthy> -->

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -17,7 +17,7 @@
       which enables them -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <roo.version>1.1.5.RELEASE</roo.version>
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <context.name>${project.artifactId}</context.name>
   </properties>

--- a/console/src/docker/Dockerfile
+++ b/console/src/docker/Dockerfile
@@ -4,15 +4,7 @@ ENV XMS=512M XMX=1G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
-
-# Temporary switch to root
-USER root
-
-RUN chown jetty:jetty /etc/georchestra
-
-# Restore jetty user
-USER jetty
+COPY --chown=jetty:jetty . /
 
 VOLUME [ "/tmp" ]
 

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -14,6 +14,7 @@
     <maven.test.skip>false</maven.test.skip>
     <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
     <server>generic</server>
+    <context.name>${project.artifactId}</context.name>
   </properties>
   <dependencies>
     <dependency>
@@ -431,9 +432,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.artifactId}.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                  <directory>${project.build.directory}/${context.name}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -12,7 +12,7 @@
   <url>http://www.georchestra.org</url>
   <properties>
     <maven.test.skip>false</maven.test.skip>
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <context.name>${project.artifactId}</context.name>
   </properties>

--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -4,7 +4,7 @@ ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
+COPY --chown=jetty:jetty . /
 
 # Temporary switch to root
 USER root
@@ -13,9 +13,8 @@ RUN apt-get update && \
    apt-get install -y libgdal-java gdal-bin && \
    rm -rf /var/lib/apt/lists/*
 
-RUN unzip -d /var/lib/jetty/webapps/extractorapp /var/lib/jetty/webapps/extractorapp.war && \
-    ln -s /usr/share/java/gdal.jar /var/lib/jetty/webapps/extractorapp/WEB-INF/lib/ && \
-    rm -f /var/lib/jetty/webapps/extractorapp.war
+RUN ln -s /usr/share/java/gdal.jar /var/lib/jetty/webapps/extractorapp/WEB-INF/lib/
+
 
 RUN mkdir /mnt/extractorapp_extracts && \
     chown jetty:jetty /etc/georchestra /mnt/extractorapp_extracts

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <packageName>georchestra-geoserver</packageName>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
+    <context.name>geoserver</context.name>
   </properties>
   <dependencies>
     <dependency>
@@ -1233,9 +1234,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>geoserver.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                  <directory>${project.build.directory}/${context.name}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -11,7 +11,7 @@
   <name>geOrchestra GeoServer Web Application</name>
   <properties>
     <packageName>georchestra-geoserver</packageName>
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
   </properties>
   <dependencies>
     <dependency>
@@ -216,7 +216,7 @@
               as of https://github.com/geosolutions-it/imageio-ext/pull/207
             - imageio-ext-kakadujni-5.2.6.jar: this is kdu_jni.jar renamed. We exclude it and provide
               v7.10.6 by lack of a mechanism for the user to easily install the version that comes
-              with his kakadu build. 
+              with his kakadu build.
            -->
           <packagingExcludes>
             WEB-INF/lib/imageio-ext-kakadu-1.2.1.jar,

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -4,7 +4,7 @@ ENV XMS=1536M XMX=8G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,jndi,http-forwarded
 
-ADD . /
+COPY --chown=jetty:jetty . /
 
 # Temporary switch to root
 USER root

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -15,7 +15,7 @@
     <maven.test.skip>false</maven.test.skip>
     <geowebcache.version>1.8.1</geowebcache.version>
     <gt.version>14.1</gt.version><!-- must match the version used by gwc@geowebcache.version -->
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
   </properties>
   <dependencies>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -16,6 +16,7 @@
     <geowebcache.version>1.8.1</geowebcache.version>
     <gt.version>14.1</gt.version><!-- must match the version used by gwc@geowebcache.version -->
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
+    <context.name>geowebcache</context.name>
     <server>generic</server>
   </properties>
   <dependencies>

--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -4,12 +4,14 @@ ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
+COPY --chown=jetty:jetty . /
 
 # Temporary switch to root
 USER root
 
-RUN mkdir /mnt/geowebcache_tiles /mnt/geowebcache_datadir && \
+RUN mkdir /mnt/geowebcache_tiles /mnt/geowebcache_datadir &&                              \
+    unzip -d /var/lib/jetty/webapps/geowebcache /var/lib/jetty/webapps/geowebcache.war && \
+    rm -f /var/lib/jetty/webapps/geowebcache.war &&                                       \
     chown jetty:jetty /etc/georchestra /mnt/geowebcache_tiles /mnt/geowebcache_datadir
 
 # restore jetty user

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -315,9 +315,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.artifactId}.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${finalName}</targetPath>
+                  <directory>${project.build.directory}/${finalName}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -12,7 +12,7 @@
   <url>http://www.georchestra.org</url>
   <properties>
     <finalName>header</finalName>
-    <packageDatadirScmVersion>19.04</packageDatadirScmVersion>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
   </properties>
   <dependencies>

--- a/header/src/docker/Dockerfile
+++ b/header/src/docker/Dockerfile
@@ -4,15 +4,7 @@ ENV XMS=256M XMX=512M
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
-
-# Temporary switch to root
-USER root
-
-RUN chown jetty:jetty /etc/georchestra
-
-# Restore jetty user
-USER jetty
+COPY --chown=jetty:jetty . /
 
 VOLUME [ "/tmp", "/run/jetty" ]
 

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -19,6 +19,7 @@
     	throws java.lang.NoSuchMethodError: org.json.JSONWriter.<init>(Ljava/io/Writer;)V
     -->
     <json.version>20080701</json.version>
+    <context.name>${project.artifactId}</context.name>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
   </properties>
@@ -575,9 +576,8 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/var/lib/jetty/webapps</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.artifactId}.war</include>
+                  <targetPath>/var/lib/jetty/webapps/${context.name}</targetPath>
+                  <directory>${project.build.directory}/${context.name}</directory>
                 </resource>
                 <resource>
                   <targetPath>/etc/georchestra</targetPath>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -19,7 +19,7 @@
     	throws java.lang.NoSuchMethodError: org.json.JSONWriter.<init>(Ljava/io/Writer;)V
     -->
     <json.version>20080701</json.version>
-
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
   </properties>
   <dependencies>
@@ -540,7 +540,7 @@
       <properties>
         <dockerImageName>georchestra/${project.artifactId}:${project.version}</dockerImageName>
         <dockerDatadirScmUrl>scm:git:https://github.com/georchestra/datadir.git</dockerDatadirScmUrl>
-        <dockerDatadirScmVersion>docker-master</dockerDatadirScmVersion>
+        <dockerDatadirScmVersion>docker-${packageDatadirScmVersion}</dockerDatadirScmVersion>
       </properties>
       <build>
         <finalName>mapfishapp</finalName>

--- a/mapfishapp/src/docker/Dockerfile
+++ b/mapfishapp/src/docker/Dockerfile
@@ -4,8 +4,7 @@ ENV XMS=1G XMX=2G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
-ADD . /
-
+COPY --chown=jetty:jetty . /
 # Temporary switch to root
 USER root
 

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -14,6 +14,7 @@
     <maven.test.skip>false</maven.test.skip>
     <server>generic</server>
     <context.name>ROOT</context.name>
+    <packageDatadirScmVersion>master</packageDatadirScmVersion>
   </properties>
   <dependencies>
     <dependency>
@@ -362,7 +363,7 @@
       <properties>
         <dockerImageName>georchestra/${project.artifactId}:${project.version}</dockerImageName>
         <dockerDatadirScmUrl>scm:git:https://github.com/georchestra/datadir.git</dockerDatadirScmUrl>
-        <dockerDatadirScmVersion>docker-master</dockerDatadirScmVersion>
+        <dockerDatadirScmVersion>docker-${packageDatadirScmVersion}</dockerDatadirScmVersion>
       </properties>
       <build>
         <finalName>ROOT</finalName>


### PR DESCRIPTION
This makes the customization (via volumes or so) easier.

inspired from what as already been done on CAS & SP, like the following PR:
https://github.com/georchestra/georchestra/pull/2644/files

Note: I encountered an issue while working on this, which might be worth waiting for a fix:
https://github.com/georchestra/georchestra/issues/2848

Tests:
Each module tested with `mvn clean package docker:build`, then manually checking that:

1. the webapp is unzipped in `/var/lib/jetty/webapps`
2. it is (almost) correctly launched (not taking care of db not ready or missing / unresolved variables, just that the webapp context remains correct).
