### PR TITLE
Spring authentication based on pre-authenticated georchestra headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docker-build-analytics: build-deps docker-pull-jetty
 docker-build-mapfishapp: build-deps docker-pull-jetty
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl mapfishapp
 
-docker-build-datafeeder: build-deps 
+docker-build-datafeeder: 
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl datafeeder
 
 docker-build-georchestra: build-deps docker-pull-jetty docker-build-database docker-build-ldap docker-build-geoserver docker-build-geowebcache docker-build-gn3

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -21,6 +21,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -34,6 +34,14 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- test scoped for spring boot's (1.5.19.RELEASE) TestRestTemplate pass request headers (sec-* headers ignored with 
+        default java client) -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${project.artifactId}-${server}</finalName>
@@ -71,7 +79,8 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
           <plugin>
-            <!-- REVISIT: why don't have the datadir project as a submodule at the project's root folder instead of checking it out on each service module? -->
+            <!-- REVISIT: why don't have the datadir project as a submodule at the project's root folder instead of checking 
+              it out on each service module? -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-scm-plugin</artifactId>
             <version>1.11.2</version>

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfiguration.java
@@ -27,7 +27,8 @@ public class GeorchestraSecurityProxyAuthenticationConfiguration extends WebSecu
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)//
                 .and()//
                 .csrf().disable()//
-                .authorizeRequests().antMatchers("/import/test").permitAll().and().authorizeRequests()//
+                // .authorizeRequests().antMatchers("/**").permitAll().and()//
+                .authorizeRequests()//
                 .anyRequest()//
                 .authenticated()//
                 .and()//

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfiguration.java
@@ -1,0 +1,36 @@
+package org.georchestra.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+@EnableWebSecurity
+public class GeorchestraSecurityProxyAuthenticationConfiguration extends WebSecurityConfigurerAdapter {
+
+    public @Bean GeorchestraSecurityProxyAuthenticationManager georchestraSecurityProxyAuthenticationManager() {
+        return new GeorchestraSecurityProxyAuthenticationManager();
+    }
+
+    public @Bean GeorchestraSecurityProxyAuthenticationFilter georchestraSecurityProxyAuthenticationFilter() {
+        GeorchestraSecurityProxyAuthenticationFilter filter = new GeorchestraSecurityProxyAuthenticationFilter();
+        filter.setAuthenticationManager(georchestraSecurityProxyAuthenticationManager());
+        return filter;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.sessionManagement()//
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)//
+                .and()//
+                .csrf().disable()//
+                .authorizeRequests().antMatchers("/import/test").permitAll().and().authorizeRequests()//
+                .anyRequest()//
+                .authenticated()//
+                .and()//
+                .addFilter(georchestraSecurityProxyAuthenticationFilter());
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package org.georchestra.config.security;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GeorchestraSecurityProxyAuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
+
+    @Override
+    protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+        String principal = request.getHeader("sec-username");
+        return principal;
+    }
+
+    @Override
+    protected List<String> getPreAuthenticatedCredentials(HttpServletRequest request) {
+        String rolesHeader = request.getHeader("sec-roles");
+        if (StringUtils.isEmpty(rolesHeader)) {
+            return Collections.emptyList();
+        }
+        String[] roles = rolesHeader.split(";");
+        List<String> credentials = Arrays.stream(roles).filter(StringUtils::hasText).collect(Collectors.toList());
+        log.info("roles: " + credentials);
+        return credentials;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationManager.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationManager.java
@@ -1,0 +1,34 @@
+package org.georchestra.config.security;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+public class GeorchestraSecurityProxyAuthenticationManager implements AuthenticationManager {
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if (authentication instanceof PreAuthenticatedAuthenticationToken) {
+            @SuppressWarnings("unchecked")
+            List<String> roles = (List<String>) authentication.getCredentials();
+            Object principal = authentication.getPrincipal();
+            if (roles == null || roles.isEmpty()) {
+                throw new AuthenticationCredentialsNotFoundException("No roles given for " + principal);
+            }
+            List<GrantedAuthority> authorities = roles.stream().map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+            PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(principal, roles,
+                    authorities);
+            auth.setAuthenticated(true);
+            return auth;
+        }
+        return authentication;
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraUserDetails.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraUserDetails.java
@@ -1,0 +1,112 @@
+package org.georchestra.config.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@NoArgsConstructor
+public class GeorchestraUserDetails implements UserDetails {
+    private static final long serialVersionUID = -8672954222635750682L;
+
+    /** Provided by request header {@code sec-username} */
+    private @NonNull String username;
+
+    /** Provided by request header {@code sec-roles} */
+    private @NonNull List<String> roles;
+
+    /** Provided by request header {@code sec-email} */
+    private @Getter String email;
+
+    /** Provided by request header {@code sec-firstname} */
+    private @Getter String firstName;
+
+    /** Provided by request header {@code sec-lastname} */
+    private @Getter String lastName;
+
+    /** Provided by request header {@code sec-org} */
+    private @Getter String organization;
+
+    /** Provided by request header {@code sec-orgname} */
+    private @Getter String organizationName;
+
+    /** {@code true} if request header {@code sec-username} is {@code null} */
+    private boolean anonymous;
+
+    public GeorchestraUserDetails(@NonNull String userName, @NonNull List<String> roles, String email, String firstName,
+            String lastName, String organization, String organizationName, boolean anonymous) {
+        this.anonymous = anonymous;
+        this.username = userName;
+        this.roles = Collections.unmodifiableList(new ArrayList<>(roles));
+        this.email = email;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.organization = organization;
+        this.organizationName = organizationName;
+    }
+
+    /**
+     * @return user name as given by request header {@code sec-username}
+     */
+    public @Override String getUsername() {
+        return username;
+    }
+
+    /**
+     * @return role names as given by request header {@code sec-roles} wrapped in
+     *         {@link SimpleGrantedAuthority} instances
+     */
+    @JsonIgnore
+    public @Override Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    /**
+     * @return {@code null}
+     */
+    public @Override String getPassword() {
+        return null;
+    }
+
+    /**
+     * @return {@code true}
+     */
+    public @Override boolean isAccountNonExpired() {
+        return true;
+    }
+
+    /**
+     * @return {@code true}
+     */
+    public @Override boolean isAccountNonLocked() {
+        return true;
+    }
+
+    /**
+     * @return {@code true}
+     */
+    public @Override boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    /**
+     * @return {@code true}
+     */
+    public @Override boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataFeederApiConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataFeederApiConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableWebMvc
 @ComponentScan
 @EnableGlobalMethodSecurity(//
-        jsr250Enabled = true // enable @RolesAlloed annotation in API methods
+        jsr250Enabled = true // enable @RolesAllowed annotation in API methods
 )
 public @Configuration class DataFeederApiConfiguration extends GlobalMethodSecurityConfiguration {
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataFeederApiConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataFeederApiConfiguration.java
@@ -20,10 +20,15 @@ package org.georchestra.datafeeder.api;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @EnableWebMvc
 @ComponentScan
-public @Configuration class DataFeederApiConfiguration {
+@EnableGlobalMethodSecurity(//
+        jsr250Enabled = true // enable @RolesAlloed annotation in API methods
+)
+public @Configuration class DataFeederApiConfiguration extends GlobalMethodSecurityConfiguration {
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataImportWizardController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataImportWizardController.java
@@ -18,16 +18,44 @@
  */
 package org.georchestra.datafeeder.api;
 
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.annotation.security.RolesAllowed;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.request.NativeWebRequest;
 
 @RequestMapping(path = "/import")
 public @Controller class DataImportWizardController {
 
+    private @Autowired NativeWebRequest currentRequest;
+
     @GetMapping("/test")
     public ResponseEntity<String> test() {
-        return ResponseEntity.ok("test OK");
+        return ResponseEntity.ok("annonymous test OK. " + buildHeaders());
+    }
+
+    @GetMapping("/test/admin")
+    @RolesAllowed("ROLE_ADMINISTRATOR")
+    public ResponseEntity<String> testAdmin() {
+        return ResponseEntity.ok("admin role test OK. " + buildHeaders());
+    }
+
+    @GetMapping("/test/user")
+    @RolesAllowed("ROLE_USER")
+    public ResponseEntity<String> testUser() {
+        return ResponseEntity.ok("user role test OK. " + buildHeaders());
+    }
+
+    private String buildHeaders() {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(currentRequest.getHeaderNames(), 0), false)
+                .map(name -> String.format("%s=%s", name, currentRequest.getHeader(name)))
+                .collect(Collectors.joining(", "));
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataImportWizardController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataImportWizardController.java
@@ -38,7 +38,7 @@ public @Controller class DataImportWizardController {
 
     @GetMapping("/test")
     public ResponseEntity<String> test() {
-        return ResponseEntity.ok("annonymous test OK. " + buildHeaders());
+        return ResponseEntity.ok("anonymous test OK. " + buildHeaders());
     }
 
     @GetMapping("/test/admin")

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/CloudNativeGeonetworkIntegrationAutoConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/CloudNativeGeonetworkIntegrationAutoConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration
 @Profile("geonetwork")
-public class CloudNativeGeonetworkIntegrationConfiguration {
+public class CloudNativeGeonetworkIntegrationAutoConfiguration {
 
     public @PostConstruct void fail() {
         throw new ApplicationContextException("'geonetwork' profile auto-configuration not yet implemented");

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.georchestra.datafeeder.autoconf;
 
+import org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationConfiguration;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -15,8 +16,8 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration
 @Profile("georchestra")
-@Import(GeorchestraDatadirConfiguration.class)
-public class GeorchestraIntegrationConfiguration {
+@Import({ GeorchestraDatadirConfiguration.class, GeorchestraSecurityProxyAuthenticationConfiguration.class })
+public class GeorchestraIntegrationAutoConfiguration {
 
     @ConfigurationProperties
     public @Bean DataFeederConfigurationProperties configProperties() {

--- a/datafeeder/src/main/resources/META-INF/spring.factories
+++ b/datafeeder/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.georchestra.datafeeder.autoconf.GeorchestraIntegrationConfiguration,\
-org.georchestra.datafeeder.autoconf.CloudNativeGeonetworkIntegrationConfiguration
+org.georchestra.datafeeder.autoconf.GeorchestraIntegrationAutoConfiguration,\
+org.georchestra.datafeeder.autoconf.CloudNativeGeonetworkIntegrationAutoConfiguration

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -1,0 +1,128 @@
+package org.georchestra.config.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+
+import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Test suite for {@link GeorchestraSecurityProxyAuthenticationConfiguration},
+ * which shall be enabled through the {@code georchestra} spring profile
+ * 
+ * @see SecurityTestController
+ */
+@SpringBootTest(classes = DataFeederApiConfiguration.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "test" })
+public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
+
+    private @LocalServerPort int port;
+    private @Autowired TestRestTemplate template;
+
+    private String baseURI;
+
+    private HttpHeaders requestHeaders;
+
+    private ResponseEntity<GeorchestraUserDetails> response;
+
+    public @Before void before() {
+        baseURI = "http://localhost:" + port + "/test/security/georchestra";
+
+        requestHeaders = new HttpHeaders();
+        requestHeaders.set("sec-proxy", "true");
+        requestHeaders.set("sec-username", "testUserName");
+        requestHeaders.set("sec-email", "test@email.com");
+        requestHeaders.set("sec-firstname", "Test");
+        requestHeaders.set("sec-lastname", "Lastnametest");
+        requestHeaders.set("sec-org", "test-org");
+        requestHeaders.set("sec-orgname", "Test Organization");
+    }
+
+    public ResponseEntity<GeorchestraUserDetails> doGet(String relaitvePath) {
+        HttpHeaders headers = this.requestHeaders;
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String uri = baseURI + relaitvePath;
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers);
+        return template.exchange(uri, HttpMethod.GET, requestEntity, GeorchestraUserDetails.class);
+    }
+
+    public @Test void requestNotProxied() {
+        requestHeaders.clear();
+        response = doGet("/anonymous");
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    public @Test void testAnonymous() {
+        requestHeaders.remove("sec-username");
+        response = doGet("/anonymous");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        GeorchestraUserDetails authenticatedAs = response.getBody();
+        assertNotNull(authenticatedAs);
+        assertEquals("anonymousUser", authenticatedAs.getUsername());
+
+        response = doGet("/user");
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+
+        response = doGet("/admin");
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    public @Test void testUserRole() {
+        requestHeaders.set("sec-roles", "ROLE_USER");
+
+        response = doGet("/anonymous");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        response = doGet("/user");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        GeorchestraUserDetails authenticatedAs = response.getBody();
+        assertNotNull(authenticatedAs);
+        assertEquals("testUserName", authenticatedAs.getUsername());
+
+        response = doGet("/admin");
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+
+    }
+
+    public @Test void testAdministrator() {
+        requestHeaders.set("sec-roles", "ROLE_ADMINISTRATOR");
+
+        response = doGet("/anonymous");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        response = doGet("/user");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        response = doGet("/admin");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        GeorchestraUserDetails authenticatedAs = response.getBody();
+        assertNotNull(authenticatedAs);
+        assertEquals("testUserName", authenticatedAs.getUsername());
+    }
+
+}

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityTestConfiguration.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityTestConfiguration.java
@@ -1,0 +1,7 @@
+package org.georchestra.config.security;
+
+import org.springframework.context.annotation.Configuration;
+
+public @Configuration class GeorchestraSecurityTestConfiguration {
+
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/GeorchestraSecurityTestController.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/GeorchestraSecurityTestController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.api;
+
+import javax.annotation.security.RolesAllowed;
+
+import org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationConfigurationTest;
+import org.georchestra.config.security.GeorchestraUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ *
+ * @see GeorchestraSecurityProxyAuthenticationConfigurationTest
+ */
+@RequestMapping(path = "/test/security/georchestra")
+public @Controller class GeorchestraSecurityTestController {
+
+    @GetMapping("/anonymous")
+    @RolesAllowed({ "ROLE_ANONYMOUS", "ROLE_ADMINISTRATOR", "ROLE_USER" })
+    public ResponseEntity<GeorchestraUserDetails> testAnonymous() {
+        GeorchestraUserDetails user = getPrincipal();
+        return ResponseEntity.ok(user);
+    }
+
+    @GetMapping("/admin")
+    @RolesAllowed("ROLE_ADMINISTRATOR")
+    public ResponseEntity<GeorchestraUserDetails> testAdmin() {
+        GeorchestraUserDetails user = (GeorchestraUserDetails) getPrincipal();
+        return ResponseEntity.ok(user);
+    }
+
+    @GetMapping("/user")
+    @RolesAllowed({ "ROLE_USER", "ROLE_ADMINISTRATOR" })
+    public ResponseEntity<GeorchestraUserDetails> testUser() {
+        GeorchestraUserDetails user = (GeorchestraUserDetails) getPrincipal();
+        return ResponseEntity.ok(user);
+    }
+
+    private GeorchestraUserDetails getPrincipal() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return (GeorchestraUserDetails) authentication.getPrincipal();
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -17,14 +17,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
- * Test suite for {@link GeorchestraIntegrationConfiguration}, which shall be
- * enabled through the {@code georchestra} spring profile
+ * Test suite for {@link GeorchestraIntegrationAutoConfiguration}, which shall
+ * be enabled through the {@code georchestra} spring profile
  */
 @SpringBootTest(classes = BaseTestConfig.class)
 @EnableAutoConfiguration
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = { "georchestra", "test" })
-public class GeorchestraIntegrationConfigurationTest {
+public class GeorchestraIntegrationAutoConfigurationTest {
 
     private @Autowired ApplicationContext context;
 


### PR DESCRIPTION
Leverage pre-authenticated georchestra's "security proxy" request headers to implement a Spring authentication configuration.

Instead of checking for the request's `sec-user` and `sec-roles` manually on each api entry point, implement an authentication manager, filter, and configure them to set a regular spring authentication token.
Api methods can be annotated like `@RolesAllowed("ROLE_ADMIN")`, etc.