### PR TITLE
GeoServer 2.17.2 update

### DIFF
--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -55,13 +55,13 @@ jobs:
     - name: "Building docker image with native security"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-log4j,authkey,mapstore2 -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
 
 
     - name: "Building docker image with geofence"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-log4j,authkey,mapstore2 -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Docker related targets
 
-GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k
+GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,mapstore2
 BTAG=latest
 
 docker-pull-jetty:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Docker related targets
 
-GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,mapstore2
+GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2
 BTAG=latest
 
 docker-pull-jetty:

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -11,15 +11,15 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.16.1</gs.version>
-    <gt.version>22.1</gt.version>
+    <gs.version>2.17.0</gs.version>
+    <gt.version>23.0</gt.version>
     <geofence.version>3.4.2</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.10.1</jackson.version>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.1.1.RELEASE</spring.version>
-    <spring-security.version>5.1.5.RELEASE</spring-security.version>
+    <spring.version>5.1.13.RELEASE</spring.version>
+    <spring-security.version>5.1.8.RELEASE</spring-security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--
     <commons-beanutils.version>1.8.0</commons-beanutils.version>

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -11,15 +11,15 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.17.0</gs.version>
-    <gt.version>23.0</gt.version>
+    <gs.version>2.17.2</gs.version>
+    <gt.version>23.2</gt.version>
     <geofence.version>3.4.2</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>
     <jackson.version>2.10.1</jackson.version>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.1.13.RELEASE</spring.version>
-    <spring-security.version>5.1.8.RELEASE</spring-security.version>
+    <spring.version>5.1.16.RELEASE</spring.version>
+    <spring-security.version>5.1.11.RELEASE</spring-security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--
     <commons-beanutils.version>1.8.0</commons-beanutils.version>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -765,7 +765,7 @@
       <id>authkey</id>
       <dependencies>
         <dependency>
-          <groupId>org.geoserver.community</groupId>
+          <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-authkey</artifactId>
           <version>${gs.version}</version>
         </dependency>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1020,6 +1020,11 @@
             <artifactId>gs-dds</artifactId>
             <version>${gs.version}</version>
           </dependency>
+          <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-authkey</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1020,11 +1020,6 @@
             <artifactId>gs-dds</artifactId>
             <version>${gs.version}</version>
           </dependency>
-          <dependency>
-            <groupId>org.geoserver.community</groupId>
-            <artifactId>gs-authkey</artifactId>
-            <version>${gs.version}</version>
-          </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -977,6 +977,52 @@
       </dependencies>
     </profile>
     <profile>
+        <!-- this profile adds every plugins needed by the mapstore2 viewer as dependencies -->
+        <id>mapstore2</id>
+        <dependencies>
+          <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-wmts-multi-dimensional</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-querylayer</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-wps-core</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-dxf-core</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-dxf-wps</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-excel</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-css</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-dds</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>debianPackage</id>
       <build>
         <plugins>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -170,6 +170,11 @@
       <version>${gt.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlets</artifactId>
+      <version>9.4.18.v20190429</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>apache-log4j-extras</artifactId>
       <version>1.2.17</version>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -243,35 +243,6 @@
       </dependencies>
     </profile>
     <profile>
-      <id>arcsde</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.geoserver.extension</groupId>
-          <artifactId>gs-arcsde</artifactId>
-          <version>${gs.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>sdeLibs</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.esri</groupId>
-          <artifactId>jsde_sdk</artifactId>
-          <version>${sde.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.esri</groupId>
-          <artifactId>jpe_sdk</artifactId>
-          <version>${sde.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.ibm.icu</groupId>
-          <artifactId>icu4j</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
       <id>sqlserver</id>
       <dependencies>
         <dependency>
@@ -448,6 +419,12 @@
           <groupId>org.geoserver.importer</groupId>
           <artifactId>gs-importer-core</artifactId>
           <version>${gs.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.geotools</groupId>
+              <artifactId>gt-arcsde</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.geoserver.importer</groupId>

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM jetty:9-jre8
 
 ENV XMS=1536M XMX=8G
 
-RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,jndi,http-forwarded,servlets
+RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,jndi,http-forwarded
 
 COPY --chown=jetty:jetty . /
 

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.7</version>
+        <version>3.8.1</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>

--- a/security-proxy/src/main/java/org/georchestra/security/CachedContentInputStream.java
+++ b/security-proxy/src/main/java/org/georchestra/security/CachedContentInputStream.java
@@ -1,0 +1,39 @@
+package org.georchestra.security;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CachedContentInputStream extends ServletInputStream {
+
+    private InputStream cachedBodyInputStream;
+
+    public CachedContentInputStream(byte[] cachedBody) {
+        this.cachedBodyInputStream = new ByteArrayInputStream(cachedBody);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return cachedBodyInputStream.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+        try {
+            return cachedBodyInputStream.available() == 0;
+        } catch (IOException e) {
+            return true;
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+    }
+}

--- a/security-proxy/src/main/java/org/georchestra/security/UrlFormEncodedPostFilter.java
+++ b/security-proxy/src/main/java/org/georchestra/security/UrlFormEncodedPostFilter.java
@@ -61,15 +61,9 @@ public class UrlFormEncodedPostFilter extends OncePerRequestFilter {
          */
         public WrappedRequest(HttpServletRequest request) {
             super(request);
-            String charset = request.getCharacterEncoding();
+
             try {
-                Charset.forName(charset);
-            } catch (Throwable t) {
-                charset = "UTF-8";
-            }
-            try {
-                String payload = IOUtils.toString(request.getInputStream(), charset);
-                this.content = payload.getBytes();
+                this.content = IOUtils.toByteArray(request.getInputStream());
             } catch (IOException e) {
                 Logger.error("Unable to extract body payload", e);
             }

--- a/security-proxy/src/main/java/org/georchestra/security/UrlFormEncodedPostFilter.java
+++ b/security-proxy/src/main/java/org/georchestra/security/UrlFormEncodedPostFilter.java
@@ -1,0 +1,90 @@
+package org.georchestra.security;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+public class UrlFormEncodedPostFilter extends OncePerRequestFilter {
+    public void destroy() {
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (request.getMethod().equalsIgnoreCase(HttpMethod.POST.name()) && isFormContentType(request)) {
+            // Morph the request to a WrappedRequest, as this will
+            // allow us to read the body content in the Proxy.java class once again.
+            request = new WrappedRequest(request);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Returns if the request is a POST x-www-form-urlencoded or not.
+     *
+     * @return true if this is the case, else false.
+     *
+     */
+    private boolean isFormContentType(HttpServletRequest request) {
+        if (request.getContentType() == null) {
+            return false;
+        }
+        String contentType = request.getContentType().split(";")[0].trim();
+
+        return "application/x-www-form-urlencoded".equalsIgnoreCase(contentType);
+    }
+
+    private static class WrappedRequest extends HttpServletRequestWrapper {
+        byte[] content = new byte[0];
+        private static Logger Logger = LoggerFactory.getLogger(WrappedRequest.class);
+
+        /**
+         * Constructs a request object wrapping the given request.
+         *
+         * @param request
+         * @throws IllegalArgumentException if the request is null
+         */
+        public WrappedRequest(HttpServletRequest request) {
+            super(request);
+            String charset = request.getCharacterEncoding();
+            try {
+                Charset.forName(charset);
+            } catch (Throwable t) {
+                charset = "UTF-8";
+            }
+            try {
+                String payload = IOUtils.toString(request.getInputStream(), charset);
+                this.content = payload.getBytes();
+            } catch (IOException e) {
+                Logger.error("Unable to extract body payload", e);
+            }
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return new CachedContentInputStream(this.content);
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.content);
+            return new BufferedReader(new InputStreamReader(byteArrayInputStream));
+        }
+
+    }
+}

--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -32,6 +32,7 @@
         <s:custom-filter ref="basicAuthChallengeByUserAgent" before="CAS_FILTER" />
         <s:custom-filter ref="casFilter" after="CAS_FILTER" />
         <s:custom-filter ref="filterSecurityInterceptor" after="EXCEPTION_TRANSLATION_FILTER" />
+        <s:custom-filter ref="urlFormEncodedPostFilter" after="CHANNEL_FILTER" />
         <!--  <s:http-basic />  -->
         <s:headers>
           <s:frame-options disabled="true"/>
@@ -40,6 +41,8 @@
         <s:logout logout-success-url="${logout-success-url:${scheme}://${domainName}/cas/logout?fromgeorchestra}" />
         <s:csrf disabled="true" />
      </s:http>
+
+    <bean id="urlFormEncodedPostFilter" class="org.georchestra.security.UrlFormEncodedPostFilter" />
 
 	<bean id="filterSecurityInterceptor" class="org.springframework.security.web.access.intercept.FilterSecurityInterceptor">
 		<property name="authenticationManager" ref="authenticationManager" />

--- a/security-proxy/src/main/webapp/WEB-INF/web.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/web.xml
@@ -22,6 +22,7 @@
     <filter-name>springSecurityFilterChain</filter-name>
     <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
   </filter>
+
   <filter-mapping>
     <filter-name>springSecurityFilterChain</filter-name>
     <url-pattern>/*</url-pattern>


### PR DESCRIPTION
This is the following of the previous one which targeted GS 2.17.0, see: https://github.com/georchestra/georchestra/pull/3070

* utests OK
*  runtime tested on a Jetty & a tomcat

Note for tomcat users:

Using the `useRelativeRedirects=false` parameter on the context is still mandatory (or else, you will encounter redirection loops). See:
https://github.com/georchestra/georchestra/blob/master/docs/setup/tomcat.md#create-the-instance-2

About the  CSRF filter triggered and returning "400 bad request" errors:
https://github.com/georchestra/georchestra/blob/master/docs/setup/tomcat.md#in-case-of-troubles-with-the-geoserver-ui

It is possible to avoid this parameter by configuring the Connector as follows (proxyName, proxyPort and scheme attribute):

```xml
    <Connector port="8080" protocol="HTTP/1.1"
               connectionTimeout="20000"
               proxyName="georchestra.mydomain.org"
               proxyPort="443"
               scheme="https"
               redirectPort="8443" />
```
