### PR TITLE
atlas - restoring compatible dependencies (#3167)

### DIFF
--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -12,6 +12,9 @@
     <url>http://www.georchestra.org</url>
     <properties>
         <context.name>atlas</context.name>
+        <!-- override geotools & json versions to ensure compatibility with print-lib 3.5.0 -->
+        <gt.version>14.3</gt.version>
+        <json.version>20080701</json.version>
     </properties>
     <dependencies>
         <!-- Camel dependencies -->


### PR DESCRIPTION
See #3167 for the motivation.

Tests: compile / runtime in a minimal docker compo, hitting http://<ip>:8080/atlas/print/capabilities.json until it's working back again.

Note: see comments in the issue, I first tried to upgrade the libraries to more recent versions, but this lead to other issues that have to be addressed more thoroughly, and we are in a hurry with the release right now.

Note2: a more recent version of the mapfish/print-lib should allow us to remove all the explicit dependencies against geotools and so on.

