### PR TITLE
Docker images built on release published

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,analytics -pl commons
-
     - name: install & check formating
       working-directory: analytics/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,analytics -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: analytics/

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,analytics -pl commons
+
     - name: install & check formating
       working-directory: analytics/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: analytics/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: analytics/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/analytics:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/analytics:${GITHUB_REF##*/} -DskipTests
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,atlas -pl commons
-
     - name: install & check formating
       working-directory: atlas/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,atlas -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: atlas/

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,atlas -pl commons
+
     - name: install & check formating
       working-directory: atlas/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: atlas/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: atlas/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/atlas:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/atlas:${GITHUB_REF##*/} -DskipTests
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,cas -pl commons
+
     - name: install & check formating
       working-directory: cas-server-webapp/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: cas-server-webapp/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: cas-server-webapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/cas:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,cas -pl commons
-
     - name: install & check formating
       working-directory: cas-server-webapp/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,cas -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: cas-server-webapp/

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: build a docker image
       working-directory: cas-server-webapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/cas:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/cas:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,console -pl commons
-
     - name: install & check formating
       working-directory: console/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,console -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: console/

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,console -pl commons
+
     - name: install & check formating
       working-directory: console/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: console/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: console/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/console:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: build a docker image
       working-directory: console/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/console:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/console:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,extractorapp -pl commons
+
     - name: install & check formating
       working-directory: extractorapp/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: extractorapp/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: extractorapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/extractorapp:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: build a docker image
       working-directory: extractorapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/extractorapp:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/extractorapp:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,extractorapp -pl commons
-
     - name: install & check formating
       working-directory: extractorapp/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,extractorapp -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: extractorapp/

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -10,12 +10,15 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
+
     - name: "Checking out submodules"
       uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -25,17 +28,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: "installing georchestra-commons into .m2"
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,geoserver -pl commons
+
     - name: "install"
       working-directory: geoserver/
       run: ../mvnw --no-transfer-progress -B -Dfmt.skip=true install -Dadditionalparam=-Xdoclint:none -DskipTests
+
     - name: "run test"
       working-directory: geoserver/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: "build a docker image"
       working-directory: geoserver/webapp
       run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geoserver:${GITHUB_REF##*/}
+
     - name: "publish the docker image"
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -43,9 +51,11 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: "build a docker image (geofence)"
       working-directory: geoserver/webapp/
       run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geoserver:${GITHUB_REF##*/}-geofence
+
     - name: "publish the docker image (geofence)"
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -53,6 +63,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: "publish the docker images on docker-hub"
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: "build a docker image"
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geoserver:${GITHUB_REF##*/}
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geoserver:${GITHUB_REF##*/} -DskipTests
 
     - name: "publish the docker image"
       run: |
@@ -54,7 +54,7 @@ jobs:
 
     - name: "build a docker image (geofence)"
       working-directory: geoserver/webapp/
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geoserver:${GITHUB_REF##*/}-geofence
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geoserver:${GITHUB_REF##*/}-geofence -DskipTests
 
     - name: "publish the docker image (geofence)"
       run: |

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+      run: git submodule update --init --recursive geoserver/geoserver-submodule
 
     - name: "Setting up Java"
       uses: actions/setup-java@v1

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -29,12 +29,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: "installing georchestra-commons into .m2"
-      run: ./mvnw install -P-all,geoserver -pl commons
-
     - name: "install"
       working-directory: geoserver/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.skip=true install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,geoserver -Dfmt.skip=true install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: "run test"
       working-directory: geoserver/

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,geowebcache -pl commons
+
     - name: install & check formating
       working-directory: geowebcache-webapp/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: geowebcache-webapp/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: geowebcache-webapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geowebcache:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: build a docker image
       working-directory: geowebcache-webapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geowebcache:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/geowebcache:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,geowebcache -pl commons
-
     - name: install & check formating
       working-directory: geowebcache-webapp/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,geowebcache -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: geowebcache-webapp/

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -24,17 +25,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,header -pl commons
+
     - name: install & check formating
       working-directory: header/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: header/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: header/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/header:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -42,6 +48,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: build a docker image
       working-directory: header/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/header:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/header:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -26,12 +26,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,header -pl commons
-
     - name: install & check formating
       working-directory: header/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,header -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: header/

--- a/.github/workflows/ldap-push.yml
+++ b/.github/workflows/ldap-push.yml
@@ -1,0 +1,33 @@
+name: "LDAP"
+on:
+  push:
+    paths:
+    - "ldap/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checking out"
+      uses: actions/checkout@v1
+
+    - name: "Docker build LDAP"
+      working-directory: ldap/
+      run: docker build -t docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/} .
+
+    - name: publish the docker images
+      run: |
+        docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+        docker push docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/}
+      env:
+          DOCKER_USERNAME: georchestra
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: publish the docker image on docker-hub
+      run: |
+        docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+        docker tag docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/} georchestra/ldap:latest
+        docker push georchestra/ldap:latest
+      if: github.ref == 'refs/heads/master'
+      env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/ldap-release.yml
+++ b/.github/workflows/ldap-release.yml
@@ -1,0 +1,31 @@
+name: "LDAP releases"
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checking out"
+      uses: actions/checkout@v1
+
+    - name: "Docker build LDAP"
+      working-directory: ldap/
+      run: docker build -t docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/} .
+
+    - name: publish the docker images
+      run: |
+        docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+        docker push docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/}
+      env:
+          DOCKER_USERNAME: georchestra
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: publish the docker image on docker-hub
+      run: |
+        docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+        docker tag docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/} georchestra/ldap:${GITHUB_REF##*/}
+        docker push georchestra/ldap:${GITHUB_REF##*/}
+      env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -10,16 +10,20 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
+
     - name: "Checking out submodules"
       uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: setup Python 2.x (for jsbuild)
       uses: actions/setup-python@v1
       with:
         python-version: '2.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -29,17 +33,22 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
       run: ./mvnw install -pl commons
+
     - name: install & check formating
       working-directory: mapfishapp/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: mapfishapp/
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: mapfishapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/mapfishapp:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -47,6 +56,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: build a docker image
       working-directory: mapfishapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/mapfishapp:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/mapfishapp:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -34,12 +34,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
-
     - name: install & check formating
       working-directory: mapfishapp/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,mapfishapp -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: mapfishapp/

--- a/.github/workflows/postgresql-push.yml
+++ b/.github/workflows/postgresql-push.yml
@@ -1,25 +1,23 @@
-name: "LDAP"
+name: "PostGreSQL"
 on:
   push:
     paths:
-    - "ldap/**"
+    - "postgresql/**"
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
 
-    - name: "Docker build LDAP"
-      working-directory: ldap/
-      run: docker build -t docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/} .
+    - name: "Docker build database"
+      working-directory: postgresql/
+      run: docker build -t docker.pkg.github.com/georchestra/georchestra/database:${GITHUB_REF##*/} .
 
     - name: publish the docker images
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-        docker push docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/}
+        docker push docker.pkg.github.com/georchestra/georchestra/database:${GITHUB_REF##*/}
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -27,8 +25,8 @@ jobs:
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-        docker tag docker.pkg.github.com/georchestra/georchestra/ldap:${GITHUB_REF##*/} georchestra/ldap:latest
-        docker push georchestra/ldap:latest
+        docker tag docker.pkg.github.com/georchestra/georchestra/database:${GITHUB_REF##*/} georchestra/database:latest
+        docker push georchestra/database:latest
       if: github.ref == 'refs/heads/master'
       env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/postgresql-release.yml
+++ b/.github/workflows/postgresql-release.yml
@@ -1,18 +1,15 @@
-name: "PostGreSQL"
+name: "PostGreSQL releases"
 on:
-  push:
-    paths:
-    - "postgresql/**"
+  release:
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
 
-    - name: "Docker build Database"
+    - name: "Docker build database"
       working-directory: postgresql/
       run: docker build -t docker.pkg.github.com/georchestra/georchestra/database:${GITHUB_REF##*/} .
 
@@ -27,9 +24,8 @@ jobs:
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-        docker tag docker.pkg.github.com/georchestra/georchestra/database:${GITHUB_REF##*/} georchestra/database:latest
-        docker push georchestra/database:latest
-      if: github.ref == 'refs/heads/master'
+        docker tag docker.pkg.github.com/georchestra/georchestra/database:${GITHUB_REF##*/} georchestra/database:${GITHUB_REF##*/}
+        docker push georchestra/database:${GITHUB_REF##*/}
       env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -27,15 +27,9 @@ jobs:
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
 
-    - name: installing georchestra-commons into .m2
-      run: ./mvnw install -P-all,proxy -pl commons
-
-    - name: installing ogc-server-statistics into .m2
-      run: ./mvnw install -pl ogc-server-statistics
-
     - name: install & check formating
       working-directory: security-proxy/
-      run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ../mvnw --no-transfer-progress -B -P-all,proxy -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: run tests
       working-directory: security-proxy/

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: build a docker image
       working-directory: security-proxy/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/security-proxy:${GITHUB_REF##*/}
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/security-proxy:${GITHUB_REF##*/} -DskipTests
 
     - name: publish the docker image
       run: |

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '8.x'
+
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
@@ -25,19 +26,25 @@ jobs:
 
     - name: "installing geOrchestra root pom"
       run: ./mvnw install --non-recursive
+
     - name: installing georchestra-commons into .m2
-      run: ./mvnw install -pl commons
+      run: ./mvnw install -P-all,proxy -pl commons
+
     - name: installing ogc-server-statistics into .m2
       run: ./mvnw install -pl ogc-server-statistics
+
     - name: install & check formating
       working-directory: security-proxy/
       run: ../mvnw --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
-    - name: run test
+
+    - name: run tests
       working-directory: security-proxy/
       run: ../mvnw --no-transfer-progress verify -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+
     - name: build a docker image
       working-directory: security-proxy/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=docker.pkg.github.com/georchestra/georchestra/security-proxy:${GITHUB_REF##*/}
+
     - name: publish the docker image
       run: |
         docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
@@ -45,6 +52,7 @@ jobs:
       env:
           DOCKER_USERNAME: georchestra
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
     - name: publish the docker image on docker-hub
       run: |
         docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
     - name: "Checking out"
       uses: actions/checkout@v1
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "Setting up Java"
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
This PR:
 * builds LDAP and DB docker images on release published
 * prevents checking out useless submodules

Probably interesting to generalize to all other modules if it works as expected