### PR TITLE
s/basedir/project.basedir/ (#2482)

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -307,7 +307,7 @@
                 <configuration>
                   <target>
                     <chmod perm="ugo+x">
-                      <fileset dir="${basedir}/target/deb">
+                      <fileset dir="${project.basedir}/target/deb">
                         <include name="**/bin/**"/>
                         <include name="**/sbin/**"/>
                         <include name="DEBIAN/post*"/>

--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -306,7 +306,7 @@
         </plugins>
         <resources>
             <resource>
-                <directory>${basedir}/src/main/resources</directory>
+                <directory>${project.basedir}/src/main/resources</directory>
             </resource>
         </resources>
     </build>
@@ -365,7 +365,7 @@
                                 <configuration>
                                     <target>
                                         <chmod perm="ugo+x">
-                                            <fileset dir="${basedir}/target/deb">
+                                            <fileset dir="${project.basedir}/target/deb">
                                                 <include name="**/bin/**"/>
                                                 <include name="**/sbin/**"/>
                                                 <include name="DEBIAN/post*"/>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -207,7 +207,7 @@
                 <configuration>
                   <target>
                     <chmod perm="ugo+x">
-                      <fileset dir="${basedir}/target/deb">
+                      <fileset dir="${project.basedir}/target/deb">
                         <include name="**/bin/**"/>
                         <include name="**/sbin/**"/>
                         <include name="DEBIAN/post*"/>

--- a/extractorapp/pom.xml
+++ b/extractorapp/pom.xml
@@ -192,7 +192,6 @@
             <scanTarget>src/main/java</scanTarget>
             <scanTarget>src/main/resources</scanTarget>
           </scanTargets>
-          <!--<webApp>${basedir}/target/extractorapp.war</webApp>-->
           <httpConnector>
             <port>8283</port>
           </httpConnector>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1050,7 +1050,7 @@
                 <configuration>
                   <target>
                     <chmod perm="ugo+x">
-                      <fileset dir="${basedir}/target/deb">
+                      <fileset dir="${project.basedir}/target/deb">
                         <include name="**/bin/**"/>
                         <include name="**/sbin/**"/>
                         <include name="DEBIAN/post*"/>

--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -134,9 +134,9 @@
           </connectors>
           <webAppConfig>
             <contextPath>/geowebcache</contextPath>
-            <descriptor>${basedir}/src/main/webapp/WEB-INF/web.xml</descriptor>
+            <descriptor>${project.basedir}/src/main/webapp/WEB-INF/web.xml</descriptor>
             <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
-              <resourcesAsCSV>${basedir}/src/main/webapp,${gwc.unpack.dir}</resourcesAsCSV>
+              <resourcesAsCSV>${project.basedir}/src/main/webapp,${gwc.unpack.dir}</resourcesAsCSV>
             </baseResource>
           </webAppConfig>
           <stopKey>GWC_JETTY_STOP</stopKey>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -288,7 +288,7 @@
     </plugins>
     <resources>
       <resource>
-        <directory>${basedir}/src/main/resources</directory>
+        <directory>${project.basedir}/src/main/resources</directory>
         <excludes>
           <exclude>**/*.example</exclude>
         </excludes>
@@ -413,7 +413,7 @@
                 <configuration>
                   <target>
                     <chmod perm="ugo+x">
-                      <fileset dir="${basedir}/target/deb">
+                      <fileset dir="${project.basedir}/target/deb">
                         <include name="**/bin/**"/>
                         <include name="**/sbin/**"/>
                         <include name="DEBIAN/post*"/>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -159,7 +159,7 @@
           <webApp>
             <contextPath>/</contextPath>
             <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
-              <resourcesAsCSV>${basedir}/src/main/webapp</resourcesAsCSV>
+              <resourcesAsCSV>${project.basedir}/src/main/webapp</resourcesAsCSV>
             </baseResource>
           </webApp>
           <scanIntervalSeconds>5</scanIntervalSeconds>


### PR DESCRIPTION
`basedir` variable is deprecated, switching to `project.basedir` instead, see #2482 

Tests: compile-time on analytics OK resources are still copied.