### PR TITLE
[Console] Enable history api

### DIFF
--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -102,7 +102,7 @@ angular.module('manager', [
         })
         .determinePreferredLanguage()
         .fallbackLanguage('en')
-      $location.html5Mode(false)
+      $location.html5Mode(true)
       paginationTemplate.setPath('templates/dirPagination.tpl.html')
       $qP.errorOnUnhandledRejections(false)
       // see https://github.com/georchestra/georchestra/issues/1695 {{{


### PR DESCRIPTION
To switch from url like `/console/manager/#!orgs/all` to `/console/manager/orgs/all`.
No need for server tweaks, previous redirection should work as expected.

Related to https://github.com/georchestra/georchestra/issues/2449