### PR TITLE
[console][fix][master] edit organization link, from user form

### DIFF
--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -188,7 +188,7 @@ var gdprAllowAccountDeletion = ${gdprAllowAccountDeletion};
       <legend>
         <s:message code="editUserDetailsForm.organisation"/> «{{org.name}}»
 				<a ng-if="isReferentOrSuperUser"
-					 href="/console/account/orgdetails"
+					 href="/console/account/orgdetails" target="_self"
 					 title="<s:message code="editUserDetailsForm.editOrg"/>"
 					 class="small pull-right" aria-label="<s:message code="editUserDetailsForm.editOrg"/>"
 				>


### PR DESCRIPTION
 (console/account/userdetails)

Link was followed in the browser's URL bar, but not actually loaded