### PR TITLE
atlas - overriding guava version (#3167)

### DIFF
--- a/atlas/pom.xml
+++ b/atlas/pom.xml
@@ -12,9 +12,10 @@
     <url>http://www.georchestra.org</url>
     <properties>
         <context.name>atlas</context.name>
-        <!-- override geotools & json versions to ensure compatibility with print-lib 3.5.0 -->
+        <!-- override versions to ensure compatibility with print-lib 3.5.0 -->
         <gt.version>14.3</gt.version>
         <json.version>20080701</json.version>
+        <guava.version>16.0.1</guava.version>
     </properties>
     <dependencies>
         <!-- Camel dependencies -->


### PR DESCRIPTION
See previous PR (#3168) as well as https://github.com/georchestra/georchestra/issues/3167#issuecomment-705013425.

#3168 was fixing the webapp bootstrap, This one fixes completely the behaviour at runtime.

Tested: runtime directly on the rennes-métropole infrastructure, I was able to generate a PDF with 3 features. I could not receive it by mail and had to grab it directly in the tmp dir of the container but because of a SMTP policy issue (not being allowed to send mails to people outside of Rennes-Métropole it seems).

 