### PR TITLE
mapfishapp - prevent logical filters with a single term

### DIFF
--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -40,34 +40,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
-      if: github.repository == "georchestra/georchestra"
+      if: github.repository == 'georchestra/georchestra'
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
-      if: github.repository == "georchestra/georchestra"
+      if: github.repository == 'georchestra/georchestra'
       working-directory: mapfishapp/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
-      if: github.repository == "georchestra/georchestra"
+      if: github.repository == 'georchestra/georchestra'
       uses: azure/docker-login@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
+      if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra'
       run: |
         docker tag georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} georchestra/mapfishapp:latest
         docker push georchestra/mapfishapp:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == 'georchestra/georchestra'
       run: |
         docker push georchestra/mapfishapp:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == 'georchestra/georchestra'
       run: |
         docker push georchestra/mapfishapp:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -37,34 +37,34 @@ jobs:
       run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
-      if: github.repository == "georchestra/georchestra"
+      if: github.repository == 'georchestra/georchestra'
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
-      if: github.repository == "georchestra/georchestra"
+      if: github.repository == 'georchestra/georchestra'
       working-directory: security-proxy/
       run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-spring  -DdockerImageName=georchestra/security-proxy:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1
-      if: github.repository == "georchestra/georchestra"
+      if: github.repository == 'georchestra/georchestra'
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master' && github.repository == "georchestra/georchestra"
+      if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra'
       run: |
         docker tag georchestra/security-proxy:${{ steps.version.outputs.VERSION }} georchestra/security-proxy:latest
         docker push georchestra/security-proxy:latest
 
     - name: "Pushing release branch to docker.io"
-      if: contains(github.ref, 'refs/heads/20.') && github.repository == "georchestra/georchestra"
+      if: contains(github.ref, 'refs/heads/20.') && github.repository == 'georchestra/georchestra'
       run: |
         docker push georchestra/security-proxy:${{ steps.version.outputs.VERSION }}
 
     - name: "Pushing release tag to docker.io"
-      if: contains(github.ref, 'refs/tags/20.') && github.repository == "georchestra/georchestra"
+      if: contains(github.ref, 'refs/tags/20.') && github.repository == 'georchestra/georchestra'
       run: |
         docker push georchestra/security-proxy:${{ steps.version.outputs.VERSION }}

--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
@@ -830,33 +830,27 @@ Ext.app.FreetextField = Ext.extend(Ext.form.TwinTriggerField, {
             // data type filters
             // improve relevance of results: (might not be relevant with other csw servers than geonetwork)
             byTypes = new OpenLayers.Filter.Logical({
-                type: "&&",
+                type: "||",
                 filters: [
-                    // do not request dc:type = service, just dc:type = dataset OR series
-                    new OpenLayers.Filter.Logical({
-                        type: "||",
-                        filters: [
-                            new OpenLayers.Filter.Comparison({
-                                type: "==",
-                                property: "Type",
-                                value: 'data'
-                            }),
-                            new OpenLayers.Filter.Comparison({
-                                type: "==",
-                                property: "Type",
-                                value: 'dataset'
-                            }),
-                            new OpenLayers.Filter.Comparison({
-                                type: "==",
-                                property: "Type",
-                                value: 'datasetcollection'
-                            }),
-                            new OpenLayers.Filter.Comparison({
-                                type: "==",
-                                property: "Type",
-                                value: 'series'
-                            })
-                        ]
+                    new OpenLayers.Filter.Comparison({
+                        type: "==",
+                        property: "Type",
+                        value: 'data'
+                    }),
+                    new OpenLayers.Filter.Comparison({
+                        type: "==",
+                        property: "Type",
+                        value: 'dataset'
+                    }),
+                    new OpenLayers.Filter.Comparison({
+                        type: "==",
+                        property: "Type",
+                        value: 'datasetcollection'
+                    }),
+                    new OpenLayers.Filter.Comparison({
+                        type: "==",
+                        property: "Type",
+                        value: 'series'
                     })
                 ]
             }),
@@ -972,7 +966,13 @@ Ext.app.FreetextField = Ext.extend(Ext.form.TwinTriggerField, {
         // spatial filter
         finalFilters.push(GEOR.cswquerier.getSpatialFilter());
 
-        if (byWords.length > 0) {
+        if (byWords.length == 1) {
+            finalFilters.push(new OpenLayers.Filter.Logical({
+                    type: "||",
+                    filters: [byIds, byWords[0]]
+                })
+            );
+        } else if (byWords.length > 1) {
             finalFilters.push(new OpenLayers.Filter.Logical({
                     type: "||",
                     filters: [


### PR DESCRIPTION
This PR fixes an issue in mapfishapp's CSW querier which could be ignored as long as geonetwork was not too strict about the incoming query filters.
It seems it's not the case anymore as of GeoNetwork 2.8+ 
