### PR TITLE
Enable CORS request in geoserver

### DIFF
--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -26,6 +26,17 @@ RUN wget https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-t
 RUN mkdir /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs && \
     chown jetty:jetty /etc/georchestra /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mnt/geoserver_native_libs
 
+# add a tweaked configuration. First use case is support of OPTIONS.
+ADD web.xml /var/lib/jetty/webapps/geoserver/WEB-INF/web.xml
+
+# This is needed to activate the CrossOriginFilter in web.xml
+RUN ln -s /usr/local/jetty/lib/jetty-servlets-*.jar        \
+        /usr/local/jetty/lib/jetty-continuation-*.jar   \
+        /usr/local/jetty/lib/jetty-http-*.jar           \
+        /usr/local/jetty/lib/jetty-util-*.jar           \
+        /usr/local/jetty/lib/jetty-io-*.jar             \
+        /var/lib/jetty/webapps/geoserver/WEB-INF/lib/
+
 USER jetty
 
 VOLUME [ "/mnt/geoserver_datadir", "/mnt/geoserver_geodata", "/mnt/geoserver_tiles", "/mnt/geoserver_native_libs", "/tmp", "/run/jetty" ]

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM jetty:9-jre8
 
 ENV XMS=1536M XMX=8G
 
-RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,jndi,http-forwarded
+RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,jndi,http-forwarded,servlets
 
 COPY --chown=jetty:jetty . /
 
@@ -28,14 +28,6 @@ RUN mkdir /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles /mn
 
 # add a tweaked configuration. First use case is support of OPTIONS.
 ADD web.xml /var/lib/jetty/webapps/geoserver/WEB-INF/web.xml
-
-# This is needed to activate the CrossOriginFilter in web.xml
-RUN ln -s /usr/local/jetty/lib/jetty-servlets-*.jar        \
-        /usr/local/jetty/lib/jetty-continuation-*.jar   \
-        /usr/local/jetty/lib/jetty-http-*.jar           \
-        /usr/local/jetty/lib/jetty-util-*.jar           \
-        /usr/local/jetty/lib/jetty-io-*.jar             \
-        /var/lib/jetty/webapps/geoserver/WEB-INF/lib/
 
 USER jetty
 

--- a/geoserver/webapp/src/docker/web.xml
+++ b/geoserver/webapp/src/docker/web.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	      version="3.0">
+    <display-name>GeoServer</display-name>
+  
+      <context-param>
+    <param-name>serviceStrategy</param-name>
+    <!-- Meaning of the different values :
+         
+         PARTIAL-BUFFER2
+         - Partially buffers the first xKb to disk. Once that has buffered, the the 
+           result is streamed to the user. This will allow for most errors to be caught
+           early. 
+           
+         BUFFER
+         - stores the entire response in memory first, before sending it off to
+           the user (may run out of memory)
+
+         SPEED
+         - outputs directly to the response (and cannot recover in the case of an
+           error)
+
+         FILE
+         - outputs to the local filesystem first, before sending it off to the user
+      -->
+    <param-value>PARTIAL-BUFFER2</param-value>
+  </context-param>
+  
+  <context-param>
+    <!-- see comments on the PARTIAL-BUFFER strategy -->
+    <!-- this sets the size of the buffer.  default is "50" = 50kb -->
+
+    <param-name>PARTIAL_BUFFER_STRATEGY_SIZE</param-name>
+    <param-value>50</param-value>
+  </context-param>
+  
+  <!--Can be true or false (defaults to: false). -->
+  <!--When true the JSONP (text/javascript) output format is enabled -->
+  <!--
+  <context-param>
+    <param-name>ENABLE_JSONP</param-name>
+    <param-value>true</param-value>
+  </context-param>
+  -->
+    <!-- 
+    <context-param>
+      <param-name>PROXY_BASE_URL</param-name>
+      <param-value>http://82.58.146.45/geoserver</param-value>
+    </context-param>
+     -->
+   
+     <!--
+    <context-param>
+       <param-name>GEOSERVER_DATA_DIR</param-name>
+        <param-value>C:\eclipse\workspace\geoserver_trunk\cite\confCiteWFSPostGIS</param-value>
+    </context-param> 
+   -->
+    
+    <!-- pick up all spring application contexts -->
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>classpath*:/applicationContext.xml classpath*:/applicationSecurityContext.xml</param-value>
+    </context-param>
+    
+    <filter>
+     <filter-name>FlushSafeFilter</filter-name>
+     <filter-class>org.geoserver.filters.FlushSafeFilter</filter-class>
+    </filter>
+     
+    <filter>
+      <filter-name>Set Character Encoding</filter-name>
+      <filter-class>org.springframework.web.filter.CharacterEncodingFilter</filter-class>
+      <init-param>
+        <param-name>encoding</param-name>
+        <param-value>UTF-8</param-value>
+      </init-param>
+    </filter>
+
+    <filter>
+     <filter-name>SessionDebugger</filter-name>
+     <filter-class>org.geoserver.filters.SessionDebugFilter</filter-class>
+    </filter>
+
+    <filter>
+    <filter-name>filterChainProxy</filter-name>     
+     <filter-class> org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
+
+    <filter>
+      <filter-name>xFrameOptionsFilter</filter-name>
+      <filter-class>org.geoserver.filters.XFrameOptionsFilter</filter-class>
+    </filter>
+
+   <filter>
+     <filter-name>GZIP Compression Filter</filter-name>
+     <filter-class>org.geoserver.filters.GZIPFilter</filter-class>
+     <init-param>
+         <!-- The compressed-types parameter is a comma-separated list of regular expressions.
+              If a mime type matches any of the regular expressions then it will be compressed.
+              -->
+         <param-name>compressed-types</param-name>
+         <param-value>text/.*,.*xml.*,application/json,application/x-javascript</param-value>
+     </init-param>
+   </filter>
+
+   <filter>
+     <filter-name>Request Logging Filter</filter-name>
+     <filter-class>org.geoserver.filters.LoggingFilter</filter-class>
+     <init-param>
+         <!-- The 'enabled' parameter is a boolean value, "true" (case-insensitive) for true or
+              any other value for false.  If enabled, then the logging will be performed;
+              otherwise the logging filter will have no effect.  If not specified, this 
+              parameter defaults to false.
+              -->
+         <param-name>enabled</param-name>
+         <param-value>false</param-value>
+     </init-param>
+     <init-param>
+         <!-- The 'log-request-headers' parameter is a boolean value, "true" (case-insensitive) for
+              true or any other value for false.  If enabled, then the logging will include the HTTP 
+              headers of requests.  If not specified, this parameter defaults to false.
+              -->
+         <param-name>log-request-headers</param-name>
+         <param-value>false</param-value>
+     </init-param>  
+     <init-param>
+     <!-- The 'log-request-bodies' parameter is a boolean value, "true" (case-insensitive) for
+          true or any other value for false.  If enabled, then the logging will include the body
+          of POST and PUT requests.  If not specified, this parameter defaults to false.
+          Note that this may noticeably degrade responsiveness of your geoserver since it will
+          not begin to process requests until the entire request body has been received by the 
+          server.
+          -->
+     <param-name>log-request-bodies</param-name>
+     <param-value>false</param-value>
+     </init-param>
+   </filter>
+   
+   <filter>
+     <filter-name>Advanced Dispatch Filter</filter-name>
+     <filter-class>org.geoserver.platform.AdvancedDispatchFilter</filter-class>
+     <!-- 
+     This filter allows for a single mapping to the spring dispatcher. However using /* as a mapping
+     in a servlet mapping causes the servlet path to be "/" of the request. This causes problems with
+     library like wicket and restlet. So this filter fakes the servlet path by assuming the first 
+     component of the path is the mapped path. 
+     -->
+   </filter>
+   
+   <filter>
+    <filter-name>Spring Delegating Filter</filter-name>
+    <filter-class>org.geoserver.filters.SpringDelegatingFilter</filter-class>
+    <!--
+    This filter allows for filters to be loaded via spring rather than 
+    registered here in web.xml.  One thing to note is that for such filters 
+    init() is not called. INstead any initialization is performed via spring 
+    ioc.
+    -->
+   </filter>
+   
+   <filter>
+     <filter-name>Thread locals cleanup filter</filter-name>
+     <filter-class>org.geoserver.filters.ThreadLocalsCleanupFilter</filter-class>
+     <!-- 
+     This filter cleans up thread locals Geotools is setting up for concurrency and performance
+     reasons 
+     -->
+   </filter>
+
+   <!-- Uncomment following filter to enable CORS-->
+   <filter>
+        <filter-name>cross-origin</filter-name>
+        <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
+       <init-param>
+           <param-name>chainPreflight</param-name>
+           <param-value>false</param-value>
+       </init-param>
+       <init-param>
+           <param-name>allowedOrigins</param-name>
+           <param-value>*</param-value>
+       </init-param>
+       <init-param>
+           <param-name>allowedMethods</param-name>
+           <param-value>GET,POST,PUT,DELETE,HEAD,OPTIONS</param-value>
+       </init-param>
+       <init-param>
+           <param-name>allowedHeaders</param-name>
+           <param-value>*</param-value>
+       </init-param>
+    </filter>
+
+    <!--
+      THIS FILTER MUST BE THE FIRST ONE, otherwise we end up with ruined chars in the input from the GUI
+      See the "Note" in the Tomcat character encoding guide:
+      http://wiki.apache.org/tomcat/FAQ/CharacterEncoding
+    -->
+    <filter-mapping>
+      <filter-name>Set Character Encoding</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <!-- Uncomment following filter to enable CORS -->
+    <filter-mapping>
+        <filter-name>cross-origin</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>FlushSafeFilter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
+    <filter-mapping>
+      <filter-name>SessionDebugger</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>GZIP Compression Filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>xFrameOptionsFilter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
+    <filter-mapping>
+      <filter-name>Request Logging Filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+   
+    <!-- 
+      If you want to use your security system comment out this one too
+    -->
+    <filter-mapping>
+      <filter-name>filterChainProxy</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
+    <filter-mapping>
+      <filter-name>Advanced Dispatch Filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>Spring Delegating Filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
+    <filter-mapping>
+      <filter-name>Thread locals cleanup filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
+    <!-- general initializer, should be first thing to execute -->
+    <listener>
+      <listener-class>org.geoserver.GeoserverInitStartupListener</listener-class>
+    </listener>
+    
+    <!-- logging initializer, should execute before spring context startup -->
+    <listener>
+      <listener-class>org.geoserver.logging.LoggingStartupContextListener</listener-class>
+    </listener>
+  
+    <!--  spring context loader -->
+    <listener>
+      <listener-class>org.geoserver.platform.GeoServerContextLoaderListener</listener-class>
+    </listener>
+    
+    <!--  http session listener proxy -->
+    <listener>
+      <listener-class>org.geoserver.platform.GeoServerHttpSessionListenerProxy</listener-class>
+    </listener>
+
+	<!-- request context listener for session-scoped beans -->
+	<listener>
+		<listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
+	</listener>
+    
+    <!-- spring dispatcher servlet, dispatches all incoming requests -->
+    <servlet>
+      <servlet-name>dispatcher</servlet-name>
+      <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    </servlet>
+    
+    <!-- single mapping to spring, this only works properly if the advanced dispatch filter is 
+         active -->
+    <servlet-mapping>
+        <servlet-name>dispatcher</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    
+    <session-config>
+      <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+
+    <mime-mapping>
+      <extension>xsl</extension>
+      <mime-type>text/xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+      <extension>sld</extension>
+      <mime-type>text/xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+      <extension>json</extension>
+      <mime-type>application/json</mime-type>
+    </mime-mapping>
+  
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+    
+</web-app>


### PR DESCRIPTION
It includes: preflight request (HTTP options method request) and
`Allow-Origin-*` headers (present in all requests). `web.xml` has been
extracted from the previous geoserver image and parts corresponding to
CORS have been uncommented.