### PR TITLE
Proxy all HTTP verb

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -20,9 +20,14 @@
 package org.georchestra.security;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
+import static org.springframework.web.bind.annotation.RequestMethod.OPTIONS;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+import static org.springframework.web.bind.annotation.RequestMethod.PATCH;
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
+import static org.springframework.web.bind.annotation.RequestMethod.TRACE;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -87,6 +92,7 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -364,7 +370,8 @@ public class Proxy {
      * sometimes used by the underlying webapps (e.g. mapfishapp and the mfprint
      * configuration). hence we need to allow it in the following "params" array.*
      */
-    @RequestMapping(value = "/**", params = { "!login" })
+    @RequestMapping(value = "/**", params = { "!login" }, method = { GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE,
+            TRACE })
     public void handleRequest(HttpServletRequest request, HttpServletResponse response) {
         handlePathEncodedRequests(request, response);
     }
@@ -1032,6 +1039,14 @@ public class Proxy {
                 HttpDelete delete = new HttpDelete(uri);
 
                 targetRequest = delete;
+                break;
+            }
+            case PATCH: {
+                logger.debug("New request is: " + sURL + "\nRequest is PATCH");
+
+                HttpPatch patch = new HttpPatch(uri);
+
+                targetRequest = patch;
                 break;
             }
             default: {

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -13,14 +13,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.sql.DataSource;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
@@ -255,6 +257,20 @@ public class ProxyTest {
             thrown = true;
         }
         assertTrue(thrown);
+    }
+
+    @Test
+    public void testVerb() throws UnsupportedEncodingException {
+
+        for (RequestMethod e : RequestMethod.values()) {
+            request = new MockHttpServletRequest(e.toString(), "/extractorapp/home");
+            response = new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.OK.value(), e.toString() + " worked");
+            response.setHeader("X-Test-Header", e.toString() + " worked");
+            httpResponse = new MockHttpServletResponse();
+            proxy.handleRequest(request, httpResponse);
+            assertEquals(HttpStatus.OK.value(), httpResponse.getStatus());
+            assertEquals(e.toString() + " worked", httpResponse.getHeader("X-Test-Header"));
+        }
     }
 
 }


### PR DESCRIPTION
This PR add explicitly all HTTP verb and allow the proxy to forward
all types of HTTP verb.

Also handle the case of HTTP PATCH which was not handled by proxy.

This PR was primarily made to support forwarding of CORS pre-flight request. and to address part of #3084