### PR TITLE
Console - Display Org name instead of id

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -133,7 +133,7 @@ public class EditUserDetailsFormController {
      *
      * @param account input data
      */
-    private EditUserDetailsFormBean createForm(final Account account) {
+    EditUserDetailsFormBean createForm(final Account account) {
 
         EditUserDetailsFormBean formBean = new EditUserDetailsFormBean();
 
@@ -146,7 +146,7 @@ public class EditUserDetailsFormController {
         formBean.setFacsimile(account.getFacsimile());
         formBean.setDescription(account.getDescription());
         formBean.setPostalAddress(account.getPostalAddress());
-        formBean.setOrg(account.getOrg());
+        formBean.setOrg(orgsDao.findByCommonName(account.getOrg()).getName());
 
         return formBean;
     }

--- a/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
@@ -228,4 +228,15 @@ public class EditUserDetailsFormControllerTest {
         assertEquals("required", resultErrors.getFieldError("description").getDefaultMessage());
         assertEquals("required", resultErrors.getFieldError("postalAddress").getDefaultMessage());
     }
+
+    @Test
+    public void testCreateForm() {
+        ctrl = new EditUserDetailsFormController(dao, orgsDao, roleDao,
+                new Validation("phone,facsimile,title,description,postalAddress"));
+        EditUserDetailsFormBean editUserDetailsFormBean = ctrl.createForm(mtesterAccount);
+        assertEquals("email", editUserDetailsFormBean.getEmail());
+        assertEquals("mtester", editUserDetailsFormBean.getUid());
+        assertEquals("geOrchestra testing LLC", editUserDetailsFormBean.getOrg());
+
+    }
 }


### PR DESCRIPTION
Fix #2935 - In the detail page (`/console/account/userdetails`) we
are now displaying the org name instead of the id (ex: Camptocamp
instead of c2c).