### PR TITLE
all webapps - remove sentry-spring / reintroduce sentry-log4j

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: analytics/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/analytics:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/analytics:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: atlas/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/atlas:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/atlas:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: cas-server-webapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/cas:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j  -DdockerImageName=georchestra/cas:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: console/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/console:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/console:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: extractorapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/extractorapp:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/extractorapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -55,13 +55,13 @@ jobs:
     - name: "Building docker image with native security"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-spring -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
 
 
     - name: "Building docker image with geofence"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-spring -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geowebcache-webapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/geowebcache:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/geowebcache:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: header/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring -DdockerImageName=georchestra/header:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/header:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -55,7 +55,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: mapfishapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j  -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -52,7 +52,7 @@ jobs:
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
       working-directory: security-proxy/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/security-proxy:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j  -DdockerImageName=georchestra/security-proxy:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/pom.xml
+++ b/pom.xml
@@ -814,12 +814,12 @@
   </reporting>
   <profiles>
     <profile>
-      <id>sentry-spring</id>
+      <id>sentry-log4j</id>
       <dependencies>
         <dependency>
           <groupId>io.sentry</groupId>
-          <artifactId>sentry-spring</artifactId>
-          <version>1.7.27</version>
+          <artifactId>sentry-log4j</artifactId>
+          <version>1.7.30</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
Quoting the sentry doc:

>A Sentry logging integration is more general and will capture errors
(and possibly warnings, depending on your configuration) that occur
inside or outside of a Spring controller. In most scenarios, using one
of the logging integrations instead of sentry-spring is preferred.

https://docs.sentry.io/clients/java/integrations/#spring

Which is actually what we did in the first place.