### PR TITLE
Add JAXB libraries to SP maven dependencies

### DIFF
--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -117,6 +117,27 @@
       <groupId>org.apache.taglibs</groupId>
       <artifactId>taglibs-standard-impl</artifactId>
     </dependency>
+    <!-- JAXB libraries, required since JAVA 9 -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
     <!-- geOrchestra commons -->
     <dependency>
       <groupId>org.georchestra</groupId>


### PR DESCRIPTION
Solve https://github.com/georchestra/georchestra/issues/2953

Since JAVA 9, JAXB libs are not more loaded by JAVA SE, so they need to be added to maven dependencies.