### PR TITLE
all - maven repo cleanup 20.0.x

### DIFF
--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -26,17 +26,6 @@
 
   </properties>
 
-  <repositories>
-    <repository>
-      <id>opengeo</id>
-      <name>OpenGeo Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1026,20 +1026,21 @@
     </repository>
     <!-- geotools -->
     <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
+      <name>OSGeo Nexus Release Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+      <!-- contains release (including third-party-dependences)                            -->
+      <!-- ucar (https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases) -->
+      <!-- geosolutions (http://maven.geo-solutions.it/)                                   -->
+      <snapshots><enabled>false</enabled></snapshots>
+      <releases><enabled>true</enabled></releases>
     </repository>
     <repository>
-      <id>opengeo</id>
-      <name>OpenGeo Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
+      <id>osgeo-snapshot</id>
+      <name>OSGeo Nexus Snapshot Repository</name>
+      <url>https://repo.osgeo.org/repository/snapshot/</url>
+      <snapshots><enabled>true</enabled></snapshots>
+      <releases><enabled>false</enabled></releases>
     </repository>
     <repository>
       <id>jetty-repository</id>
@@ -1063,14 +1064,4 @@
       <url>https://maven.atlassian.com/3rdparty/</url>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>opengeo</id>
-      <name>OpenGeo Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 </project>


### PR DESCRIPTION
* boundlessgeo repositories do not respond anymore
* osgeo now set up a nexus

tests: only a mvn clean install -DskipTests, the purpose here is just to
make sure we can fetch the dependencies.

Backport of https://github.com/georchestra/georchestra/pull/3065/commits