### PR TITLE
mapfishapp - allow addons to override i18n strings

### DIFF
--- a/mapfishapp/src/main/webapp/app/addons/extractor/config.json
+++ b/mapfishapp/src/main/webapp/app/addons/extractor/config.json
@@ -1,30 +1,47 @@
 [{
-        "id": "extractor_0",
-        "name": "Extractor",
-        "enabled": true,
-        "title": {
-            "en": "Extractor",
-            "es": "Extractor",
-            "fr": "Extracteur",
-            "nl": "Afzuigkap"
-        },
-        "description": {
-            "en": "This addon allows one to download data from the layers visible on the map",
-            "es": "Este addon permite descargar datos de las capas visibles en el mapa",
-            "fr": "Cet addon permet de télécharger les données des couches visibles sur la carte",
-            "nl": "Met deze addon kunnen de gegevens van de zichtbare lagen op de kaart worden gedownload"
-        },
-        "roles": [
-            "ROLE_EXTRACTORAPP"
+    "id": "extractor_0",
+    "name": "Extractor",
+    "enabled": true,
+    "title": {
+        "en": "Extractor",
+        "es": "Extractor",
+        "fr": "Extracteur",
+        "nl": "Afzuigkap"
+    },
+    "description": {
+        "en": "This addon allows one to download data from the layers visible on the map",
+        "es": "Este addon permite descargar datos de las capas visibles en el mapa",
+        "fr": "Cet addon permet de télécharger les données des couches visibles sur la carte",
+        "nl": "Met deze addon kunnen de gegevens van de zichtbare lagen op de kaart worden gedownload"
+    },
+    "roles": [
+        "ROLE_EXTRACTORAPP"
+    ],
+    "options": {
+        "srsData": [
+            ["EPSG:4326", "WGS84 (EPSG:4326)"],
+            ["EPSG:3857", "Spherical Mercator (EPSG:3857)"]
         ],
-        "options": {
-            "srsData": [
-                ["EPSG:4326", "WGS84 (EPSG:4326)"],
-                ["EPSG:3857", "Spherical Mercator (EPSG:3857)"]
-            ],
-            "defaultSRS": "EPSG:4326",
-            "defaultVectorFormat": "shp",
-            "defaultRasterFormat": "geotiff",
-            "defaultRasterResolution": 50
+        "defaultSRS": "EPSG:4326",
+        "defaultVectorFormat": "shp",
+        "defaultRasterFormat": "geotiff",
+        "defaultRasterResolution": 50
+    },
+    "i18n": {
+        "en": {
+            "addon_extractor_help": "For more information regarding the use of the extraction module, please have a look at the <a href=\"https://github.com/georchestra/georchestra/blob/master/extractorapp/README.md\" target=\"_blank\">documentation</a>"
+        },
+        "es": {
+            "addon_extractor_help": "Para obtener más información sobre el uso del módulo de extracción, consulte la <a href=\"https://github.com/georchestra/georchestra/blob/master/extractorapp/README.md\" target=\"_blank\">documentación</a>"
+        },
+        "fr": {
+            "addon_extractor_help": "Pour plus d'information sur l'utilisation du module d'extraction, veuillez consulter la <a href=\"https://github.com/georchestra/georchestra/blob/master/extractorapp/README.md\" target=\"_blank\">documentation</a>"
+        },
+         "de": {
+            "addon_extractor_help": "Weitere Informationen zur Verwendung des Extraktionsmoduls finden Sie in der <a href=\"https://github.com/georchestra/georchestra/blob/master/extractorapp/README.md\" target=\"_blank\">Dokumentation</a>"
+        },
+         "nl": {
+            "addon_extractor_help": "Raadpleeg de <a href=\"https://github.com/georchestra/georchestra/blob/master/extractorapp/README.md\" target=\"_blank\">documentatie</a> voor meer informatie over het gebruik van de extractiemodule"
         }
+    }
 }]

--- a/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_tools.js
@@ -211,6 +211,13 @@ GEOR.tools = (function() {
                                 r.get("options") || {},
                                 o.default_options || {}
                             ));
+                            // handle i18n overrides
+                            if (r.get("i18n")) {
+                                Ext.iterate(r.get("i18n"), function(k, v) {
+                                    OpenLayers.Lang[k] =
+                                        OpenLayers.Util.extend(OpenLayers.Lang[k], v);
+                                });
+                            }
                             addonsCache[r.id] = addon;
                             // we're passing the record to the init method
                             // so that the addon has access to the administrator's strings
@@ -464,7 +471,7 @@ GEOR.tools = (function() {
                 }
             });
             store = new Ext.data.JsonStore({
-                fields: ["id", "name", "title", "thumbnail", "description", "group", "options", {
+                fields: ["id", "name", "title", "thumbnail", "description", "group", "options", "i18n", {
                     name: "_loaded", defaultValue: false, type: "boolean"
                 }, {
                     name: "preloaded", defaultValue: false, type: "boolean"


### PR DESCRIPTION
Since #3085 one needs a mechanism to override i18n strings provided by the addon.
This is now possible, see eg https://github.com/georchestra/datadir/pull/188