### PR TITLE
Console - fix bug where role cannot have hyphens.

### DIFF
--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -153,7 +153,7 @@ angular.module('manager', [
     restrict: 'A',
     link: (scope, elm, attrs, ctrl) => {
       const alphanum = v => v && v.match(/^[A-Z0-9-_]+$/)
-      ctrl.$validators.shortname = v => alphanum(v) && v.toUpperCase() === v
+      ctrl.$validators.shortname = alphanum
     }
   }))
 

--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -152,7 +152,7 @@ angular.module('manager', [
     require: 'ngModel',
     restrict: 'A',
     link: (scope, elm, attrs, ctrl) => {
-      const alphanum = v => v && v.match(/^\w*$/)
+      const alphanum = v => v && v.match(/^[a-zA-Z-_]+$/)
       let validator = alphanum
       if (scope.$eval(attrs.uppercased)) {
         validator = v => alphanum(v) && v.toUpperCase() === v

--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -153,11 +153,7 @@ angular.module('manager', [
     restrict: 'A',
     link: (scope, elm, attrs, ctrl) => {
       const alphanum = v => v && v.match(/^[A-Z0-9-_]+$/)
-      let validator = alphanum
-      if (scope.$eval(attrs.uppercased)) {
-        validator = v => alphanum(v) && v.toUpperCase() === v
-      }
-      ctrl.$validators.shortname = validator
+      ctrl.$validators.shortname = v => alphanum(v) && v.toUpperCase() === v
     }
   }))
 

--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -152,7 +152,7 @@ angular.module('manager', [
     require: 'ngModel',
     restrict: 'A',
     link: (scope, elm, attrs, ctrl) => {
-      const alphanum = v => v && v.match(/^[a-zA-Z-_]+$/)
+      const alphanum = v => v && v.match(/^[A-Z0-9-_]+$/)
       let validator = alphanum
       if (scope.$eval(attrs.uppercased)) {
         validator = v => alphanum(v) && v.toUpperCase() === v

--- a/console/src/main/webapp/manager/app/templates/roleForm.tpl.html
+++ b/console/src/main/webapp/manager/app/templates/roleForm.tpl.html
@@ -11,7 +11,7 @@
         <label class="col-sm-4" for="cn" translate>role.cn</label>
         <div class="col-sm-8">
           <input ng-model="model.cn" class="form-control" id="cn"
-            placeholder="" ng-required="true" ng-readonly="isProtectedRole(model)" shortname uppercased="true">
+            placeholder="" ng-required="true" ng-readonly="isProtectedRole(model)" shortname >
            <p class="help-block" translate>role.helpFormat</p>
         </div>
       </div>


### PR DESCRIPTION
Hyphens are ok on the backend side but not on the frontend side. Change
the validation logic in the js code allow a role to have hyphens. Ex:
GN_MY-GROUP-OF-USER is now valid.