### PR TITLE
Sp improvements (#2948)

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -397,7 +397,7 @@ public class Proxy {
         try {
             return InetAddress.getByName(request.getServerName()).equals(InetAddress.getByName(url.getHost()));
         } catch (UnknownHostException e) {
-            logger.error("Unknown host: " + request.getServerName());
+            logger.error(e.getMessage(), e);
             return false;
         }
     }
@@ -709,7 +709,8 @@ public class Proxy {
             doHandleRequest(finalResponse, proxiedResponse);
         } catch (IOException | ExecutionException | InterruptedException | TimeoutException e) {
             // connection problem with the host
-            logger.error("Exception occured when trying to connect to the remote host: ", e);
+            String errMsg = String.format("Exception occured when trying to connect to the remote url '%s'", sURL);
+            logger.error(errMsg, e);
             try {
                 finalResponse.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             } catch (IOException e2) {


### PR DESCRIPTION
As described in #2948, this PR aims to solve the following "issues"

* When a URL cannot be retrieved, we have a meaningless "an error occured while trying to reach the remote host." with no info of which server/url were causing an issue
* When calling `isSameServer()`, the error logged in the try/catch might be wrong and report the wrong server as failing
* In case of unresolveable host in the target mappings, the future won't be detected as finished, and will block during 5 minutes, where it could return almost immediately.

Asking @cmangeat for a review, because of the brainstorm we had about these Future / asynchronous debates and which object should take care of reporting the error.
