### PR TITLE
mfapp - improve logging

### DIFF
--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/A_DocService.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/A_DocService.java
@@ -410,7 +410,7 @@ public abstract class A_DocService {
             throw new DocServiceException("File is not valid. " + ex.getMessage(),
                     HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Error while checking validity of the document", e);
         }
         return false;
     }
@@ -580,9 +580,9 @@ public abstract class A_DocService {
                 content = new String(bytes);
 
             } catch (FileNotFoundException fnfExc) {
-                fnfExc.printStackTrace();
+                LOG.error("file not found", fnfExc);
             } catch (IOException ioExc) {
-                ioExc.printStackTrace();
+                LOG.error("Error accessing file", ioExc);
             } finally {
                 if (fis != null) {
                     try {

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
@@ -35,6 +35,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.georchestra.commons.configuration.GeorchestraConfiguration;
 import org.georchestra.mapfishapp.ws.classif.ClassifierCommand;
 import org.georchestra.mapfishapp.ws.classif.SLDClassifier;
@@ -87,6 +89,8 @@ public class DocController {
 
     @Autowired
     public GeorchestraConfiguration georchestraConfiguration;
+
+    private static final Log LOG = LogFactory.getLog(DocController.class.getPackage().getName());
 
     /** the connection pool used by the document services */
     @Autowired
@@ -457,9 +461,9 @@ public class DocController {
             out.println("{\"success\":true,\"" + FILEPATH_VARNAME + "\":\"" + SLD_URL + fileName + "\"}");
         } catch (DocServiceException e) {
             sendErrorToClient(response, e.getErrorCode(), e.getMessage());
-            e.printStackTrace();
+            LOG.error("Error occured while doing a classification", e);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("I/O exception encountered while doing a classification", e);
         }
     }
 
@@ -529,9 +533,9 @@ public class DocController {
             out.println("{\"success\":true,\"" + FILEPATH_VARNAME + "\":\"" + docUrl + fileName + "\"}");
         } catch (DocServiceException e) {
             sendErrorToClient(response, e.getErrorCode(), e.getMessage());
-            e.printStackTrace();
+            LOG.error("Error occured while storing an uploaded file", e);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("I/O exception encountered while storing an uploaded file", e);
         }
     }
 
@@ -572,10 +576,10 @@ public class DocController {
             out.println(docService.getContent());
         } catch (DocServiceException docExc) {
             sendErrorToClient(response, docExc.getErrorCode(), docExc.toString());
-            docExc.printStackTrace();
+            LOG.error("Error occured while storing an uploaded file", docExc);
         } catch (Exception e) {
             sendErrorToClient(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "");
-            e.printStackTrace();
+            LOG.error("I/O exception encountered while storing an uploaded file", e);
         }
     }
 
@@ -667,12 +671,9 @@ public class DocController {
             while ((sLine = reader.readLine()) != null) {
                 strBuilder.append(sLine);
             }
-        } catch (IOException ioExc) {
-            ioExc.printStackTrace();
-        } catch (Exception exc) {
-            exc.printStackTrace();
+        } catch (Exception e) {
+            LOG.error("exception occured while trying to get the request body", e);
         }
-
         return strBuilder.toString();
     }
 
@@ -688,7 +689,7 @@ public class DocController {
             try {
                 response.sendError(status, message);
             } catch (IOException ioExc) {
-                ioExc.printStackTrace();
+                LOG.error("Exception occured while sending the error status to the client", ioExc);
             }
         }
     }

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/OGCProxy.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/OGCProxy.java
@@ -40,6 +40,8 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -68,6 +70,7 @@ public class OGCProxy {
      */
     private String[] _allowedHosts = {};
 
+    private static final Log LOG = LogFactory.getLog(OGCProxy.class.getPackage().getName());
     /**
      * List of valid content types
      */
@@ -332,7 +335,7 @@ public class OGCProxy {
             streamToClient.close();
         } catch (IOException e) {
             // connection problem with the host
-            e.printStackTrace();
+            LOG.error(String.format("I/O exception occured while proxyfying to %s", sURL), e);
         }
     }
 

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/classif/SLDClassifier.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/classif/SLDClassifier.java
@@ -39,6 +39,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.georchestra.mapfishapp.ws.DocServiceException;
@@ -81,6 +83,8 @@ public class SLDClassifier {
     private Map<String, UsernamePasswordCredentials> _credentials;
 
     private WFSDataStoreFactory _factory = new WFSDataStoreFactory();
+
+    private static final Log LOG = LogFactory.getLog(SLDClassifier.class.getPackage().getName());
 
     public void setWFSDataStoreFactory(WFSDataStoreFactory f) {
         _factory = f;
@@ -267,7 +271,7 @@ public class SLDClassifier {
             // Use FeatureTypeStyle to generate a complete SLD object
             _sld = createSLD(fts);
         } catch (IOException e) {
-            e.printStackTrace(); // could happened when communicating with WFS
+            LOG.error("Error occured while trying to do a classification", e);
         }
     }
 
@@ -339,7 +343,7 @@ public class SLDClassifier {
             schema = wfs.getSchema(_wfsngTypeName); // get schema
             clazz = schema.getType(_command.getPropertyName()).getBinding(); // get data type as Class
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Unable to get the WFS schema", e);
         }
         if (clazz == null) {
             throw new RuntimeException("Should never happen, we need to know what type is the attribute of");
@@ -395,7 +399,8 @@ public class SLDClassifier {
             // happens when wfs url is wrong (missing request or service parameters...)
             throw new DocServiceException(e.getMessage(), HttpServletResponse.SC_BAD_REQUEST);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Error occured while connecting to the WFS url", e);
+            throw new DocServiceException("Error while creating a WFS object", HttpServletResponse.SC_BAD_REQUEST);
         }
         return wfs;
     }


### PR DESCRIPTION

* Avoid calls to printStackTrace() use logger with error level instead
* Better error feedback in case connecting to WFS ends up with an error
  because of bad credentials (401)

Tests:

* testsuite OK

Note: We should consider using slf4j instead of apache commons, but since the mfapp webapp is almost considered EOL ...
