### PR TITLE
ldap,console - add / fix EMAILPROXY role references

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/emails/EmailController.java
+++ b/console/src/main/java/org/georchestra/console/ws/emails/EmailController.java
@@ -106,7 +106,7 @@ public class EmailController {
      *
      * Basically, this webapp can send emails on behalf of LDAP users. The service
      * endpoint is available at /console/emailProxy Usage is restricted to users
-     * having the MOD_EMAILPROXY role by default, cf
+     * having the EMAILPROXY role by default, cf
      * https://github.com/georchestra/datadir/blob/master/security-proxy/security-mappings.xml
      * see https://github.com/georchestra/georchestra/pull/1572 for more
      * information.

--- a/console/src/test/resources/console-it.properties
+++ b/console/src/test/resources/console-it.properties
@@ -107,7 +107,7 @@ warnUserIfUidModified=true
 # Email proxy configuration
 # Basically, this webapp can send emails on behalf of LDAP users.
 # The service endpoint is available at /console/emailProxy
-# Usage is restricted to users having the MOD_EMAILPROXY role by default,
+# Usage is restricted to users having the EMAILPROXY role by default,
 # cf https://github.com/georchestra/datadir/blob/master/security-proxy/security-mappings.xml
 # see https://github.com/georchestra/georchestra/pull/1572 for more information.
 emailProxyFromAddress=no-reply@georchestra.org

--- a/console/src/test/resources/console.properties
+++ b/console/src/test/resources/console.properties
@@ -98,7 +98,7 @@ warnUserIfUidModified=true
 # Email proxy configuration
 # Basically, this webapp can send emails on behalf of LDAP users.
 # The service endpoint is available at /console/emailProxy
-# Usage is restricted to users having the MOD_EMAILPROXY role by default,
+# Usage is restricted to users having the EMAILPROXY role by default,
 # cf https://github.com/georchestra/datadir/blob/master/security-proxy/security-mappings.xml
 # see https://github.com/georchestra/georchestra/pull/1572 for more information.
 emailProxyFromAddress=no-reply@georchestra.org

--- a/ldap/docker-root/georchestra.ldif
+++ b/ldap/docker-root/georchestra.ldif
@@ -231,6 +231,16 @@ cn: ORGADMIN
 description: This role is automatically granted to all users holding an admin delegation
 member: uid=testdelegatedadmin,ou=users,dc=georchestra,dc=org
 
+# EMAILPROXY, roles, georchestra.org
+dn: cn=EMAILPROXY,ou=roles,dc=georchestra,dc=org
+objectClass: top
+objectClass: groupOfMembers
+cn: EMAILPROXY
+description: This role allows to use the emailProxy webservice from the console
+member: uid=testadmin,ou=users,dc=georchestra,dc=org
+
+
+
 # orgs, georchestra.org
 dn: ou=orgs,dc=georchestra,dc=org
 objectClass: organizationalUnit


### PR DESCRIPTION
As this is specified in the default security mappings from the SP, we
need to add the role as a default in the LDAP.

See also https://github.com/georchestra/datadir/pull/183

tests: untested