### PR TITLE
console - adding orgType as mandatory fields (#2666)

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/utils/Validation.java
+++ b/console/src/main/java/org/georchestra/console/ws/utils/Validation.java
@@ -72,6 +72,7 @@ public class Validation {
         // Add mandatory field for org
         this.requiredOrgFields.add("name");
         this.requiredOrgFields.add("shortName");
+        this.requiredOrgFields.add("type");
 
         // Extract all fields starting by Org and change next letter to lower case
         // orgShortName --> shortName

--- a/console/src/test/java/org/georchestra/console/ws/utils/ValidationTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/utils/ValidationTest.java
@@ -29,12 +29,13 @@ public class ValidationTest {
     public void testHardCodedOrgFields() {
 
         Validation validation = new Validation("");
-        Set<String> requiredOrgFields = new HashSet<String>();
+        Set<String> expected = new HashSet<String>();
 
-        requiredOrgFields.add("name");
-        requiredOrgFields.add("shortName");
+        expected.add("name");
+        expected.add("shortName");
+        expected.add("type");
 
-        Assert.assertEquals(validation.getRequiredOrgFields(), requiredOrgFields);
+        Assert.assertEquals(validation.getRequiredOrgFields(), expected);
 
     }
 
@@ -93,9 +94,9 @@ public class ValidationTest {
         Assert.assertFalse(v.validateUserField("required_field", (String) null));
 
         // non required org field
-        Assert.assertTrue(v.validateOrgField("type", "josé"));
-        Assert.assertTrue(v.validateOrgField("type", ""));
-        Assert.assertTrue(v.validateOrgField("type", (String) null));
+        Assert.assertTrue(v.validateOrgField("type", "Association"));
+        Assert.assertFalse(v.validateOrgField("type", (String) null));
+        Assert.assertFalse(v.validateOrgField("type", ""));
 
         // required org field (default)
         Assert.assertTrue(v.validateOrgField("name", "josé"));


### PR DESCRIPTION
See #2666: the "type" field should be considered as mandatory.

tests:
* utests OK
* IT OK