### PR TITLE
Add swagger (openapi) to console

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -59,6 +59,19 @@
     </pluginRepository>
   </pluginRepositories>
   <dependencies>
+    <!--Dependency for swagger 2 -->
+
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2</artifactId>
+      <version>2.9.2</version>
+    </dependency>
+    <!--Dependency for swagger ui -->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger-ui</artifactId>
+      <version>2.9.2</version>
+    </dependency>
     <!-- General dependencies for standard applications -->
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -19,13 +19,25 @@
             http://www.springframework.org/schema/mvc
             http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-    <security:global-method-security pre-post-annotations="enabled" >
-	  <security:expression-handler ref="expressionHandler"/>
-	</security:global-method-security>
+  <context:component-scan
+          base-package="org.georchestra.console.ws.backoffice" use-default-filters="false">
+    <context:include-filter type="annotation" expression="org.springframework.stereotype.Controller" />
+    <context:include-filter type="annotation" expression="org.springframework.web.bind.annotation.ControllerAdvice" />
+  </context:component-scan>
 
-	<bean id="expressionHandler" class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
-		<property name="permissionEvaluator" ref="consolePermissionEvaluator"/>
-	</bean>
+  <security:global-method-security pre-post-annotations="enabled" >
+    <security:expression-handler ref="expressionHandler"/>
+  </security:global-method-security>
+
+  <bean id="swagger2Config" class="springfox.documentation.swagger2.configuration.Swagger2DocumentationConfiguration"/>
+  <mvc:resources mapping="swagger-ui.html"
+                 location="classpath:/META-INF/resources/" />
+  <mvc:resources mapping="/webjars/**"
+                 location="classpath:/META-INF/resources/webjars/" />
+
+  <bean id="expressionHandler" class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
+      <property name="permissionEvaluator" ref="consolePermissionEvaluator"/>
+  </bean>
 
   <bean id="consolePermissionEvaluator" class="org.georchestra.console.ConsolePermissionEvaluator" />
 


### PR DESCRIPTION
Fix #2340 

No code change just config.

## How to test ?

* Launch console (`mvn jetty:run -Dgeorchestra.datadir=<path_to_datadir> ` for example)
* go to `http://localhost:8286/console/swagger-ui.html` or `https://georchestra.mydomain.org/console/swagger-ui.html`
* Enjoy. 

(Almost) everything is possible through config. Note that this is swagger2 (OpenAPI2) and the current spec is OpenAPI3. OpenAPI3 is possible with [springdoc](https://github.com/springdoc/springdoc-openapi) but requires spring-boot.