### PR TITLE
console - remove useless SLAPD_ADDITIONAL_MODULES

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -885,7 +885,6 @@
                           <SLAPD_ORGANISATION>georchestra</SLAPD_ORGANISATION>
                           <SLAPD_DOMAIN>georchestra.org</SLAPD_DOMAIN>
                           <SLAPD_PASSWORD>secret</SLAPD_PASSWORD>
-                          <SLAPD_ADDITIONAL_MODULES>groupofmembers,openssh</SLAPD_ADDITIONAL_MODULES>
                         </env>
                         <wait>
                           <!-- Need to figure out a good way to make sure


### PR DESCRIPTION
`ENV SLAPD_ADDITIONAL_MODULES = groupofmembers,openssh` is already provided as default in the base image