### PR TITLE
Mapfishapp - Fix tests dependency fail introduceda while ago

### DIFF
--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -159,6 +159,12 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.10.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>mapfishapp-${server}</finalName>


### PR DESCRIPTION
it seems to be introduced by
https://github.com/georchestra/georchestra/commit/0da5782f3a891e183f0da1fe5c0a52d98d4de0e0#diff-acb8fe7e00154b6e6b35bb938c4c4bba
but ant was never a direct dep of the project, it was transitive, so harder to find.