### PR TITLE
SP - configure the http request timeout

### DIFF
--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -28,7 +28,7 @@
           <property name="publicUrl" value="${scheme}://${domainName}"/>
           <property name="headerManagement" ref="headerManagementBean"/>
           <property name="defaultCharset" value="UTF-8"/>
-          <property name="httpQueryTimeout" value="${httpQueryTimeout:20}" />
+          <property name="entityEnclosedOrEmptyResponseTimeout" value="${entityEnclosedOrEmptyResponseTimeout:20}" />
           <property name="defaultTarget" value="${defaultTarget:/header/}" />
           <property name="proxyPermissionsFile" value="permissions.xml"/>
           <property name="httpClientTimeout">

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -28,6 +28,7 @@
           <property name="publicUrl" value="${scheme}://${domainName}"/>
           <property name="headerManagement" ref="headerManagementBean"/>
           <property name="defaultCharset" value="UTF-8"/>
+          <property name="httpQueryTimeout" value="${httpQueryTimeout:20}" />
           <property name="defaultTarget" value="${defaultTarget:/header/}" />
           <property name="proxyPermissionsFile" value="permissions.xml"/>
           <property name="httpClientTimeout">
@@ -38,7 +39,7 @@
 
           <property name="targets">
                <map>
-                    
+
                </map>
           </property>
           <property name="requireCharsetContentTypes">
@@ -84,7 +85,7 @@
                     <constructor-arg index="1" value="${ldapOrgsRdn}"/>
                     <constructor-arg index="2">
                         <map>
-                        
+
                         </map>
                     </constructor-arg>
                 </bean>


### PR DESCRIPTION
When a user uploads a big file on a rather bad connection, this can take
some time. Currently, the request is made onto the SP in an asynchronous
fashion (to avoid getting the whole response in memory before giving it
back to the client). There is a timeout set to 5 minutes in the code
that limits the time for the client being able to send data to the
proxified server, regardless of other timeouts set on frontend proxies.

If the frontend sets a timeout to 20 minutes, then we should also be
able to allow the query to take the same amount of time when getting
through the SP.

Note: this revealed another issue: In case of reaching the "query
timeout",we need to wait for the end of the data from the client being
sent before giving a bad status.  Unfortunately, it does not seem
possible with Servlets to interrupt / close the request, even if we know
that the query failed.

Tests:

* No tests added, this case being pretty hard to set up a testing
  scenario
* mvn clean verify -Pit ok though
* runtime tested on a dev env with a low timeout set & bandwidth
  trickled