### PR TITLE
console - fixing mail templates logic (#3173)

### DIFF
--- a/console/src/main/java/org/georchestra/console/mailservice/Email.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/Email.java
@@ -34,6 +34,8 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.servlet.ServletContext;
 import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,6 +59,7 @@ public class Email {
     private String publicUrl;
     private String instanceName;
     private GeorchestraConfiguration georConfig;
+    private ServletContext servletContext;
 
     public Email(List<String> recipients, String emailSubject, String smtpHost, int smtpPort, boolean emailHtml,
             String replyTo, String from, String bodyEncoding, String subjectEncoding, String templateEncoding,
@@ -76,9 +79,9 @@ public class Email {
         this.georConfig = georConfig;
         this.publicUrl = publicUrl;
         this.instanceName = instanceName;
-
+        this.servletContext = servletContext;
         // Load template from filesystem
-        this.emailBody = this.loadBody(servletContext.getRealPath(fileTemplate));
+        this.emailBody = this.loadBody(fileTemplate);
     }
 
     public void set(String key, String value) {
@@ -97,7 +100,10 @@ public class Email {
     /**
      * Loads the body template.
      *
-     * @param fileName path + file name
+     * if available, the templates will be resolved from the geOrchestra datadir,
+     * and if not defined, a one inside the webapp will be used.
+     *
+     * @param fileName the filename to open, without the path to it.
      * @return
      * @throws IOException
      */
@@ -105,20 +111,22 @@ public class Email {
 
         if ((georConfig != null) && (georConfig.activated())) {
             try {
-                String basename = FilenameUtils.getName(fileName);
-                return FileUtils.readFileToString(new File(georConfig.getContextDataDir(), "templates/" + basename),
-                        templateEncoding);
+                File fileTmpl = Paths.get(georConfig.getContextDataDir(), "templates", fileName).toFile();
+
+                return FileUtils.readFileToString(fileTmpl, templateEncoding);
             } catch (IOException e) {
-                LOG.error(
-                        "Unable to get the template from geOrchestra datadir. Falling back on the default template provided by the webapp.",
-                        e);
+                LOG.error("Unable to get the template from geOrchestra datadir. "
+                        + "Falling back on the default template provided by the webapp.", e);
             }
         }
+        /** Trying to resolve the templates from inside the webapp */
+        String tmplFromWebapp = this.servletContext
+                .getRealPath(Paths.get("/WEB-INF", "templates", fileName).toString());
 
         BufferedReader reader = null;
         String body = null;
         try {
-            body = FileUtils.readFileToString(new File(fileName), templateEncoding);
+            body = FileUtils.readFileToString(new File(tmplFromWebapp), templateEncoding);
         } catch (Exception e) {
             LOG.error(e);
         } finally {

--- a/console/src/main/java/org/georchestra/console/mailservice/Email.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/Email.java
@@ -119,23 +119,15 @@ public class Email {
                         + "Falling back on the default template provided by the webapp.", e);
             }
         }
-        /** Trying to resolve the templates from inside the webapp */
+        /* Trying to resolve the templates from inside the webapp */
         String tmplFromWebapp = this.servletContext
                 .getRealPath(Paths.get("/WEB-INF", "templates", fileName).toString());
 
-        BufferedReader reader = null;
         String body = null;
         try {
             body = FileUtils.readFileToString(new File(tmplFromWebapp), templateEncoding);
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOG.error(e);
-        } finally {
-            try {
-                if (reader != null)
-                    reader.close();
-            } catch (IOException e) {
-                LOG.error(e);
-            }
         }
         return body;
     }

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -72,14 +72,18 @@ public class EmailFactory {
 
     public void sendAccountWasCreatedEmail(ServletContext servletContext, String recipient, String userName, String uid)
             throws MessagingException {
+        sendAccountWasCreatedEmail(servletContext, recipient, userName, uid, true);
+    }
+
+    public void sendAccountWasCreatedEmail(ServletContext servletContext, String recipient, String userName, String uid,
+            boolean reallySend) throws MessagingException {
         Email email = new Email(singletonList(recipient), this.accountWasCreatedEmailSubject, this.smtpHost,
                 this.smtpPort, this.emailHtml, this.replyTo, this.from, this.bodyEncoding, this.subjectEncoding,
                 this.templateEncoding, this.accountWasCreatedEmailFile, servletContext, this.georConfig, this.publicUrl,
                 this.instanceName);
         email.set("name", userName);
         email.set("uid", uid);
-        email.send();
-
+        email.send(reallySend);
     }
 
     /**
@@ -87,6 +91,11 @@ public class EmailFactory {
      */
     public void sendAccountCreationInProcessEmail(ServletContext servletContext, String recipient, String userName,
             String uid) throws MessagingException {
+        sendAccountCreationInProcessEmail(servletContext, recipient, userName, uid, true);
+    }
+
+    public void sendAccountCreationInProcessEmail(ServletContext servletContext, String recipient, String userName,
+            String uid, boolean reallySend) throws MessagingException {
 
         Email email = new Email(singletonList(recipient), this.accountCreationInProcessEmailSubject, this.smtpHost,
                 this.smtpPort, this.emailHtml, this.replyTo, this.from, this.bodyEncoding, this.subjectEncoding,
@@ -94,7 +103,7 @@ public class EmailFactory {
                 this.publicUrl, this.instanceName);
         email.set("name", userName);
         email.set("uid", uid);
-        email.send();
+        email.send(reallySend);
     }
 
     /**
@@ -102,6 +111,12 @@ public class EmailFactory {
      */
     public void sendNewAccountRequiresModerationEmail(ServletContext servletContext, List<String> recipients,
             String userName, String uid, String userEmail, String userOrg) throws MessagingException {
+        sendNewAccountRequiresModerationEmail(servletContext, recipients, userName, uid, userEmail, userOrg, true);
+    }
+
+    public void sendNewAccountRequiresModerationEmail(ServletContext servletContext, List<String> recipients,
+            String userName, String uid, String userEmail, String userOrg, boolean reallySend)
+            throws MessagingException {
 
         Email email = new Email(recipients, this.newAccountRequiresModerationEmailSubject, this.smtpHost, this.smtpPort,
                 this.emailHtml, userEmail, // Reply-to
@@ -113,22 +128,32 @@ public class EmailFactory {
         email.set("uid", uid);
         email.set("email", userEmail);
         email.set("org", userOrg);
-        email.send();
+        email.send(reallySend);
     }
 
     public void sendChangePasswordEmail(ServletContext servletContext, String recipient, String userName, String uid,
             String url) throws MessagingException {
+        sendChangePasswordEmail(servletContext, recipient, userName, uid, url, true);
+    }
+
+    public void sendChangePasswordEmail(ServletContext servletContext, String recipient, String userName, String uid,
+            String url, boolean reallySend) throws MessagingException {
         Email email = new Email(singletonList(recipient), this.changePasswordEmailSubject, this.smtpHost, this.smtpPort,
                 this.emailHtml, this.replyTo, this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
                 this.changePasswordEmailFile, servletContext, this.georConfig, this.publicUrl, this.instanceName);
         email.set("name", userName);
         email.set("uid", uid);
         email.set("url", url);
-        email.send();
+        email.send(reallySend);
     }
 
     public void sendAccountUidRenamedEmail(ServletContext servletContext, String recipient, String userName, String uid)
             throws MessagingException {
+        sendAccountUidRenamedEmail(servletContext, recipient, userName, uid, true);
+    }
+
+    public void sendAccountUidRenamedEmail(ServletContext servletContext, String recipient, String userName, String uid,
+            boolean reallySend) throws MessagingException {
 
         Email email = new Email(singletonList(recipient), this.accountUidRenamedEmailSubject, this.smtpHost,
                 this.smtpPort, this.emailHtml, this.replyTo, this.from, this.bodyEncoding, this.subjectEncoding,
@@ -136,11 +161,16 @@ public class EmailFactory {
                 this.instanceName);
         email.set("name", userName);
         email.set("uid", uid);
-        email.send();
+        email.send(reallySend);
     }
 
     public void sendNewAccountNotificationEmail(ServletContext servletContext, List<String> recipients, String userName,
             String uid, String userEmail, String userOrg) throws MessagingException {
+        sendNewAccountNotificationEmail(servletContext, recipients, userName, uid, userEmail, userOrg, true);
+    }
+
+    public void sendNewAccountNotificationEmail(ServletContext servletContext, List<String> recipients, String userName,
+            String uid, String userEmail, String userOrg, boolean reallySend) throws MessagingException {
 
         Email email = new Email(recipients, this.newAccountNotificationEmailSubject, this.smtpHost, this.smtpPort,
                 this.emailHtml, userEmail, // Reply-to
@@ -154,7 +184,7 @@ public class EmailFactory {
             userOrg = "";
         }
         email.set("org", userOrg);
-        email.send();
+        email.send(reallySend);
     }
 
     public MimeMessage createEmptyMessage() {

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -260,17 +260,17 @@
     <property name="bodyEncoding" value="UTF-8"/>
     <property name="subjectEncoding" value="UTF-8"/>
     <property name="templateEncoding" value="${templateEncoding:UTF-8}"/>
-    <property name="accountWasCreatedEmailFile" value="/WEB-INF/templates/newaccount-was-created-template.txt"/>
+    <property name="accountWasCreatedEmailFile" value="newaccount-was-created-template.txt"/>
     <property name="accountWasCreatedEmailSubject" value="${subject.account.created:[${instanceName}] Your account has been created}"/>
-    <property name="accountCreationInProcessEmailFile" value="/WEB-INF/templates/account-creation-in-progress-template.txt"/>
+    <property name="accountCreationInProcessEmailFile" value="account-creation-in-progress-template.txt"/>
     <property name="accountCreationInProcessEmailSubject" value="${subject.account.in.process:[${instanceName}] Your new account is waiting for validation}"/>
-    <property name="newAccountRequiresModerationEmailFile" value="/WEB-INF/templates/newaccount-requires-moderation-template.txt"/>
+    <property name="newAccountRequiresModerationEmailFile" value="newaccount-requires-moderation-template.txt"/>
     <property name="newAccountRequiresModerationEmailSubject" value="${subject.requires.moderation:[${instanceName}] New account waiting for validation}"/>
-    <property name="changePasswordEmailFile" value="/WEB-INF/templates/changepassword-email-template.txt"/>
+    <property name="changePasswordEmailFile" value="changepassword-email-template.txt"/>
     <property name="changePasswordEmailSubject" value="${subject.change.password:[${instanceName}] Update your password}"/>
-    <property name="accountUidRenamedEmailFile" value="/WEB-INF/templates/account-uid-renamed.txt" />
+    <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="${subject.account.uid.renamed:[${instanceName}] New login for your account}" />
-    <property name="newAccountNotificationEmailFile" value="/WEB-INF/templates/newaccount-notification-template.txt"/>
+    <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>
     <property name="newAccountNotificationEmailSubject" value="${subject.new.account.notification:[${instanceName}] New account created}"/>
     <property name="publicUrl" value="${scheme}://${domainName}"/>
     <property name="instanceName" value="${instanceName}"/>

--- a/console/src/main/webapp/WEB-INF/templates/README.md
+++ b/console/src/main/webapp/WEB-INF/templates/README.md
@@ -1,0 +1,22 @@
+# Console email templates
+
+This folder hosts email templates which are sent to users and platform administrators at various times.
+
+Either account creation is moderated or it is not.
+This is set with the `moderatedSignup` variable from the [console.properties](/console/console.properties) file, which defaults to `true`.
+
+When account creation is moderated:
+ * [newaccount-requires-moderation-template.txt](newaccount-requires-moderation-template.txt) is sent to members of the SUPERUSER role and also to users holding a delegation (if any) for the organisation that was declared by the new user.
+ * [account-creation-in-progress-template.txt](account-creation-in-progress-template.txt) is sent to the requesting user (this is an ACK mail, the account is pending moderation).
+ * [newaccount-was-created-template.txt](newaccount-was-created-template.txt) is sent to the requesting user upon account validation, his account is now active.
+
+When account creation is not moderated:
+ * [newaccount-notification-template.txt](newaccount-notification-template.txt) is sent to members of the SUPERUSER role and also to users holding a delegation (if any) for the organisation that was declared by the new user.
+ * [newaccount-was-created-template.txt](newaccount-was-created-template.txt) is sent to the requesting user (this is a welcoming email).
+
+In both cases, it's the responsibility of the platform admin to inform the user that his account was granted roles.
+
+[account-uid-renamed.txt](account-uid-renamed.txt) is sent to the user whose login have been modified by a platform admin.
+
+[changepassword-email-template.txt](changepassword-email-template.txt) is sent when the user requests a new password with the "I lost my password" link from the CAS login page.
+It is also sent to the user when the administrator triggers a password regeneration from the admin console.

--- a/console/src/main/webapp/WEB-INF/templates/account-creation-in-progress-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/account-creation-in-progress-template.txt
@@ -1,0 +1,8 @@
+Dear {name}, 
+
+Your request for a new account will be processed very soon.
+
+Your login is: {uid}
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/main/webapp/WEB-INF/templates/account-uid-renamed.txt
+++ b/console/src/main/webapp/WEB-INF/templates/account-uid-renamed.txt
@@ -1,0 +1,9 @@
+Dear {name}, 
+
+This message is intended to let you know that your identifier on the
+{instanceName} platform has been modified.
+
+Your new login is now: {uid}
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/main/webapp/WEB-INF/templates/changepassword-email-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/changepassword-email-template.txt
@@ -1,0 +1,12 @@
+Dear {name},
+
+You (or someone else) asked to reset your password on {publicUrl}/.
+If you did not request any password update, just ignore this e-mail, you're safe.
+
+To set a new password for your user ({uid}), go to {url}.
+You will then be able to connect to the platform.
+
+Caution: this e-mail is personal, don't forward it.
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/main/webapp/WEB-INF/templates/newaccount-notification-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/newaccount-notification-template.txt
@@ -1,0 +1,11 @@
+Dear admin,
+
+A new user signed up on {publicUrl}/ !
+
+User name: {name}
+User email: {email}
+User ID: {uid}
+User Organization: {org}
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/main/webapp/WEB-INF/templates/newaccount-requires-moderation-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/newaccount-requires-moderation-template.txt
@@ -1,0 +1,12 @@
+Dear admin,
+
+A new account has been created on {publicUrl}/ and is waiting for validation.
+
+User name: {name}
+User ID: {uid}
+User Organization: {org}
+
+Visit {publicUrl}/console/manager/browse/pending/users?login to review the pending users.
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/main/webapp/WEB-INF/templates/newaccount-was-created-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/newaccount-was-created-template.txt
@@ -1,0 +1,10 @@
+Dear {name},
+
+Your account on {publicUrl}/ has been successfully created !
+Visit {publicUrl}/cas/login to login with your identifier "{uid}" and your password.
+
+Have fun with geOrchestra,
+
+Your platform administrator
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/test/java/org/georchestra/console/integration/EmailFactoryIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/EmailFactoryIT.java
@@ -1,0 +1,71 @@
+package org.georchestra.console.integration;
+
+import com.google.common.io.Files;
+import org.apache.commons.io.FileUtils;
+import org.georchestra.commons.configuration.GeorchestraConfiguration;
+import org.georchestra.console.mailservice.EmailFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.mail.MessagingException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = { "classpath:/mail-factory-test.xml" })
+public class EmailFactoryIT {
+
+    @Autowired
+    private EmailFactory toTest;
+
+    @Autowired
+    private GeorchestraConfiguration georConfig;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Test
+    public void testObjectInstantiation() {
+        assertTrue(toTest != null);
+    }
+
+    @Test
+    public void testNoGeorchestraDatadir() throws MessagingException {
+        toTest.sendAccountWasCreatedEmail(wac.getServletContext(), "root@localhost", "recipient@localhost", "pmauduit",
+                false);
+    }
+
+    private File createGeorchestraDatadir() throws IOException {
+        File georDatadir = Files.createTempDir();
+        File consoleDir = Paths.get(georDatadir.getAbsolutePath(), "console", "templates").toFile();
+        FileUtils.forceMkdir(consoleDir);
+        String path = wac.getServletContext().getRealPath("/WEB-INF/templates");
+        FileUtils.copyDirectory(new File(path), consoleDir);
+        return georDatadir;
+    }
+
+    @Test
+    public void testWithGeorchestraDatadir() throws MessagingException, IOException {
+        File georDataDir = createGeorchestraDatadir();
+        System.setProperty("georchestra.datadir", georDataDir.getAbsolutePath());
+        GeorchestraConfiguration withGeorDatadir = new GeorchestraConfiguration("console");
+        toTest.setGeorConfig(withGeorDatadir);
+
+        toTest.sendAccountWasCreatedEmail(wac.getServletContext(), "root@localhost", "recipient@localhost", "pmauduit",
+                false);
+
+        System.clearProperty("georchestra.datadir");
+        toTest.setGeorConfig(georConfig);
+    }
+
+}

--- a/console/src/test/java/org/georchestra/console/mailservice/EmailTest.java
+++ b/console/src/test/java/org/georchestra/console/mailservice/EmailTest.java
@@ -59,15 +59,15 @@ public class EmailTest {
         this.georchestraConfiguration = Mockito.mock(GeorchestraConfiguration.class);
         this.publicUrl = "http://localhost:8080";
         this.instanceName = "geOrchestra";
-        Mockito.when(this.servletContext.getRealPath(this.simpleTemplate))
+        Mockito.when(this.servletContext.getRealPath("/WEB-INF/templates/" + this.simpleTemplate))
                 .thenReturn(this.getClass().getClassLoader().getResource(this.simpleTemplate).getPath());
-        Mockito.when(this.servletContext.getRealPath(this.htmlTemplate))
+        Mockito.when(this.servletContext.getRealPath("/WEB-INF/templates/" + this.htmlTemplate))
                 .thenReturn(this.getClass().getClassLoader().getResource(this.htmlTemplate).getPath());
-        Mockito.when(this.servletContext.getRealPath(this.utf8Template))
+        Mockito.when(this.servletContext.getRealPath("/WEB-INF/templates/" + this.utf8Template))
                 .thenReturn(this.getClass().getClassLoader().getResource(this.utf8Template).getPath());
-        Mockito.when(this.servletContext.getRealPath(this.isoTemplate))
+        Mockito.when(this.servletContext.getRealPath("/WEB-INF/templates/" + this.isoTemplate))
                 .thenReturn(this.getClass().getClassLoader().getResource(this.isoTemplate).getPath());
-        Mockito.when(this.servletContext.getRealPath(this.replaceTemplate))
+        Mockito.when(this.servletContext.getRealPath("/WEB-INF/templates/" + this.replaceTemplate))
                 .thenReturn(this.getClass().getClassLoader().getResource(this.replaceTemplate).getPath());
     }
 

--- a/console/src/test/resources/mail-factory-test.xml
+++ b/console/src/test/resources/mail-factory-test.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <!-- Email Factory configuration -->
+  <bean id="emailFactory" class="org.georchestra.console.mailservice.EmailFactory" >
+    <property name="smtpHost" value="localhost"/>
+    <property name="smtpPort" value="25"/>
+    <property name="emailHtml" value="false"/>
+    <property name="replyTo" value="pmt@example.org"/>
+    <property name="from" value="admin@example.org"/>
+    <property name="bodyEncoding" value="UTF-8"/>
+    <property name="subjectEncoding" value="UTF-8"/>
+    <property name="templateEncoding" value="UTF-8"/>
+    <property name="accountWasCreatedEmailFile" value="newaccount-was-created-template.txt"/>
+    <property name="accountWasCreatedEmailSubject" value="[georTest] Your account has been created"/>
+    <property name="accountCreationInProcessEmailFile" value="account-creation-in-progress-template.txt"/>
+    <property name="accountCreationInProcessEmailSubject" value="[georTest] Your new account is waiting for validation"/>
+    <property name="newAccountRequiresModerationEmailFile" value="newaccount-requires-moderation-template.txt"/>
+    <property name="newAccountRequiresModerationEmailSubject" value="[georTest]] New account waiting for validation"/>
+    <property name="changePasswordEmailFile" value="changepassword-email-template.txt"/>
+    <property name="changePasswordEmailSubject" value="[georTest] Update your password}"/>
+    <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
+    <property name="accountUidRenamedEmailSubject" value="[georTest] New login for your account" />
+    <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>
+    <property name="newAccountNotificationEmailSubject" value="[georTest]] New account created"/>
+    <property name="publicUrl" value="https://georchestra.mydomain.org"/>
+    <property name="instanceName" value="georchestra test"/>
+  </bean>
+
+  <bean id="georchestraConfiguration" class="org.georchestra.commons.configuration.GeorchestraConfiguration">
+    <constructor-arg value="console"/>
+  </bean>
+
+</beans>

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -249,17 +249,17 @@
     <property name="bodyEncoding" value="UTF-8"/>
     <property name="subjectEncoding" value="UTF-8"/>
     <property name="templateEncoding" value="${templateEncoding:UTF-8}"/>
-    <property name="accountWasCreatedEmailFile" value="/WEB-INF/templates/newaccount-was-created-template.txt"/>
+    <property name="accountWasCreatedEmailFile" value="newaccount-was-created-template.txt"/>
     <property name="accountWasCreatedEmailSubject" value="${subject.account.created:[${instanceName}] Your account has been created}"/>
-    <property name="accountCreationInProcessEmailFile" value="/WEB-INF/templates/account-creation-in-progress-template.txt"/>
+    <property name="accountCreationInProcessEmailFile" value="account-creation-in-progress-template.txt"/>
     <property name="accountCreationInProcessEmailSubject" value="${subject.account.in.process:[${instanceName}] Your new account is waiting for validation}"/>
-    <property name="newAccountRequiresModerationEmailFile" value="/WEB-INF/templates/newaccount-requires-moderation-template.txt"/>
+    <property name="newAccountRequiresModerationEmailFile" value="newaccount-requires-moderation-template.txt"/>
     <property name="newAccountRequiresModerationEmailSubject" value="${subject.requires.moderation:[${instanceName}] New account waiting for validation}"/>
-    <property name="changePasswordEmailFile" value="/WEB-INF/templates/changepassword-email-template.txt"/>
+    <property name="changePasswordEmailFile" value="changepassword-email-template.txt"/>
     <property name="changePasswordEmailSubject" value="${subject.change.password:[${instanceName}] Update your password}"/>
-    <property name="accountUidRenamedEmailFile" value="/WEB-INF/templates/account-uid-renamed.txt" />
+    <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="${subject.account.uid.renamed:[${instanceName}] New login for your account}" />
-    <property name="newAccountNotificationEmailFile" value="/WEB-INF/templates/newaccount-notification-template.txt"/>
+    <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>
     <property name="newAccountNotificationEmailSubject" value="${subject.new.account.notification:[${instanceName}] New account created}"/>
     <property name="publicUrl" value="${scheme}://${domainName}"/>
     <property name="instanceName" value="${instanceName}"/>


### PR DESCRIPTION
Note: I reintroduced the templates inside the webapp. I know that the `georchestra.datadir` is now mandatory, but I dislike the fact that the webapps cannot run by themselves, and require external resources that they could provide.

* tests: added some basic integration tests for the EmailFactory class,
  that still could be improved.
* UT ok
* IT ok