### PR TITLE
Geoserver - fix logging in geoserver in docker

### DIFF
--- a/geoserver/webapp/src/docker/docker-entrypoint.d/00-geoserver-bootstrap
+++ b/geoserver/webapp/src/docker/docker-entrypoint.d/00-geoserver-bootstrap
@@ -14,6 +14,6 @@ else
     sed -i 's:<serverURL>ldap\://localhost\:389</serverURL>:<serverURL>ldap\://ldap\:389</serverURL>:g' /mnt/geoserver_datadir/security/role/my_ldap/config.xml
     sed -i 's:<serverURL>ldap\://localhost\:389</serverURL>:<serverURL>ldap\://ldap\:389</serverURL>:g' /mnt/geoserver_datadir/security/usergroup/my_ldap/config.xml
 
-    echo 'Change rootLogger config according to docker setup'
-    sed -i 's:log4j.rootLogger=WARN, geoserverlogfile, stdout:log4j.rootLogger=WARN, stdout:g' /mnt/geoserver_datadir/logs/*
+    echo 'Change log config according to docker setup'
+    sed -i 's:stdOutLogging>false:stdOutLogging>true:g' /mnt/geoserver_datadir/logging.xml
 fi


### PR DESCRIPTION
In a docker env, it will now log in `/tmp/geoserver.log` and in stdout.
Not logging in `/tmp/geoserver.log` breaks a feature in geoserver where
you can see geoserver logs from the web UI.