### PR TITLE
[Console] Check if user have an org. Orgs are not mandatory in georchestra

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -154,7 +154,10 @@ public class EditUserDetailsFormController {
         formBean.setFacsimile(account.getFacsimile());
         formBean.setDescription(account.getDescription());
         formBean.setPostalAddress(account.getPostalAddress());
-        formBean.setOrg(orgsDao.findByCommonName(account.getOrg()).getName());
+        String org = account.getOrg();
+        if (!org.equals("")) {
+            formBean.setOrg(orgsDao.findByCommonName(org).getName());
+        }
 
         return formBean;
     }

--- a/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
@@ -157,7 +157,7 @@ public class EditUserDetailsFormControllerTest {
     @Test
     public void testSetupFormNoOrg() throws Exception {
         request.addHeader("sec-username", "mtesterNoOrg");
-        Mockito.when(dao.findByUID(Mockito.anyString())).thenReturn(this.mtesterAccount);
+        Mockito.when(dao.findByUID(Mockito.anyString())).thenReturn(this.mtesterAccountNoOrg);
 
         String ret = ctrl.setupForm(request, response, model);
 
@@ -167,7 +167,7 @@ public class EditUserDetailsFormControllerTest {
     @Test
     public void testEditNoOrg() throws Exception {
         request.addHeader("sec-username", "mtesterNoOrg");
-
+        Mockito.when(dao.findByUID(Mockito.anyString())).thenReturn(this.mtesterAccountNoOrg);
         String ret = ctrl.edit(request, response, model, formBean, resultErrors, sessionStatus);
 
         assertEquals("editUserDetailsForm", ret);


### PR DESCRIPTION
This is a quick fix in order to get rid of NPE, but a nice refactor could be to add _explicitly_ in the type the optional nature of the Org. like `Optional<String>` in front of all `getOrg()` method.


linked to #3184 cc @jusabatier 