### PR TITLE
console - using the http headers instead of LDAP (#2983)

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -262,6 +262,8 @@ public class UsersController {
         String[] rolesHeader = StringUtils.isEmpty(request.getHeader("sec-roles")) ? new String[0]
                 : request.getHeader("sec-roles").split(";");
 
+        rolesHeader = Arrays.stream(rolesHeader).map(s -> s.replaceFirst("ROLE_", "")).toArray(String[]::new);
+
         String orgHeader = StringUtils.isEmpty(request.getHeader("sec-org")) ? "" : request.getHeader("sec-org");
         JSONObject res = new JSONObject();
         res.put("uid", auth.getName());

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -259,17 +259,14 @@ public class UsersController {
     public String myProfile(HttpServletRequest request) throws DataServiceException, JSONException {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-        Account user = this.accountDao.findByUID(auth.getName());
+        String[] rolesHeader = StringUtils.isEmpty(request.getHeader("sec-roles")) ? new String[0]
+                : request.getHeader("sec-roles").split(";");
 
-        JSONArray roles = new JSONArray();
-
-        for (Role role : this.roleDao.findAllForUser(user)) {
-            roles.put(role.getName());
-        }
+        String orgHeader = StringUtils.isEmpty(request.getHeader("sec-org")) ? "" : request.getHeader("sec-org");
         JSONObject res = new JSONObject();
         res.put("uid", auth.getName());
-        res.put("roles", roles);
-        res.put("org", user.getOrg());
+        res.put("roles", rolesHeader);
+        res.put("org", orgHeader);
 
         return res.toString();
     }

--- a/console/src/test/java/org/georchestra/console/integration/UsersIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/UsersIT.java
@@ -3,18 +3,14 @@ package org.georchestra.console.integration;
 import static com.github.database.rider.core.api.dataset.SeedStrategy.CLEAN_INSERT;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -22,29 +18,21 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.LogFactory;
 import org.georchestra.console.dto.Account;
 import org.georchestra.console.dto.AccountImpl;
-import org.georchestra.console.dto.Role;
 import org.georchestra.console.integration.ds.PostgresExtendedDataTypeFactory;
 import org.georchestra.console.integration.instruments.WithMockRandomUidUser;
 import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker;
-import org.georchestra.console.ws.backoffice.users.UsersController;
 import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker.DeletedAccountSummary;
-import org.hamcrest.core.StringContains;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.ldap.core.LdapTemplate;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -97,23 +85,6 @@ public class UsersIT {
                 LogFactory.getLog(getClass()).error("Error deleting " + user, e);
             }
         }
-    }
-
-    @WithMockRandomUidUser
-    public @Test void profile() throws Exception {
-        String userName = ((User) (SecurityContextHolder.getContext().getAuthentication().getPrincipal()))
-                .getUsername();
-        createUser(userName);
-
-        getProfile().andExpect(jsonPath("$.roles[0]").value("USER"));
-
-        String role1Name = createRole();
-        String role2Name = createRole();
-        setRole(userName, role1Name, role2Name);
-
-        getProfile().andExpect(jsonPath("$.roles[1]").value(role1Name))
-                .andExpect(jsonPath("$.roles[2]").value(role2Name));
-
     }
 
     @WithMockRandomUidUser

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersControllerTest.java
@@ -586,10 +586,9 @@ public class UsersControllerTest {
         JSONObject parsed = new JSONObject(ret);
         assertEquals(parsed.get("uid"), "testadmin");
         assertEquals(parsed.get("org"), "camptocamp");
-        assertTrue(parsed.getJSONArray("roles").length() == 3
-                && parsed.getJSONArray("roles").get(0).equals("ROLE_SUPERUSER")
-                && parsed.getJSONArray("roles").get(1).equals("ROLE_ADMINISTRATOR")
-                && parsed.getJSONArray("roles").get(2).equals("ROLE_USER"));
+        assertTrue(parsed.getJSONArray("roles").length() == 3 && parsed.getJSONArray("roles").get(0).equals("SUPERUSER")
+                && parsed.getJSONArray("roles").get(1).equals("ADMINISTRATOR")
+                && parsed.getJSONArray("roles").get(2).equals("USER"));
     }
 
     private void mockLookup(String uuid, boolean pending) {


### PR DESCRIPTION
Instead of using an extra LDAP connection to retrieve the orgs and roles
of the current logged user, guess the infos from the HTTP headers
received from the security-proxy.

See https://github.com/georchestra/georchestra/issues/2983.

Tests:

* utests ok
* IT ok

Note:

Since the connection to an OpenLDAP is not necessary anymore, we don't
rely on it in the tests. That is the reason why I removed the IT which
was testing the profile endpoint, and migrated to some new unit tests
instead.