### PR TITLE
console - (re ?)introducing urlrewrite (#2449)

### DIFF
--- a/console/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/console/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 3.0//EN" "http://tuckey.org/res/dtds/urlrewrite3.0.dtd">
+<urlrewrite>
+    <rule match-type="regex">
+        <condition type="request-uri" operator="notequal" next="and">^/.*/manager/public/.*$</condition>
+        <condition type="request-uri" operator="notequal" next="and">^/.*/manager/fonts/.*$</condition>
+        <from>^/manager/(.*)$</from>
+        <to type="passthrough">/manager/#!/$1</to>
+    </rule>
+</urlrewrite>

--- a/console/src/main/webapp/WEB-INF/web.xml
+++ b/console/src/main/webapp/WEB-INF/web.xml
@@ -1,32 +1,23 @@
 <?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
-
-
     <display-name>console</display-name>
-
     <description>console application</description>
-
     <distributable/>
-
     <context-param>
-      <param-name>contextConfigLocation</param-name>
-      <param-value>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>
         classpath*:META-INF/spring/applicationContext*.xml
         WEB-INF/spring/applicationContext*.xml
       </param-value>
     </context-param>
-
     <context-param>
-      <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
-      <param-value>false</param-value>
+        <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
+        <param-value>false</param-value>
     </context-param>
-
     <listener>
-      <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
+        <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
     </listener>
-
     <!-- Creates the Spring Container shared by all Servlets and Filters -->
-
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
@@ -46,7 +37,6 @@
         <url-pattern>/</url-pattern>
         <url-pattern>/manager/public/</url-pattern>
     </servlet-mapping>
-
     <servlet-mapping>
         <servlet-name>default</servlet-name>
         <url-pattern>/account/css/*</url-pattern>
@@ -55,11 +45,9 @@
         <url-pattern>/manager/public/*</url-pattern>
         <url-pattern>/manager/fonts/*</url-pattern>
     </servlet-mapping>
-
     <session-config>
         <session-timeout>10</session-timeout>
     </session-config>
-
     <error-page>
         <exception-type>java.lang.Exception</exception-type>
         <location>/WEB-INF/views/uncaughtException.jsp</location>
@@ -72,12 +60,14 @@
         <error-code>403</error-code>
         <location>/WEB-INF/views/forbidden.jsp</location>
     </error-page>
-
-	<filter>
-	  <filter-name>springSecurityFilterChain</filter-name>
-	  <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
-	</filter>
-
+    <filter>
+        <filter-name>UrlRewriteFilter</filter-name>
+        <filter-class>org.tuckey.web.filters.urlrewrite.UrlRewriteFilter</filter-class>
+    </filter>
+    <filter>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
     <filter>
         <filter-name>characterEncodingFilter</filter-name>
         <filter-class>org.springframework.web.filter.CharacterEncodingFilter</filter-class>
@@ -90,16 +80,18 @@
             <param-value>true</param-value>
         </init-param>
     </filter>
- 
-	<filter-mapping>
-	  <filter-name>springSecurityFilterChain</filter-name>
-	  <url-pattern>/*</url-pattern>
-	</filter-mapping>
+    <filter-mapping>
+        <filter-name>UrlRewriteFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
     <filter-mapping>
         <filter-name>characterEncodingFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
-
     <!-- Database connection -->
     <!-- This source is definend in the [TOMCAT]/conf/context.xml file -->
     <!--resource-ref>
@@ -108,5 +100,4 @@
       <res-type>javax.sql.DataSource</res-type>
       <res-auth>Container</res-auth>
     </resource-ref-->
-
 </web-app>


### PR DESCRIPTION
See issue #2449 for the motivation.

Caveats: using path-info to get the request-uri without the context name
did not seem to work at runtime, so I used the request URI but with a
wildcard pattern on the webapp name (see in urlrewrite.xml). As a
consequence, "/console/manager/public/libraries.css" will match as well
as "/aaaa/bbbb/manager/public/libraries.css". But at least, it shall
allow people deploying in an other context name to still trigger the
rule accordingly.

tests:

* utests OK
* IT OK
* runtime tests OK