### PR TITLE
[console] delete GDPR data when an account is deleted

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/GlobalExceptionHandler.java
+++ b/console/src/main/java/org/georchestra/console/ws/GlobalExceptionHandler.java
@@ -2,52 +2,42 @@ package org.georchestra.console.ws;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.console.ws.backoffice.utils.Response;
+import org.georchestra.console.ws.backoffice.utils.ResponseUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.ldap.NameNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     private static final Log LOG = LogFactory.getLog(GlobalExceptionHandler.class.getName());
 
-    @ExceptionHandler(Exception.class)
-    public void handleException(Exception e, HttpServletResponse response) {
-
-        // Set HTTP response code according to exception type
-        if (e instanceof NameNotFoundException) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-        } else if (e instanceof AccessDeniedException) {
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        } else {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        }
-
-        // Generate stack trace as String
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw, true);
-        e.printStackTrace(pw);
-
-        // Log error and stack trace
-        LOG.error(sw.getBuffer().toString());
-
-        // Send error message to browser
-        PrintWriter output = null;
-        try {
-            output = response.getWriter();
-            output.write(e.toString());
-            output.close();
-        } catch (IOException ex) {
-        }
-
+    @ExceptionHandler(NameNotFoundException.class)
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public Response handleNameNotFoundException(NameNotFoundException e) {
+        LOG.info(e.getMessage());
+        return ResponseUtil.failure(e.getMessage());
     }
 
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
+    @ResponseBody
+    public Response handleAccessDeniedException(AccessDeniedException e) {
+        LOG.debug(e.getMessage());
+        return ResponseUtil.failure(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public Response handleException(Exception e) {
+        LOG.error(e.getMessage(), e);
+        return ResponseUtil.failure(e.getMessage());
+    }
 }

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/utils/Response.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/utils/Response.java
@@ -1,0 +1,17 @@
+package org.georchestra.console.ws.backoffice.utils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Data;
+
+public @Data class Response {
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private boolean success;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String error;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Object response;
+}

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/utils/ResponseUtil.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/utils/ResponseUtil.java
@@ -22,6 +22,7 @@ package org.georchestra.console.ws.backoffice.utils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -37,6 +38,28 @@ final public class ResponseUtil {
 
     private ResponseUtil() {
         // utility class pattern
+    }
+
+    public static Response success() {
+        return success(null);
+    }
+
+    public static Response success(@Nullable Object payload) {
+        Response response = new Response();
+        response.setSuccess(true);
+        response.setResponse(payload);
+        return response;
+    }
+
+    public static Response failure() {
+        return failure(null);
+    }
+
+    public static Response failure(@Nullable String errorMessage) {
+        Response response = new Response();
+        response.setSuccess(false);
+        response.setError(errorMessage);
+        return response;
     }
 
     /**

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersControllerTest.java
@@ -12,6 +12,7 @@ import org.georchestra.console.dto.orgs.Org;
 import org.georchestra.console.dto.UserSchema;
 import org.georchestra.console.model.DelegationEntry;
 import org.georchestra.console.ws.backoffice.roles.RoleProtected;
+import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker.DeletedAccountSummary;
 import org.georchestra.console.ws.utils.LogUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -66,6 +67,7 @@ public class UsersControllerTest {
     private RoleDaoImpl roleDao;
     private UserRule userRule;
     private RoleProtected roles;
+    private GDPRAccountWorker mockGDPR;
 
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
@@ -73,7 +75,7 @@ public class UsersControllerTest {
     private LogUtils mockLogUtils;
 
     @Before
-    public void setUp() {
+    public void setUp() throws DataServiceException {
         userRule = new UserRule();
         userRule.setListOfprotectedUsers(new String[] { "geoserver_privileged_user" });
 
@@ -115,6 +117,10 @@ public class UsersControllerTest {
         usersCtrl.setRoleDao(roleDao);
 
         usersCtrl.logUtils = mockLogUtils;
+
+        mockGDPR = Mockito.mock(GDPRAccountWorker.class);
+        when(mockGDPR.deleteAccountRecords(any(Account.class))).thenReturn(DeletedAccountSummary.builder().build());
+        usersCtrl.setGdprInfoWorker(mockGDPR);
 
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();


### PR DESCRIPTION
When an account is deleted, make sure its GDPR sensitive
data is also deleted/obfuscated so that any remaining record
cannot be traced back to the user.

Additionally, the JSON response handling is improved to return
a Response object and let Jackson do the encoding instead of
dealing with creating JSON strings manually.