### PR TITLE
GeoServer dockerfile updated

### DIFF
--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -20,10 +20,10 @@ RUN echo "deb http://httpredir.debian.org/debian buster main contrib" > /etc/apt
     && rm -rf /var/lib/apt/lists/*
 
 # install libjpeg turbo
-RUN wget https://sourceforge.net/projects/libjpeg-turbo/files/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb \
-    && dpkg -i libjpeg-turbo-official_1.5.3_amd64.deb \
+RUN wget https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-official_2.0.4_amd64.deb \
+    && dpkg -i libjpeg-turbo-official_2.0.4_amd64.deb \
     && apt-get -f install \
-    && rm libjpeg-turbo-official_1.5.3_amd64.deb
+    && rm libjpeg-turbo-official_2.0.4_amd64.deb
 
 RUN mkdir /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs && \
     chown jetty:jetty /etc/georchestra /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -45,7 +45,6 @@ CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
 -DENABLE_JSONP=true \
 -Ds3.caching.ehCacheConfig=/etc/georchestra/geoserver/s3-geotiff/s3-geotiff-ehcache.xml \
 -Ds3.properties.location=/etc/georchestra/geoserver/s3-geotiff/s3.properties \
--Dorg.geotools.coverage.jaiext.enabled=true \
 -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 \
 -Xms$XMS -Xmx$XMX \
 -XX:SoftRefLRUPolicyMSPerMB=36000 \

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -6,7 +6,6 @@ RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-rem
 
 COPY --chown=jetty:jetty . /
 
-# Temporary switch to root
 USER root
 
 RUN echo "deb http://httpredir.debian.org/debian buster main contrib" > /etc/apt/sources.list \
@@ -19,7 +18,6 @@ RUN echo "deb http://httpredir.debian.org/debian buster main contrib" > /etc/apt
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# install libjpeg turbo
 RUN wget https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-official_2.0.4_amd64.deb \
     && dpkg -i libjpeg-turbo-official_2.0.4_amd64.deb \
     && apt-get -f install \
@@ -28,7 +26,6 @@ RUN wget https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-t
 RUN mkdir /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs && \
     chown jetty:jetty /etc/georchestra /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs
 
-# Restore jetty user
 USER jetty
 
 VOLUME [ "/mnt/geoserver_datadir", "/mnt/geoserver_geodata", "/mnt/geoserver_tiles", "/mnt/geoserver_native_libs", "/tmp", "/run/jetty" ]

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -28,8 +28,6 @@ RUN wget https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-t
 RUN mkdir /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs && \
     chown jetty:jetty /etc/georchestra /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs
 
-RUN sed -i 's/threads.max=200/threads.max=50/g' /var/lib/jetty/start.d/server.ini
-
 # Restore jetty user
 USER jetty
 


### PR DESCRIPTION
Updating libjpeg-turbo to 2.0.4 & removing `threads.max` limitation in favor of control flow, which we configure via https://github.com/georchestra/geoserver_minimal_datadir/blob/19.04/controlflow.properties