### PR TITLE
[Console] fix logs i18n & layout

### DIFF
--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -143,7 +143,10 @@ angular.module('manager', [
     }])
   .filter('dateFormat', ['$translate', ($translate) => {
     moment.locale($translate.use())
-    return date => moment(date).format('LL')
+    return (date, format) => {
+      const m = moment(date)
+      return `<span title="${m.format('lll')}">${!format ? m.fromNow() : m.format(format)}</span>`
+    }
   }])
   .directive('shortname', () => ({
     require: 'ngModel',

--- a/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
+++ b/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
@@ -74,7 +74,7 @@
           <td>
             <span ng-if="!log.changed" title="{{::log.title}}">
                 <i class="glyphicon glyphicon-{{::log.icon}}"></i>
-                {{::log.type}}
+                {{::'logs.'+log.type.split('_').join('').toLowerCase() | translate}}
             </span>  
             <span ng-if="log.changed && log.type=='EMAIL_SENT'">
               <i class="glyphicon glyphicon-envelope" title="{{::log.title | translate}}"></i>

--- a/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
+++ b/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
@@ -50,7 +50,7 @@
         </thead>
     <tbody>
         <tr dir-paginate="log in logger.logs | logs: logger.type:logger.admin:logger.target:logger.date | orderBy: '-date' | itemsPerPage: logger.itemsPerPage">
-          <td>{{::log.date | logDate}}</td>
+          <td><abbr ng-bind-html="log.date | dateFormat"></abbr></td>
           <td><a ng-link="user({id: log.admin, tab: 'infos'})" title="">{{::log.admin}}</a>
           <!--Target-->
           <td>

--- a/console/src/main/webapp/manager/app/components/user/user.tpl.html
+++ b/console/src/main/webapp/manager/app/components/user/user.tpl.html
@@ -33,7 +33,7 @@
       </div>
 
       <div class="panel-heading text-center" ng-if="user.user.expired">
-        <span translate>user.expiredmsg</span> : {{::user.user.shadowExpire | dateFormat: 'LL'}}
+        <span translate>user.expiredmsg</span> : <span ng-bind-html="user.user.shadowExpire | dateFormat: 'LL'"></span>
       </div>
 
       <div class="panel-body" ng-if="user.tab=='infos'">

--- a/console/src/main/webapp/manager/brunch-config.js
+++ b/console/src/main/webapp/manager/brunch-config.js
@@ -38,7 +38,10 @@
               'vendor/ol.js',
               'vendor/FileSaver.js',
               'vendor/promise.min.js',
-              'vendor/fetch.js'
+              'vendor/fetch.js',
+              'vendor/moment-locale-de.js',
+              'vendor/moment-locale-fr.js',
+              'vendor/moment-locale-es.js'
             ]
           }
         },


### PR DESCRIPTION
 - use shorter relative date (absolute available as tooltip)
 - translate some missing actions. (were already present in i18n files but unused).

![Screenshot from 2020-02-11 14-05-54](https://user-images.githubusercontent.com/21686/74239463-2d9afb80-4cd8-11ea-956e-cf11436487e4.png)

 - Fix #2917 
 - Fix #2906
