### PR TITLE
console: avoid "connection_read" ldap server error logs with connection pooling

### DIFF
--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -87,7 +87,7 @@
     <property name="dirContextValidator" ref="ldapContextValidator"/>
     <property name="testOnBorrow" value="${ldap.pool.testOnBorrow:true}"/>
     <property name="maxActive" value="${ldap.pool.maxActive:8}"/>
-    <property name="minIdle" value="${ldap.pool.minIdle:0}"/>
+    <property name="minIdle" value="${ldap.pool.minIdle:1}"/>
     <property name="maxIdle" value="${ldap.pool.maxIdle:8}"/>
     <property name="maxTotal" value="${ldap.pool.maxTotal:-1}"/>
     <property name="maxWait" value="${ldap.pool.maxWait:-1}"/>

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -79,8 +79,18 @@
     <property name="password" value="${ldapAdminPassword}"/>
   </bean>
 
+  <bean id="ldapContextValidator" class="org.springframework.ldap.pool.validation.DefaultDirContextValidator">
+  </bean>
+  
   <bean id="contextSource" class="org.springframework.ldap.pool.factory.PoolingContextSource" destroy-method="destroy">
     <property name="contextSource" ref="singleContextSource"/>
+    <property name="dirContextValidator" ref="ldapContextValidator"/>
+    <property name="testOnBorrow" value="${ldap.pool.testOnBorrow:true}"/>
+    <property name="maxActive" value="${ldap.pool.maxActive:8}"/>
+    <property name="minIdle" value="${ldap.pool.minIdle:0}"/>
+    <property name="maxIdle" value="${ldap.pool.maxIdle:8}"/>
+    <property name="maxTotal" value="${ldap.pool.maxTotal:-1}"/>
+    <property name="maxWait" value="${ldap.pool.maxWait:-1}"/>
   </bean>
   
   <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -72,13 +72,17 @@
   </bean>
 
   <!-- LDAP connection -->
-  <bean id="contextSource" class="org.springframework.ldap.core.support.LdapContextSource">
+  <bean id="singleContextSource" class="org.springframework.ldap.core.support.LdapContextSource">
     <property name="url" value="${ldapScheme}://${ldapHost}:${ldapPort}"/>
     <property name="base" value="${ldapBaseDn}"/>
     <property name="userDn" value="${ldapAdminDn}"/>
     <property name="password" value="${ldapAdminPassword}"/>
   </bean>
 
+  <bean id="contextSource" class="org.springframework.ldap.pool.factory.PoolingContextSource" destroy-method="destroy">
+    <property name="contextSource" ref="singleContextSource"/>
+  </bean>
+  
   <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">
     <constructor-arg ref="contextSource"/>
   </bean>

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -72,11 +72,15 @@
   </bean>
 
   <!-- LDAP connection -->
-  <bean id="contextSource" class="org.springframework.ldap.core.support.LdapContextSource">
+  <bean id="singleContextSource" class="org.springframework.ldap.core.support.LdapContextSource">
     <property name="url" value="${ldapScheme}://${ldapHost}:${ldapPort}"/>
     <property name="base" value="${ldapBaseDn}"/>
     <property name="userDn" value="${ldapAdminDn}"/>
     <property name="password" value="${ldapAdminPassword}"/>
+  </bean>
+
+  <bean id="contextSource" class="org.springframework.ldap.pool.factory.PoolingContextSource" destroy-method="destroy">
+    <property name="contextSource" ref="singleContextSource"/>
   </bean>
 
   <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -79,8 +79,18 @@
     <property name="password" value="${ldapAdminPassword}"/>
   </bean>
 
+  <bean id="ldapContextValidator" class="org.springframework.ldap.pool.validation.DefaultDirContextValidator">
+  </bean>
+  
   <bean id="contextSource" class="org.springframework.ldap.pool.factory.PoolingContextSource" destroy-method="destroy">
     <property name="contextSource" ref="singleContextSource"/>
+    <property name="dirContextValidator" ref="ldapContextValidator"/>
+    <property name="testOnBorrow" value="${ldap.pool.testOnBorrow:true}"/>
+    <property name="maxActive" value="${ldap.pool.maxActive:8}"/>
+    <property name="minIdle" value="${ldap.pool.minIdle:0}"/>
+    <property name="maxIdle" value="${ldap.pool.maxIdle:8}"/>
+    <property name="maxTotal" value="${ldap.pool.maxTotal:-1}"/>
+    <property name="maxWait" value="${ldap.pool.maxWait:-1}"/>
   </bean>
 
   <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">


### PR DESCRIPTION
Fixes #2487

Using an LDAP connection pool as described in https://docs.spring.io/spring-ldap/docs/2.3.1.RELEASE/reference/#pooling

Solves the problem of having connections closed on the client without notifying the server and hence the immense ammount of `connection_read(19): no connection!` log entries in the ldap server.

The connection pool `destroy` method makes sure all connections are properly closed at server shutdown.

Should also improve performance since it avoids creating and destroying a connection for each ldap interaction.

