### PR TITLE
Fix tootlips for SASL setup

### DIFF
--- a/console/src/main/webapp/manager/app/templates/userForm.tpl.html
+++ b/console/src/main/webapp/manager/app/templates/userForm.tpl.html
@@ -138,9 +138,10 @@
       </div>
       <div ng-if="platformInfos.saslEnabled">
         <div class="form-group form-group-sm" ng-if="model.$promise">
-          <label class="col-sm-4" for="saslUser" data-toggle="tooltip" title="{{'sasl.tooltip' | translate}}">
+          <label class="col-sm-4" for="saslUser">
             <span translate>sasl.remote.user</span>
             {{ platformInfos.saslServer }}
+            <span title="{{'sasl.tooltip' | translate}}" class="glyphicon glyphicon-info-sign"></span>
           </label>
           <div class="col-sm-8">
             <input id="saslUser" type="text" class="form-control" ng-model="model.saslUser">


### PR DESCRIPTION
We had setup a broken tootlips for SASL setup in console. The tooltips
explain the logic when adding/removing SASL user from the user editing
form.

To test this feature you only need to set `saslEnabled=true` in the
datadir. No full-SASL setup needed.

