### PR TITLE
console - fix service publishing mandatory fields for orgs

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/orgs/OrgsController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/orgs/OrgsController.java
@@ -294,8 +294,7 @@ public class OrgsController {
     @RequestMapping(value = PUBLIC_REQUEST_MAPPING + "/requiredFields", method = RequestMethod.GET)
     public void getRequiredFieldsForOrgCreation(HttpServletResponse response) throws IOException, JSONException {
         JSONArray fields = new JSONArray();
-        fields.put("name");
-        fields.put("shortName");
+        validation.getRequiredOrgFields().forEach(fields::put);
         ResponseUtil.buildResponse(response, fields.toString(4), HttpServletResponse.SC_OK);
     }
 


### PR DESCRIPTION
Now web service that return the mandatory fields for orgs
(/public/requiredFields) depends on the Validation object. Which can be
overrided by properties.