### PR TITLE
Makefile - add DEPLOY_OPTS var to pass deployment options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ deb-build-geoserver-geofence: war-build-geoserver-geofence
 	mvn clean package deb:package -pl webapp -PdebianPackage,geofence,${GEOSERVER_EXTENSION_PROFILES}
 
 deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver
-	mvn package deb:package -pl atlas,cas-server-webapp,security-proxy,header,mapfishapp,extractorapp,analytics,console,geonetwork/web,geowebcache-webapp -PdebianPackage -DskipTests
+	mvn package deb:package -pl atlas,cas-server-webapp,security-proxy,header,mapfishapp,extractorapp,analytics,console,geonetwork/web,geowebcache-webapp -PdebianPackage -DskipTests ${DEPLOY_OPTS}
 
 # Base geOrchestra common modules
 build-deps:


### PR DESCRIPTION
Add DEPLOY_OPTS var to pass deployment options to deb-build-georchestra target (#2826)

It allows for example overrides such as
```
make DEPLOY_OPTS='deb:deploy -Ddeb.repository.location=/var/www/packages.georchestra.org/htdocs/debian -Ddeb.reprepro.config=/var/www/packages.georchestra.org/htdocs/debian/conf -Ddeb.repository.branch=19.04'  deb-build-georchestra
```
so that i can hopefully produce debian pkgs in the bot with wps jars. To be backported to 19.04 & 18.06 too ?