### PR TITLE
Github actions - Activating extra profiles

### DIFF
--- a/.github/resources/m2-settings.xml
+++ b/.github/resources/m2-settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0   http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>artifactory-georchestra</id>
+      <mirrorOf>*</mirrorOf>
+      <url>https://packages.georchestra.org/artifactory/maven</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: analytics/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/analytics:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/analytics:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == "georchestra/georchestra"

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,analytics -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: analytics/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/analytics:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/analytics:${{ steps.version.outputs.VERSION }} georchestra/analytics:latest
         docker push georchestra/analytics:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/analytics:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/analytics:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: atlas/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/atlas:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/atlas:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,atlas -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: atlas/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/atlas:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1
+      if: github.repository == "georchestra/georchestra"
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/atlas:${{ steps.version.outputs.VERSION }} georchestra/atlas:latest
         docker push georchestra/atlas:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/atlas:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/atlas:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,cas -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: cas-server-webapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/cas:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/cas:${{ steps.version.outputs.VERSION }} georchestra/cas:latest
         docker push georchestra/cas:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/cas:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/cas:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: cas-server-webapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/cas:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/cas:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == "georchestra/georchestra"

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: console/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/console:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/console:${{ steps.version.outputs.VERSION }} georchestra/console:latest
         docker push georchestra/console:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/console:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/console:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: console/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/console:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/console:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == "georchestra/georchestra"

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,console -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -20,27 +20,29 @@ jobs:
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Docker build database"
+      if: github.repository == "georchestra/georchestra"
       working-directory: postgresql/
       run: docker build -t georchestra/database:${{ steps.version.outputs.VERSION }} .
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/database:${{ steps.version.outputs.VERSION }} georchestra/database:latest
         docker push georchestra/database:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/database:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/database:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,extractorapp -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: extractorapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/extractorapp:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/extractorapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: extractorapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/extractorapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1
+      if: github.repository == "georchestra/georchestra"
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/extractorapp:${{ steps.version.outputs.VERSION }} georchestra/extractorapp:latest
         docker push georchestra/extractorapp:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/extractorapp:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/extractorapp:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -46,13 +46,13 @@ jobs:
     - name: "Building docker image with native security"
       if: github.repository == "georchestra/georchestra"
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-spring -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
 
 
     - name: "Building docker image with geofence"
       if: github.repository == "georchestra/georchestra"
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-spring -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -29,9 +29,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,geoserver -Dfmt.skip=true install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -39,26 +39,30 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image with native security"
+      if: github.repository == "georchestra/georchestra"
       working-directory: geoserver/webapp
       run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
 
 
     - name: "Building docker image with geofence"
+      if: github.repository == "georchestra/georchestra"
       working-directory: geoserver/webapp
       run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1
+      if: github.repository == "georchestra/georchestra"
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/geoserver:${{ steps.version.outputs.VERSION }} georchestra/geoserver:latest
         docker tag georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence georchestra/geoserver:geofence
@@ -66,13 +70,13 @@ jobs:
         docker push georchestra/geoserver:geofence
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/geoserver:${{ steps.version.outputs.VERSION }}
         docker push georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/geoserver:${{ steps.version.outputs.VERSION }}
         docker push georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: geowebcache-webapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/geowebcache:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/geowebcache:${{ steps.version.outputs.VERSION }} georchestra/geowebcache:latest
         docker push georchestra/geowebcache:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/geowebcache:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/geowebcache:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: geowebcache-webapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/geowebcache:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/geowebcache:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == "georchestra/georchestra"

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,geowebcache -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,header -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: header/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/header:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1
+      if: github.repository == "georchestra/georchestra"
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/header:${{ steps.version.outputs.VERSION }} georchestra/header:latest
         docker push georchestra/header:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/header:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/header:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: header/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/header:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/header:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/ldap.yml
+++ b/.github/workflows/ldap.yml
@@ -20,27 +20,29 @@ jobs:
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: ldap/
       run: docker build -t georchestra/ldap:${{ steps.version.outputs.VERSION }} .
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/ldap:${{ steps.version.outputs.VERSION }} georchestra/ldap:latest
         docker push georchestra/ldap:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/ldap:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/ldap:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -29,9 +29,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,mapfishapp -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -46,7 +46,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: mapfishapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == "georchestra/georchestra"

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -39,31 +39,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: mapfishapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
+      if: github.repository == "georchestra/georchestra"
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} georchestra/mapfishapp:latest
         docker push georchestra/mapfishapp:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/mapfishapp:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/mapfishapp:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -36,31 +36,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
+      if: github.repository == "georchestra/georchestra"
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
+      if: github.repository == "georchestra/georchestra"
       working-directory: security-proxy/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/security-proxy:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1
+      if: github.repository == "georchestra/georchestra"
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
       run: |
         docker tag georchestra/security-proxy:${{ steps.version.outputs.VERSION }} georchestra/security-proxy:latest
         docker push georchestra/security-proxy:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.')
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/security-proxy:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.')
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
       run: |
         docker push georchestra/security-proxy:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -26,9 +26,7 @@ jobs:
     - name: "Configuring Maven"
       run: |
           mkdir -p $HOME/.m2
-          echo $M2_SETTINGS_FILE > $HOME/.m2/settings.xml
-      env:
-          M2_SETTINGS_FILE: ${{ secrets.M2_SETTINGS_FILE }}
+          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
       run: ./mvnw --no-transfer-progress -B -P-all,security-proxy -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == "georchestra/georchestra"
       working-directory: security-proxy/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker -DdockerImageName=georchestra/security-proxy:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/security-proxy:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1


### PR DESCRIPTION
This PR actually aims to improve some of the github actions workflows:

1. removing the `M2_SETTINGS_FILE` secret: there is actually nothing secret about it (see #2985 )
2. limit docker stuff to the main geOrchestra repository: There is no need to consume CPU resources if we don't do anything with the docker image after the build. Following something similar to the previous issue: we likely to have no secrets configured on the fork to push the generated docker images.
3. Enable `sentry-spring` and `jsonevent-layout` m2 profiles when generating the official docker images (the actual purpose of this PR). The overhead on the generated artifact is less than 1MB, so even if it is not used by the final user, it seems to provide an interesting added value to the webapps, allowing to plug them to external tools (sentry, logstash/kibana and so on).
