### PR TITLE
console - re-enable "gdpr - download my data" feature

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -87,8 +87,8 @@ public class UsersController {
     private static final String PUBLIC_REQUEST_MAPPING = "/public/users";
     private static GrantedAuthority ROLE_SUPERUSER = AdvancedDelegationDao.ROLE_SUPERUSER;
 
-    @Value("${gdpr.enable:true}")
-    private Boolean gdprEnable;
+    @Value("${gdpr.allowAccountDeletion:true}")
+    private Boolean gdprAllowAccountDeletion;
 
     private AccountDao accountDao;
 
@@ -138,8 +138,8 @@ public class UsersController {
         this.warnUserIfUidModified = warnUserIfUidModified;
     }
 
-    public void setGdprEnable(Boolean gdprEnable) {
-        this.gdprEnable = gdprEnable;
+    public void setGdprAllowAccountDeletion(Boolean gdprAllowAccountDeletion) {
+        this.gdprAllowAccountDeletion = gdprAllowAccountDeletion;
     }
 
     @Autowired
@@ -524,9 +524,10 @@ public class UsersController {
             throws DataServiceException {
 
         /*
-         * Disabling this endpoint if the gdpr.enable property is set to false.
+         * Disabling this endpoint if the gdpr.allowAccountDeletion property is set to
+         * false.
          */
-        if (!gdprEnable) {
+        if (!gdprAllowAccountDeletion) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return null;
         }

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersExport.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersExport.java
@@ -52,15 +52,8 @@ public class UsersExport {
 
     private UserInfoExporter accountInfoExporter;
 
-    @Value("${gdpr.enable:true}")
-    private Boolean gdprEnable;
-
     @Autowired
     private AdvancedDelegationDao advancedDelegationDao;
-
-    public void setGdprEnable(Boolean gdprEnable) {
-        this.gdprEnable = gdprEnable;
-    }
 
     public @Autowired UsersExport(UserInfoExporter accountInfoExporter) {
         this.accountInfoExporter = accountInfoExporter;
@@ -74,13 +67,6 @@ public class UsersExport {
     @RequestMapping(method = RequestMethod.GET, value = "/account/gdpr/download", produces = "application/zip")
     public void downloadUserData(HttpServletResponse response)
             throws NameNotFoundException, DataServiceException, IOException {
-        /*
-         * Disabling this endpoint if the gdpr.enable property is set to false.
-         */
-        if (!gdprEnable) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return;
-        }
 
         final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         final String userId = auth.getName();

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -70,13 +70,13 @@ public class EditUserDetailsFormController {
 
     private Validation validation;
 
-    private @Value("${gdpr.enable:true}") Boolean gdprEnable;
+    private @Value("${gdpr.allowAccountDeletion:true}") Boolean gdprAllowAccountDeletion;
 
     @Autowired
     protected LogUtils logUtils;
 
-    public void setGdprEnable(Boolean gdprEnable) {
-        this.gdprEnable = gdprEnable;
+    public void setGdprAllowAccountDeletion(Boolean gdprAllowAccountDeletion) {
+        this.gdprAllowAccountDeletion = gdprAllowAccountDeletion;
     }
 
     @Autowired
@@ -114,7 +114,7 @@ public class EditUserDetailsFormController {
             Org org = orgsDao.findByCommonNameWithExt(userAccount);
             model.addAttribute("org", orgToJson(org));
             model.addAttribute("isReferentOrSuperUser", isReferentOrSuperUser(userAccount));
-            model.addAttribute("gdprEnabled", gdprEnable);
+            model.addAttribute("gdprAllowAccountDeletion", gdprAllowAccountDeletion);
 
             HttpSession session = request.getSession();
             for (String f : fields) {

--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -45,7 +45,7 @@
 
 <script>var org = ${org};
 var isReferentOrSuperUser = ${isReferentOrSuperUser};
-var gdprEnabled = ${gdprEnabled};
+var gdprAllowAccountDeletion = ${gdprAllowAccountDeletion};
 </script>
 
 <div class="container">
@@ -229,7 +229,7 @@ var gdprEnabled = ${gdprEnabled};
 
       <dir-pagination-controls></dir-pagination-controls>
     </fieldset>
-    <fieldset class="gdpr" ng-if="gdprEnabled">
+    <fieldset class="gdpr">
       <legend><s:message code="editUserDetailsForm.gdpr"/></legend>
       <div
           class="panel panel-default">
@@ -246,7 +246,7 @@ var gdprEnabled = ${gdprEnabled};
           </p>
         </div>
       </div>
-      <div class="panel panel-default">
+      <div class="panel panel-default" ng-if="gdprAllowAccountDeletion">
         <div class="panel-body">
           <p>
             <s:message code="editUserDetailsForm.deleteMsg"/>

--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -84,7 +84,7 @@ class StandaloneController {
     $scope.org = window.org
     $scope.users = window.org.members
     $scope.isReferentOrSuperUser = window.isReferentOrSuperUser
-    $scope.gdprEnabled = window.gdprEnabled
+    $scope.gdprAllowAccountDeletion = window.gdprAllowAccountDeletion
   }
 }
 

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersControllerTest.java
@@ -23,7 +23,6 @@ import javax.naming.Name;
 import javax.naming.directory.SearchControls;
 import javax.naming.ldap.LdapName;
 
-import org.apache.commons.lang.StringUtils;
 import org.georchestra.console.dao.DelegationDao;
 import org.georchestra.console.ds.AccountDaoImpl;
 import org.georchestra.console.ds.DataServiceException;
@@ -61,8 +60,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.context.support.WithSecurityContext;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 public class UsersControllerTest {
@@ -128,7 +125,7 @@ public class UsersControllerTest {
         mockGDPR = Mockito.mock(GDPRAccountWorker.class);
         when(mockGDPR.deleteAccountRecords(any(Account.class))).thenReturn(DeletedAccountSummary.builder().build());
         usersCtrl.setGdprInfoWorker(mockGDPR);
-        usersCtrl.setGdprEnable(true);
+        usersCtrl.setGdprAllowAccountDeletion(true);
 
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
@@ -616,7 +613,7 @@ public class UsersControllerTest {
     }
 
     public void testGDPRDisabled() throws DataServiceException {
-        usersCtrl.setGdprEnable(false);
+        usersCtrl.setGdprAllowAccountDeletion(false);
         usersCtrl.deleteCurrentUserAndGDPRData(response);
         assertEquals(response.SC_NOT_FOUND, response.getStatus());
     }

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersExportTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersExportTest.java
@@ -183,7 +183,6 @@ public class UsersExportTest {
 
         UserInfoExporterImpl exporter = new UserInfoExporterImpl(accDao, orgDao);
         us = new UsersExport(exporter);
-        us.setGdprEnable(true);
     }
 
     @Test
@@ -443,13 +442,4 @@ public class UsersExportTest {
                 csv.contains("psc+testuser@georchestra.org") && csv.contains("psc+testadmin@georchestra.org"));
         assertEquals("CSV should contain 3 lines", 3, csv.split("\r\n").length);
     }
-
-    @Test
-    public void testEndpointDisableWhenGDPR() throws Exception {
-        us.setGdprEnable(false);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        us.downloadUserData(response);
-        assertEquals(response.SC_NOT_FOUND, response.getStatus());
-    }
-
 }

--- a/console/src/test/resources/console-it.properties
+++ b/console/src/test/resources/console-it.properties
@@ -117,4 +117,4 @@ emailProxyMaxSubjectSize=200
 emailProxyRecipientWhitelist=psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org
 # these restrictions have been implemented to prevent spammers.
 
-gdpr.enable=true
+gdpr.allowAccountDeletion=true

--- a/console/src/test/resources/console.properties
+++ b/console/src/test/resources/console.properties
@@ -108,4 +108,4 @@ emailProxyMaxSubjectSize=200
 emailProxyRecipientWhitelist=psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org
 # these restrictions have been implemented to prevent spammers.
 
-gdpr.enable=true
+gdpr.allowAccountDeletion=true


### PR DESCRIPTION
Following previous PR (https://github.com/georchestra/georchestra/pull/2806), even if `gdpr.enable` - which has been renamed to `gdpr.allowAccountDeletion` - is set to false.

See https://github.com/georchestra/georchestra/issues/2795#issuecomment-694831154

georchestra/datadir already updated.

Tests:

* runtime
* utest, it ok
