### PR TITLE
datafeeder: WIP file upload

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -242,6 +242,10 @@ components:
         error:
           type: string
           description: short description of the error that prevents the dataset to be analysed
+        featureCount:
+          type: integer
+          format: int32
+          description: Number of features in the dataset
         sampleProperties:
           type: object
           additionalProperties: true
@@ -261,10 +265,11 @@ components:
       properties:
         srs:
           type: string
-          description: Coordinate Reference System's EPSG identifier 
+          description: Coordinate Reference System's EPSG identifier.
+                       Can be null if a matching reference system couldn't be found in the EPSG database. 
         WKT:
           type: string
-          description: Coordinate Reference System's Well Known Text representation
+          description: Coordinate Reference System's Well Known Text representation. Despite the 'srs' identifier being found or not, the WKT representation is still available.
     BoundingBox:
       type: object
       properties:

--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -96,7 +96,7 @@ paths:
           type: boolean
           default: false
       responses:
-        202:
+        204:
           description: 'Job removed.'
         401:
           description: 'Not authenticated'
@@ -115,7 +115,30 @@ paths:
       - $ref: '#/components/parameters/jobId'
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/PublishStatusResponse'
+        400:
+          description: 'Bad request. Some parameter is not acceptable or missing'
+        401:
+          description: 'Not authenticated'
+        403:
+          description: 'Forbidden. User has no priviledges access the requested job'
+        409:
+          description: 'Conflict. The upload is not ready for publishing.'
+    put:
+      tags:
+        - Data Publishing
+      description: 'Save a draft state for the publication of the dataset(s) from the given upload'
+      operationId: saveDraft
+      parameters:
+      - $ref: '#/components/parameters/jobId'
+      requestBody:
+        content:
+          application/json:
             schema:
               $ref: '#/components/schemas/PublishRequest'
       responses:

--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 servers:
   - description: SwaggerHub API Auto Mocking
-    url: https://sample.url/import
+    url: https://localhost:8080/
 info:
   title: DataFeeder API
   description: This API covers dataset upload and publishing features of the application

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -77,6 +77,17 @@
         <artifactId>jackson-databind-nullable</artifactId>
         <version>0.1.0</version>
       </dependency>
+      <!-- test deps -->
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-sample-data</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>4.0.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -157,6 +168,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- test scoped for spring boot's (1.5.19.RELEASE) TestRestTemplate pass request headers (sec-* headers ignored with 
         default java client) -->
       <groupId>org.apache.httpcomponents</groupId>
@@ -167,6 +183,16 @@
     <dependency>
       <groupId>org.springframework.batch</groupId>
       <artifactId>spring-batch-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-sample-data</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -15,7 +15,6 @@
     <context.name>${project.artifactId}</context.name>
     <packageDatadirScmVersion>datafeeder</packageDatadirScmVersion>
     <openapi-generator-maven-plugin.version>4.3.1</openapi-generator-maven-plugin.version>
-    <springfox-swagger2.version>2.9.2</springfox-swagger2.version>
     <swagger.version>1.5.21</swagger.version>
     <springfox.version>2.9.2</springfox.version>
     <mapstruct.version>1.4.1.Final</mapstruct.version>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.georchestra</groupId>
     <artifactId>root</artifactId>
-    <version>20.1-SNAPSHOT</version>
+    <version>20.2-SNAPSHOT</version>
   </parent>
   <artifactId>datafeeder</artifactId>
   <packaging>jar</packaging>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -42,6 +42,16 @@
         <artifactId>commons-compress</artifactId>
         <version>1.20</version>
       </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-geopkg</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools.jdbc</groupId>
+        <artifactId>gt-jdbc-postgis</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
       <!--SpringFox dependencies -->
       <dependency>
         <groupId>io.springfox</groupId>
@@ -94,6 +104,31 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
+    </dependency>
+    <!-- Geotools dependencies -->
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-epsg-hsql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-shapefile</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-geojson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-geopkg</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools.jdbc</groupId>
+      <artifactId>gt-jdbc-postgis</artifactId>
     </dependency>
     <!--SpringFox dependencies -->
     <dependency>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -17,20 +17,41 @@
     <openapi-generator-maven-plugin.version>4.3.1</openapi-generator-maven-plugin.version>
     <springfox-swagger2.version>2.9.2</springfox-swagger2.version>
     <swagger.version>1.5.21</swagger.version>
-    <springfox-version>2.9.2</springfox-version>
+    <springfox.version>2.9.2</springfox.version>
+    <mapstruct.version>1.4.1.Final</mapstruct.version>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct</artifactId>
+        <version>${mapstruct.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct-processor</artifactId>
+        <version>${mapstruct.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-vfs2</artifactId>
+        <version>2.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.20</version>
+      </dependency>
       <!--SpringFox dependencies -->
       <dependency>
         <groupId>io.springfox</groupId>
         <artifactId>springfox-swagger2</artifactId>
-        <version>${springfox-version}</version>
+        <version>${springfox.version}</version>
       </dependency>
       <dependency>
         <groupId>io.springfox</groupId>
         <artifactId>springfox-swagger-ui</artifactId>
-        <version>${springfox-version}</version>
+        <version>${springfox.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
@@ -40,6 +61,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>2.11.3</version>
       </dependency>
       <dependency>
         <groupId>org.openapitools</groupId>
@@ -55,7 +77,23 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-batch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
     </dependency>
     <!--SpringFox dependencies -->
     <dependency>
@@ -90,6 +128,11 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.batch</groupId>
+      <artifactId>spring-batch-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -159,10 +202,39 @@
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/openapi/src</source>
+                <source>${project.build.directory}/generated-sources/mapstruct</source>
               </sources>
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <generatedSourcesDirectory>${project.build.directory}/generated-sources/mapstruct</generatedSourcesDirectory>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.config.security;
 
 import org.springframework.context.annotation.Bean;

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.config.security;
 
 import java.util.Arrays;

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
@@ -35,9 +35,6 @@ public class GeorchestraSecurityProxyAuthenticationFilter extends AbstractPreAut
 
     @Override
     protected GeorchestraUserDetails getPreAuthenticatedPrincipal(HttpServletRequest request) {
-        for (String h : Collections.list(request.getHeaderNames())) {
-            System.err.printf("%s=%s%n", h, request.getHeader(h));
-        }
         final boolean preAuthenticated = Boolean.parseBoolean(request.getHeader("sec-proxy"));
         if (preAuthenticated) {
             String username = request.getHeader("sec-username");

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationManager.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.config.security;
 
 import java.util.Collection;

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraUserDetails.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraUserDetails.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.config.security;
 
 import java.util.ArrayList;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiResponseMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiResponseMapper.java
@@ -19,11 +19,14 @@
 package org.georchestra.datafeeder.api;
 
 import org.georchestra.datafeeder.model.DataUploadState;
+import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface ApiResponseMapper {
 
     UploadJobStatus toApi(DataUploadState state);
+
+    DatasetUploadStatus toApi(DatasetUploadState dataset);
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiResponseMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiResponseMapper.java
@@ -16,10 +16,14 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.test;
+package org.georchestra.datafeeder.api;
 
-import org.springframework.context.annotation.Configuration;
+import org.georchestra.datafeeder.model.DataUploadState;
+import org.mapstruct.Mapper;
 
-public @Configuration class BaseTestConfig {
+@Mapper(componentModel = "spring")
+public interface ApiResponseMapper {
+
+    UploadJobStatus toApi(DataUploadState state);
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataFeederApiConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataFeederApiConfiguration.java
@@ -30,5 +30,4 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
         jsr250Enabled = true // enable @RolesAllowed annotation in API methods
 )
 public @Configuration class DataFeederApiConfiguration extends GlobalMethodSecurityConfiguration {
-
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
@@ -1,0 +1,21 @@
+package org.georchestra.datafeeder.api;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import io.swagger.annotations.Api;
+
+@Controller
+@Api(tags = { "Data Publishing" }) // hides the empty data-publishing-api-controller entry in swagger-ui.html
+public class DataPublishingApiController implements DataPublishingApi {
+
+    private @Autowired NativeWebRequest currentRequest;
+
+    public @Override Optional<NativeWebRequest> getRequest() {
+        return Optional.of(currentRequest);
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
@@ -42,9 +42,12 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.swagger.annotations.Api;
 import lombok.NonNull;
 
-public @Controller class FileUploadApiController implements FileUploadApi {
+@Controller
+@Api(tags = { "File Upload" }) // hides the empty file-upload-api-controller entry in swagger-ui.html
+public class FileUploadApiController implements FileUploadApi {
 
     private @Autowired NativeWebRequest currentRequest;
     private @Autowired FileStorageService storageService;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
@@ -61,7 +61,6 @@ public @Controller class FileUploadApiController implements FileUploadApi {
         DataUploadState state = uploadService.findJobState(uploadId);
         UploadJobStatus response = mapper.toApi(state);
         return ResponseEntity.ok(response);
-
     }
 
     @Override
@@ -103,6 +102,11 @@ public @Controller class FileUploadApiController implements FileUploadApi {
             @PathVariable("jobId") UUID jobId, //
             @RequestParam(value = "abort", required = false, defaultValue = "false") Boolean abort) {
 
+        if (Boolean.TRUE.equals(abort)) {
+            this.uploadService.abortAndRemove(jobId);
+        } else {
+            this.uploadService.remove(jobId);
+        }
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
@@ -18,29 +18,98 @@
  */
 package org.georchestra.datafeeder.api;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 
+import org.georchestra.datafeeder.model.DataUploadState;
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.FileStorageService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
+
+import lombok.NonNull;
 
 public @Controller class FileUploadApiController implements FileUploadApi {
 
-//    private final FileStorageService storageService;
-//
-//    public @Autowired FileUploadController(FileStorageService storageService) {
-//        this.storageService = storageService;
-//    }
+    private @Autowired NativeWebRequest currentRequest;
+    private @Autowired FileStorageService storageService;
+    private @Autowired DataUploadService uploadService;
+    private @Autowired ApiResponseMapper mapper;
+
+    public @Override Optional<NativeWebRequest> getRequest() {
+        return Optional.of(currentRequest);
+    }
 
     @Override
     @RolesAllowed("ROLE_USER")
-    public ResponseEntity<UploadJobStatus> uploadFiles(@RequestPart(value = "filename") List<MultipartFile> filename) {
+    public ResponseEntity<UploadJobStatus> findUploadJob(@PathVariable("jobId") UUID uploadId) {
+        DataUploadState state = uploadService.findJobState(uploadId);
+        UploadJobStatus response = mapper.toApi(state);
+        return ResponseEntity.ok(response);
 
-        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
 
+    @Override
+    @RolesAllowed("ROLE_USER")
+    public ResponseEntity<UploadJobStatus> uploadFiles(@RequestPart(value = "filename") List<MultipartFile> files) {
+        UUID uploadId;
+        try {
+            uploadId = storageService.saveUploads(files);
+            uploadService.analyze(uploadId);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);// TODO translate to ResponseStatusException
+        }
+        DataUploadState state = uploadService.findJobState(uploadId);
+        UploadJobStatus response = mapper.toApi(state);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @RolesAllowed("ROLE_ADMINISTRATOR")
+    public ResponseEntity<List<UploadJobStatus>> findAllUploadJobs() {
+        List<DataUploadState> all = this.uploadService.findAllJobs();
+        List<UploadJobStatus> response = all.stream().map(mapper::toApi).collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @RolesAllowed("ROLE_USER")
+    public ResponseEntity<List<UploadJobStatus>> findUserUploadJobs() {
+        String userName = getUserName();
+        List<DataUploadState> all = this.uploadService.findUserJobs(userName);
+        List<UploadJobStatus> response = all.stream().map(mapper::toApi).collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @RolesAllowed("ROLE_USER")
+    public ResponseEntity<Void> removeJob(//
+            @PathVariable("jobId") UUID jobId, //
+            @RequestParam(value = "abort", required = false, defaultValue = "false") Boolean abort) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    private @NonNull String getUserName() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication auth = context.getAuthentication();
+        String userName = auth.getName();
+        return userName;
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/app/DataFeederApplicationConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/app/DataFeederApplicationConfiguration.java
@@ -20,10 +20,11 @@ package org.georchestra.datafeeder.app;
 
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
 import org.georchestra.datafeeder.service.DataFeederServiceConfiguration;
+import org.georchestra.datafeeder.swagger.SwaggerDocConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-@Import(value = { DataFeederApiConfiguration.class, DataFeederServiceConfiguration.class })
+@Import(value = { DataFeederApiConfiguration.class, DataFeederServiceConfiguration.class, SwaggerDocConfig.class })
 public @Configuration class DataFeederApplicationConfiguration {
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/CloudNativeGeonetworkIntegrationAutoConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/CloudNativeGeonetworkIntegrationAutoConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.datafeeder.autoconf;
 
 import javax.annotation.PostConstruct;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraDatadirConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraDatadirConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.datafeeder.autoconf;
 
 import org.springframework.context.annotation.PropertySource;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.datafeeder.autoconf;
 
 import org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationConfiguration;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -1,6 +1,24 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.datafeeder.config;
 
-import java.util.Optional;
+import java.nio.file.Path;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -12,18 +30,25 @@ import lombok.Data;
  */
 public @Data class DataFeederConfigurationProperties {
 
-    private MultipartConfig fileUpload;
+    private FileUploadConfig fileUpload;
 
-    public static @Data class MultipartConfig {
-        private String location = null;
-        private long maxFileSize = -1;
+    public static @Data class FileUploadConfig {
+        /** maximum size allowed for uploaded files. */
+        private String maxFileSize;
 
-        public Optional<Long> maxFileSize() {
-            return maxFileSize < 0 ? Optional.empty() : Optional.of(maxFileSize);
-        }
+        /** maximum size allowed for multipart/form-data requests */
+        private String maxRequestSize;
 
-        public Optional<String> location() {
-            return Optional.ofNullable(location);
-        }
+        /** size threshold after which files will be written to disk. */
+        private String fileSizeThreshold;
+
+        /**
+         * directory location where files will be stored by the servlet container once
+         * the request exceeds the {@link #fileSizeThreshold}
+         */
+        private String temporaryLocation = "";
+
+        /** directory location where files will be stored. */
+        private Path persistentLocation;
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -19,6 +19,7 @@
 package org.georchestra.datafeeder.config;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -30,7 +31,7 @@ import lombok.Data;
  */
 public @Data class DataFeederConfigurationProperties {
 
-    private FileUploadConfig fileUpload;
+    private FileUploadConfig fileUpload = new FileUploadConfig();
 
     public static @Data class FileUploadConfig {
         /** maximum size allowed for uploaded files. */
@@ -49,6 +50,6 @@ public @Data class DataFeederConfigurationProperties {
         private String temporaryLocation = "";
 
         /** directory location where files will be stored. */
-        private Path persistentLocation;
+        private Path persistentLocation = Paths.get("/tmp/datafeeder/uploads");
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/BoundingBox.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/BoundingBox.java
@@ -16,10 +16,14 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.test;
+package org.georchestra.datafeeder.model;
 
-import org.springframework.context.annotation.Configuration;
+import lombok.Data;
 
-public @Configuration class BaseTestConfig {
-
+public @Data class BoundingBox {
+    private CoordinateReferenceSystemMetadata crs;
+    private Double minx;
+    private Double maxx;
+    private Double miny;
+    private Double maxy;
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/BoundingBoxMetadata.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/BoundingBoxMetadata.java
@@ -20,7 +20,7 @@ package org.georchestra.datafeeder.model;
 
 import lombok.Data;
 
-public @Data class BoundingBox {
+public @Data class BoundingBoxMetadata {
     private CoordinateReferenceSystemMetadata crs;
     private Double minx;
     private Double maxx;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/CoordinateReferenceSystemMetadata.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/CoordinateReferenceSystemMetadata.java
@@ -16,10 +16,11 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.test;
+package org.georchestra.datafeeder.model;
 
-import org.springframework.context.annotation.Configuration;
+import lombok.Data;
 
-public @Configuration class BaseTestConfig {
-
+public @Data class CoordinateReferenceSystemMetadata {
+    private String srs;
+    private String WKT;
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadState.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadState.java
@@ -16,10 +16,19 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.test;
+package org.georchestra.datafeeder.model;
 
-import org.springframework.context.annotation.Configuration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
-public @Configuration class BaseTestConfig {
+import lombok.Data;
 
+public @Data class DataUploadState {
+
+    private UUID jobId;
+    private double progress;
+    private UploadStatus status;
+    private String error;
+    private List<DatasetUploadState> datasets = new ArrayList<>();
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
@@ -16,10 +16,21 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.test;
+package org.georchestra.datafeeder.model;
 
-import org.springframework.context.annotation.Configuration;
+import java.util.Map;
 
-public @Configuration class BaseTestConfig {
+import org.georchestra.datafeeder.api.BoundingBox;
 
+import lombok.Data;
+
+public @Data class DatasetUploadState {
+    private String name;
+
+    private UploadStatus status;
+    private String error;
+    private Map<String, Object> sampleProperties;
+    private String sampleGeometryWKT;
+    private BoundingBox nativeBounds;
+    private String encoding;
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
@@ -20,8 +20,6 @@ package org.georchestra.datafeeder.model;
 
 import java.util.Map;
 
-import org.georchestra.datafeeder.api.BoundingBox;
-
 import lombok.Data;
 
 public @Data class DatasetUploadState {
@@ -29,8 +27,10 @@ public @Data class DatasetUploadState {
 
     private UploadStatus status;
     private String error;
+    private Integer featureCount;
     private Map<String, Object> sampleProperties;
     private String sampleGeometryWKT;
-    private BoundingBox nativeBounds;
+    private BoundingBoxMetadata nativeBounds;
     private String encoding;
+    private CoordinateReferenceSystemMetadata nativeCrs;
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/UploadStatus.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/UploadStatus.java
@@ -16,15 +16,8 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.api;
+package org.georchestra.datafeeder.model;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
-
-@RequestMapping(path = "/import")
-public @Controller class DataImportWizardController {
-
-    private @Autowired NativeWebRequest currentRequest;
+public enum UploadStatus {
+    PENDING, ANALYZING, DONE, ERROR;
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
@@ -67,4 +67,8 @@ public class DataFeederServiceConfiguration {
     public @Bean DataUploadService dataUploadService() {
         return new DataUploadService();
     }
+
+    public @Bean DatasetsService datasetsService() {
+        return new DatasetsService();
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
@@ -18,8 +18,53 @@
  */
 package org.georchestra.datafeeder.service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.FileUploadConfig;
+import org.georchestra.datafeeder.service.batch.DatafeederBatchConfiguration;
+import org.springframework.beans.InvalidPropertyException;
+import org.springframework.beans.factory.BeanExpressionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
-public @Configuration class DataFeederServiceConfiguration {
+import lombok.extern.slf4j.Slf4j;
 
+@Configuration
+@Import(value = { DatafeederBatchConfiguration.class })
+@Slf4j
+public class DataFeederServiceConfiguration {
+
+    private @Autowired DataFeederConfigurationProperties properties;
+
+    public @Bean FileStorageService fileStorageService() {
+        FileUploadConfig fileUploadConfig = properties.getFileUpload();
+        Path baseDirectory = fileUploadConfig.getPersistentLocation();
+        if (null == baseDirectory || baseDirectory.toString().isEmpty()) {
+            throw new InvalidPropertyException(DataFeederConfigurationProperties.class,
+                    "file-upload.persistent-location", "persitent file upload directory not provided");
+        }
+        if (!Files.isDirectory(baseDirectory)) {
+            log.warn(
+                    "Upload files directory does not exist, creating from property datafeeder.file-upload.persistent-location={}",
+                    baseDirectory);
+            try {
+                Files.createDirectories(baseDirectory);
+            } catch (IOException e) {
+                String msg = String.format(
+                        "Unable to create upload files directory from property datafeeder.file-upload.persistent-location=%s",
+                        baseDirectory);
+                throw new BeanExpressionException(msg, e);
+            }
+        }
+        return new FileStorageService(baseDirectory);
+    }
+
+    public @Bean DataUploadService dataUploadService() {
+        return new DataUploadService();
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataSourceMetadata.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataSourceMetadata.java
@@ -1,0 +1,19 @@
+package org.georchestra.datafeeder.service;
+
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class DataSourceMetadata {
+
+    public enum DataSourceType {
+        SHAPEFILE, //
+        GEOJSON, //
+        GEOPACKAGE, //
+        POSTGIS//
+    }
+
+    private DataSourceType type;
+    private Map<String, Object> connectionParameters;
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.georchestra.datafeeder.model.DataUploadState;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DataUploadService {
+
+    private @Autowired FileStorageService storageService;
+
+    public void analyze(UUID uploadId) {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+
+    public DataUploadState findJobState(UUID uploadId) {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+
+    public List<DataUploadState> findAllJobs() {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+
+    public List<DataUploadState> findUserJobs(String userName) {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -18,22 +18,86 @@
  */
 package org.georchestra.datafeeder.service;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import org.georchestra.datafeeder.model.DataUploadState;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.model.UploadStatus;
+import org.locationtech.jts.geom.Geometry;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class DataUploadService {
 
     private @Autowired FileStorageService storageService;
+    private @Autowired DatasetsService datasetsService;
+
+    private UploadPackage getUploadPack(UUID uploadId) {
+        UploadPackage pack;
+        try {
+            pack = storageService.find(uploadId);
+        } catch (FileNotFoundException fnf) {
+            throw new IllegalArgumentException("upload pack does not exist: " + uploadId);
+        } catch (IOException e) {
+            throw new RuntimeException(e);// TODO better exception handling
+        }
+        return pack;
+    }
 
     public void analyze(UUID uploadId) {
-        throw new UnsupportedOperationException("unimplemented");
+        getUploadPack(uploadId);
+        log.warn("TODO: implement analyze, job " + uploadId);
     }
 
     public DataUploadState findJobState(UUID uploadId) {
-        throw new UnsupportedOperationException("unimplemented");
+        UploadPackage pack = getUploadPack(uploadId);
+        DataUploadState stub = new DataUploadState();
+        stub.setJobId(uploadId);
+        stub.setDatasets(datasets(pack));
+        stub.setProgress(0.5);
+        stub.setStatus(UploadStatus.ANALYZING);
+        return stub;
+    }
+
+    private List<DatasetUploadState> datasets(UploadPackage pack) {
+        Set<String> datasetFileNames;
+        try {
+            datasetFileNames = pack.findDatasets();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        List<DatasetUploadState> states = new ArrayList<>();
+        for (String fileName : datasetFileNames) {
+            List<DatasetUploadState> ds = loadDataset(pack, fileName);
+            states.addAll(ds);
+        }
+        return states;
+    }
+
+    private List<DatasetUploadState> loadDataset(UploadPackage pack, String fileName) {
+        Path path = pack.resolve(fileName);
+        DatasetUploadState ds = new DatasetUploadState();
+        List<DatasetMetadata> fileDatasets = datasetsService.describe(path);
+        List<DatasetUploadState> states = new ArrayList<>(fileDatasets.size());
+        for (DatasetMetadata md : fileDatasets) {
+            ds.setEncoding(md.getEncoding());
+            ds.setName(md.getTypeName());
+            ds.setNativeBounds(md.getNativeBounds());
+            Optional<Geometry> sampleGeometry = md.sampleGeometry();
+            ds.setSampleGeometryWKT(sampleGeometry.map(Geometry::toText).orElse(null));
+            ds.setSampleProperties(md.getSampleProperties());
+            ds.setStatus(UploadStatus.ANALYZING);
+        }
+        return states;
     }
 
     public List<DataUploadState> findAllJobs() {
@@ -41,6 +105,14 @@ public class DataUploadService {
     }
 
     public List<DataUploadState> findUserJobs(String userName) {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+
+    public void abortAndRemove(UUID jobId) {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+
+    public void remove(UUID jobId) {
         throw new UnsupportedOperationException("unimplemented");
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -33,6 +33,7 @@ import org.georchestra.datafeeder.model.UploadStatus;
 import org.locationtech.jts.geom.Geometry;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -53,9 +54,22 @@ public class DataUploadService {
         return pack;
     }
 
-    public void analyze(UUID uploadId) {
-        getUploadPack(uploadId);
+    /**
+     * Asynchronously starts the analysis process for the upload pack given by its
+     * id, returns immediately with {@link DataUploadState#getStatus() status}
+     * {@link UploadStatus#PENDING} and an empty
+     * {@link DataUploadState#getDatasets() datasets} list.
+     * 
+     * @param uploadId
+     * @return
+     */
+    public DataUploadState analyze(@NonNull UUID uploadId) {
+        UploadPackage uploadPack = getUploadPack(uploadId);
         log.warn("TODO: implement analyze, job " + uploadId);
+        DataUploadState state = new DataUploadState();
+        state.setJobId(uploadId);
+        state.setStatus(UploadStatus.PENDING);
+        return state;
     }
 
     public DataUploadState findJobState(UUID uploadId) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -109,6 +109,7 @@ public class DataUploadService {
             Optional<Geometry> sampleGeometry = md.sampleGeometry();
             ds.setSampleGeometryWKT(sampleGeometry.map(Geometry::toText).orElse(null));
             ds.setSampleProperties(md.getSampleProperties());
+            ds.setFeatureCount(md.getFeatureCount());
             ds.setStatus(UploadStatus.ANALYZING);
         }
         return states;
@@ -118,15 +119,15 @@ public class DataUploadService {
         throw new UnsupportedOperationException("unimplemented");
     }
 
-    public List<DataUploadState> findUserJobs(String userName) {
+    public List<DataUploadState> findUserJobs(@NonNull String userName) {
         throw new UnsupportedOperationException("unimplemented");
     }
 
-    public void abortAndRemove(UUID jobId) {
+    public void abortAndRemove(@NonNull UUID jobId) {
         throw new UnsupportedOperationException("unimplemented");
     }
 
-    public void remove(UUID jobId) {
+    public void remove(@NonNull UUID jobId) {
         throw new UnsupportedOperationException("unimplemented");
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetMetadata.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetMetadata.java
@@ -1,0 +1,24 @@
+package org.georchestra.datafeeder.service;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.georchestra.datafeeder.api.BoundingBox;
+import org.locationtech.jts.geom.Geometry;
+
+import lombok.Data;
+
+@Data
+public class DatasetMetadata {
+
+    private String encoding;
+    private String typeName;
+    private BoundingBox nativeBounds;
+    private Geometry sampleGeometry;
+    private Map<String, Object> sampleProperties;
+
+    public Optional<Geometry> sampleGeometry() {
+        return Optional.ofNullable(sampleGeometry);
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetMetadata.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetMetadata.java
@@ -3,7 +3,7 @@ package org.georchestra.datafeeder.service;
 import java.util.Map;
 import java.util.Optional;
 
-import org.georchestra.datafeeder.api.BoundingBox;
+import org.georchestra.datafeeder.model.BoundingBoxMetadata;
 import org.locationtech.jts.geom.Geometry;
 
 import lombok.Data;
@@ -13,7 +13,8 @@ public class DatasetMetadata {
 
     private String encoding;
     private String typeName;
-    private BoundingBox nativeBounds;
+    private Integer featureCount;
+    private BoundingBoxMetadata nativeBounds;
     private Geometry sampleGeometry;
     private Map<String, Object> sampleProperties;
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
@@ -1,0 +1,100 @@
+package org.georchestra.datafeeder.service;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.georchestra.datafeeder.api.BoundingBox;
+import org.georchestra.datafeeder.api.CRS;
+import org.geotools.data.DataStore;
+import org.geotools.data.DataStoreFinder;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.GeometryAttribute;
+import org.opengis.feature.Property;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import lombok.NonNull;
+
+public class DatasetsService {
+
+    public List<DatasetMetadata> describe(@NonNull Path path) {
+        DataStore ds;
+        try {
+            ds = loadDataStore(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            String[] typeNames = ds.getTypeNames();
+            List<DatasetMetadata> mds = new ArrayList<>(typeNames.length);
+            for (String typeName : typeNames) {
+                SimpleFeatureSource fs = ds.getFeatureSource(typeName);
+                DatasetMetadata md = describe(fs);
+                mds.add(md);
+            }
+            return mds;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            ds.dispose();
+        }
+    }
+
+    private DatasetMetadata describe(SimpleFeatureSource fs) throws IOException {
+        DatasetMetadata md = new DatasetMetadata();
+        md.setTypeName(fs.getName().getLocalPart());
+        md.setNativeBounds(nativeBounds(fs));
+        SimpleFeature sampleFeature = sampleFeature(fs);
+
+        Geometry sampleGeometry = (Geometry) sampleFeature.getDefaultGeometry();
+        Map<String, Object> sampleProperties = sampleFeature.getProperties().stream()//
+                .filter(p -> !(p instanceof GeometryAttribute))//
+                .collect(Collectors.toMap(p -> p.getName().getLocalPart(), Property::getValue));
+
+        md.setSampleGeometry(sampleGeometry);
+        md.setSampleProperties(sampleProperties);
+        return md;
+    }
+
+    private BoundingBox nativeBounds(SimpleFeatureSource fs) throws IOException {
+        ReferencedEnvelope bounds = fs.getBounds();
+        if (bounds == null)
+            return null;
+
+        BoundingBox bb = new BoundingBox();
+        bb.setCrs(crs(bounds.getCoordinateReferenceSystem()));
+        bb.setMinx(bounds.getMinX());
+        bb.setMaxx(bounds.getMaxX());
+        bb.setMiny(bounds.getMinY());
+        bb.setMaxy(bounds.getMaxY());
+
+        return bb;
+    }
+
+    private CRS crs(CoordinateReferenceSystem coordinateReferenceSystem) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    private SimpleFeature sampleFeature(SimpleFeatureSource fs) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    public DataStore loadDataStore(@NonNull Path path) throws IOException {
+        Map<Object, Object> params = resolveConnectionParameters(path);
+        return DataStoreFinder.getDataStore(params);
+    }
+
+    private Map<Object, Object> resolveConnectionParameters(@NonNull Path path) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
@@ -1,26 +1,40 @@
 package org.georchestra.datafeeder.service;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.georchestra.datafeeder.api.BoundingBox;
-import org.georchestra.datafeeder.api.CRS;
+import javax.annotation.Nullable;
+
+import org.georchestra.datafeeder.model.BoundingBoxMetadata;
+import org.georchestra.datafeeder.model.CoordinateReferenceSystemMetadata;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
+import org.geotools.data.Query;
+import org.geotools.data.shapefile.ShapefileDataStoreFactory;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.wkt.Formattable;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.GeometryAttribute;
 import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class DatasetsService {
 
     public List<DatasetMetadata> describe(@NonNull Path path) {
@@ -50,24 +64,31 @@ public class DatasetsService {
         DatasetMetadata md = new DatasetMetadata();
         md.setTypeName(fs.getName().getLocalPart());
         md.setNativeBounds(nativeBounds(fs));
-        SimpleFeature sampleFeature = sampleFeature(fs);
+        md.setFeatureCount(featureCount(fs));
 
-        Geometry sampleGeometry = (Geometry) sampleFeature.getDefaultGeometry();
-        Map<String, Object> sampleProperties = sampleFeature.getProperties().stream()//
-                .filter(p -> !(p instanceof GeometryAttribute))//
-                .collect(Collectors.toMap(p -> p.getName().getLocalPart(), Property::getValue));
+        Optional<SimpleFeature> sampleFeature = sampleFeature(fs);
+        if (sampleFeature.isPresent()) {
+            SimpleFeature feature = sampleFeature.get();
+            Geometry sampleGeometry;
+            Map<String, Object> sampleProperties;
 
-        md.setSampleGeometry(sampleGeometry);
-        md.setSampleProperties(sampleProperties);
+            sampleGeometry = (Geometry) feature.getDefaultGeometry();
+            sampleProperties = feature.getProperties().stream()//
+                    .filter(p -> !(p instanceof GeometryAttribute))//
+                    .collect(Collectors.toMap(p -> p.getName().getLocalPart(), Property::getValue));
+
+            md.setSampleGeometry(sampleGeometry);
+            md.setSampleProperties(sampleProperties);
+        }
         return md;
     }
 
-    private BoundingBox nativeBounds(SimpleFeatureSource fs) throws IOException {
+    private @Nullable BoundingBoxMetadata nativeBounds(SimpleFeatureSource fs) throws IOException {
         ReferencedEnvelope bounds = fs.getBounds();
         if (bounds == null)
             return null;
 
-        BoundingBox bb = new BoundingBox();
+        BoundingBoxMetadata bb = new BoundingBoxMetadata();
         bb.setCrs(crs(bounds.getCoordinateReferenceSystem()));
         bb.setMinx(bounds.getMinX());
         bb.setMaxx(bounds.getMaxX());
@@ -77,24 +98,71 @@ public class DatasetsService {
         return bb;
     }
 
-    private CRS crs(CoordinateReferenceSystem coordinateReferenceSystem) {
-        // TODO Auto-generated method stub
-        return null;
+    private int featureCount(SimpleFeatureSource fs) throws IOException {
+        return fs.getCount(Query.ALL);
     }
 
-    private SimpleFeature sampleFeature(SimpleFeatureSource fs) {
-        // TODO Auto-generated method stub
-        return null;
+    private @Nullable CoordinateReferenceSystemMetadata crs(@Nullable CoordinateReferenceSystem crs) {
+        if (crs == null)
+            return null;
+
+        String srs = null;
+        // potentially slow, but doesn't matter for the sake of this analysis process
+        final boolean fullScan = true;
+        try {
+            srs = CRS.lookupIdentifier(crs, fullScan);
+        } catch (FactoryException e) {
+            e.printStackTrace();
+        }
+        String wkt = toSingleLineWKT(crs);
+
+        CoordinateReferenceSystemMetadata md = new CoordinateReferenceSystemMetadata();
+        md.setSrs(srs);
+        md.setWKT(wkt);
+        return md;
     }
 
-    public DataStore loadDataStore(@NonNull Path path) throws IOException {
+    private String toSingleLineWKT(@NonNull CoordinateReferenceSystem crs) {
+        if (crs instanceof Formattable) {
+            try {
+                return ((Formattable) crs).toWKT(Formattable.SINGLE_LINE, false);
+            } catch (RuntimeException e) {
+                log.warn("Error formatting CRS to single-line WKT", e);
+            }
+        }
+        return crs.toWKT();
+    }
+
+    private Optional<SimpleFeature> sampleFeature(SimpleFeatureSource fs) throws IOException {
+        Query query = new Query(fs.getName().getLocalPart());
+        query.setMaxFeatures(1);
+        SimpleFeatureCollection collection = fs.getFeatures(query);
+        try (SimpleFeatureIterator it = collection.features()) {
+            if (it.hasNext()) {
+                return Optional.of(it.next());
+            }
+        }
+        return Optional.empty();
+    }
+
+    public @NonNull DataStore loadDataStore(@NonNull Path path) throws IOException {
         Map<Object, Object> params = resolveConnectionParameters(path);
-        return DataStoreFinder.getDataStore(params);
+        DataStore ds = DataStoreFinder.getDataStore(params);
+        if (ds == null) {
+            throw new IOException("Unable to resolve dataset " + path.getFileName());
+        }
+        return ds;
     }
 
-    private Map<Object, Object> resolveConnectionParameters(@NonNull Path path) {
-        // TODO Auto-generated method stub
-        return null;
+    private @NonNull Map<Object, Object> resolveConnectionParameters(@NonNull Path path) throws IOException {
+        // TODO support other file types than shapefile
+        Map<Object, Object> params = new HashMap<>();
+        if (path.getFileName().toString().toLowerCase().endsWith(".shp")) {
+            URL url = path.toUri().toURL();
+            params.put(ShapefileDataStoreFactory.URLP.key, url);
+            params.put(ShapefileDataStoreFactory.CREATE_SPATIAL_INDEX, Boolean.FALSE);
+        }
+        return params;
     }
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/UploadPackage.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/UploadPackage.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+public class UploadPackage {
+
+    private FileStorageService service;
+    private @Getter UUID id;
+
+    private static final Pattern ARCHIVE_FILENAME_PATTERN = Pattern
+            .compile("([^.*]+(\\.(?i)(zip|gz|bz2|tar|tgz|tar\\.gz|tar\\.bz2))$)");
+
+    private static final Pattern DATASET_FILENAME_PATTERN = Pattern.compile("([^.*]+(\\.(?i)(shp|gpkg|geojson))$)");
+
+    public UploadPackage(@NonNull FileStorageService service, @NonNull UUID id) throws IOException {
+        this.service = service;
+        this.id = id;
+    }
+
+    @VisibleForTesting
+    Path root() {
+        return service.resolve(id);
+    }
+
+    public Set<String> findDatasets() throws IOException {
+        return relativeFileNames().filter(this::isDataset).collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    public Set<String> findAll() throws IOException {
+        return relativeFileNames().collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    public Path resolve(@NonNull String fileName) {
+        return root().resolve(fileName);
+    }
+
+    public boolean isArchive(@NonNull String fileName) {
+        return ARCHIVE_FILENAME_PATTERN.matcher(fileName).matches();
+    }
+
+    public boolean isDataset(@NonNull String fileName) {
+        return DATASET_FILENAME_PATTERN.matcher(fileName).matches();
+    }
+
+    public void unpack(@NonNull String archiveRelativeFileName) throws IOException {
+        Path archive = resolve(archiveRelativeFileName);
+        if (!Files.exists(archive)) {
+            throw new FileNotFoundException(archiveRelativeFileName + " not found under " + id);
+        }
+        FileSystemManager fsManager = VFS.getManager();
+        try (FileObject fsRoot = fsManager.resolveFile(archive.toUri())) {
+            try (FileObject localFileSystem = fsManager.createFileSystem(fsRoot)) {
+                FileObject[] children = localFileSystem.getChildren();
+                unpack(children);
+            }
+        }
+    }
+
+    private void unpack(FileObject[] children) throws IOException {
+        for (FileObject fo : children) {
+            unpack(fo);
+        }
+    }
+
+    private void unpack(@NonNull final FileObject fo) throws IOException {
+        final FileName name = fo.getName();
+        final FileName root = name.getRoot();
+        final String relativeName = root.getRelativeName(name);
+        final Path path = resolve(relativeName);
+
+        if (fo.isFolder()) {
+            Files.createDirectory(path);
+            unpack(fo.getChildren());
+        } else {
+            try (InputStream in = fo.getContent().getInputStream()) {
+                Files.copy(in, path);
+            }
+        }
+    }
+
+    private Stream<String> relativeFileNames() throws IOException {
+        final Path root = root();
+        return files().map(root::relativize).map(Path::toString);
+    }
+
+    private Stream<Path> files() throws IOException {
+        return Files.walk(root()).filter(Files::isRegularFile);
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/DatafeederBatchConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/DatafeederBatchConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.batch;
+
+import org.springframework.batch.item.ItemReader;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * File upload job:
+ * <p>
+ * upload -> save -> unpack -> analyze
+ *
+ */
+@Configuration
+//@EnableBatchProcessing
+public class DatafeederBatchConfiguration {
+
+//    @Autowired
+//    JobBuilderFactory jobBuilderFactory;
+//
+//    @Autowired
+//    StepBuilderFactory stepBuilderFactory;
+
+//    @Bean
+//    public Job uploadAndAnalyzeDatasetJob(JobCompletionNotificationListener listener, Step step1) {
+//        return jobBuilderFactory//
+//                .get("uploadAndAnalyzeDatasetJob")//
+//                .incrementer(new RunIdIncrementer())//
+//                .listener(listener)//
+//                .flow(step1)//
+//                .end().build();
+//    }
+//
+//    @Bean
+//    public Step uploadFile(ItemWriter<MultipartFile> writer) {
+//        return stepBuilderFactory//
+//                .get("uploadFile")//
+//                .reader(reader()).processor(processor()).writer(writer).build();
+//    }
+
+    private ItemReader<MultipartFile> reader() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/JobCompletionNotificationListener.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/JobCompletionNotificationListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.batch;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListenerSupport;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JobCompletionNotificationListener extends JobExecutionListenerSupport {
+
+//  @Autowired private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+            log.info("!!! JOB FINISHED! Time to verify the results");
+
+//      jdbcTemplate.query("SELECT first_name, last_name FROM people",
+//        (rs, row) -> new Person(
+//          rs.getString(1),
+//          rs.getString(2))
+//      ).forEach(person -> log.info("Found <" + person + "> in the database."));
+        }
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/MultipartFileUploadProcessor.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/MultipartFileUploadProcessor.java
@@ -16,10 +16,27 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.service;
+package org.georchestra.datafeeder.service.batch;
 
-import org.springframework.stereotype.Service;
+import java.io.File;
 
-public @Service class DataImportService {
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MultipartFileUploadProcessor implements ItemProcessor<MultipartFile, File> {
+
+    private @Autowired DataUploadService uploadService;
+
+    @Override
+    public File process(MultipartFile item) throws Exception {
+        File dest = new File("");
+        item.transferTo(dest);
+        return dest;
+    }
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/swagger/SwaggerDocConfig.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/swagger/SwaggerDocConfig.java
@@ -1,0 +1,34 @@
+package org.georchestra.datafeeder.swagger;
+
+import org.openapitools.configuration.OpenAPIDocumentationConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+@Import(OpenAPIDocumentationConfig.class)
+public class SwaggerDocConfig extends WebMvcConfigurerAdapter {
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/", "/api/swagger-ui.html");
+        registry.addRedirectViewController("/api", "/api/swagger-ui.html");
+        registry.addRedirectViewController("/api/", "/api/swagger-ui.html");
+
+        registry.addRedirectViewController("/api/v2/api-docs", "/v2/api-docs");
+        registry.addRedirectViewController("/api/swagger-resources/configuration/ui",
+                "/swagger-resources/configuration/ui");
+        registry.addRedirectViewController("/api/swagger-resources/configuration/security",
+                "/swagger-resources/configuration/security");
+        registry.addRedirectViewController("/api/swagger-resources", "/swagger-resources");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/api/swagger-ui.html**")
+                .addResourceLocations("classpath:/META-INF/resources/swagger-ui.html");
+        registry.addResourceHandler("/api/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+    }
+}

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -1,6 +1,10 @@
+server:
+  context-path: /import
+
 spring:
   profiles.active: georchestra
-  application.name: datafeeder-service
+  application:
+    name: datafeeder-service
   http:
     # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
     # spring 1.4+ style

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -1,28 +1,35 @@
 spring:
   profiles.active: georchestra
   application.name: datafeeder-service
-  servlet:
-    # configuration properties for javax.servlet.MultipartConfigElement
+  http:
+    # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
+    # spring 1.4+ style
     multipart:
-      # maximum size allowed for uploaded files.
       max-file-size: ${datafeeder.file-upload.max-file-size}
-      # maximum size allowed for multipart/form-data requests
       max-request-size: ${datafeeder.file-upload.max-request-size}
-      # size threshold after which files will be written to disk.
       file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
-      # directory location where files will be stored.
-      location:  ${datafeeder.file-upload.location}
+      location:  ${datafeeder.file-upload.temporary-location}
+  servlet:
+    # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
+    # spring 2.x style, for forward compatibility
+    multipart:
+      max-file-size: ${datafeeder.file-upload.max-file-size}
+      max-request-size: ${datafeeder.file-upload.max-request-size}
+      file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
+      location:  ${datafeeder.file-upload.temporary-location}
 
 datafeeder:
   file-upload:
-    # maximum size allowed for uploaded files.
-    max-file-size: ${file-upload.max-file-size:-1}
-    # maximum size allowed for multipart/form-data requests
-    max-request-size: ${file-upload.max-request-size:-1}
+    # maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)
+    max-file-size: ${file-upload.max-file-size:30MB}
+    # maximum size allowed for multipart/form-data requests (e.g. 128MB, GB can't be used, only KB or MB)
+    max-request-size: ${file-upload.max-request-size:256MB}
     # size threshold after which files will be written to disk.
-    file-size-threshold: ${file-upload.max-size-threshold:}
+    file-size-threshold: ${file-upload.max-size-threshold:1MB}
+    # directory location where files will be stored by the servlet container once the request exceeds the {@link #fileSizeThreshold}
+    temporary-location: ${file-upload.temporary-location:${java.io.tmpdir}/datafeeder/tmp}
     # directory location where files will be stored.
-    location: ${file-upload.location:}
+    persistent-location: ${file-upload.persistent-location:${java.io.tmpdir}/datafeeder/uploads}
 
 ---
 spring:

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.config.security;
 
 import static org.junit.Assert.assertEquals;
@@ -6,14 +24,18 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Arrays;
 
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -31,12 +53,16 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @see SecurityTestController
  */
 @SpringBootTest(classes = DataFeederApiConfiguration.class, webEnvironment = WebEnvironment.RANDOM_PORT)
-@EnableAutoConfiguration
+@EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class)
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = { "georchestra", "test" })
 public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
 
+    private @MockBean DataUploadService dataUploadService;
+    private @MockBean FileStorageService fileStorageService;
+
     private @LocalServerPort int port;
+
     private @Autowired TestRestTemplate template;
 
     private String baseURI;

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.embedded.LocalServerPort;
@@ -62,6 +63,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     private @MockBean FileStorageService fileStorageService;
 
     private @LocalServerPort int port;
+    private @Value("${server.context-path}") String contextPath;
 
     private @Autowired TestRestTemplate template;
 
@@ -72,7 +74,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     private ResponseEntity<GeorchestraUserDetails> response;
 
     public @Before void before() {
-        baseURI = "http://localhost:" + port + "/test/security/georchestra";
+        baseURI = "http://localhost:" + port + contextPath + "/test/security/georchestra";
 
         requestHeaders = new HttpHeaders();
         requestHeaders.set("sec-proxy", "true");

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityTestConfiguration.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityTestConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.config.security;
 
 import org.springframework.context.annotation.Configuration;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
@@ -1,0 +1,73 @@
+package org.georchestra.datafeeder.api;
+
+import java.util.Collections;
+
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.FileStorageService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@SpringBootTest(classes = { DataFeederApiConfiguration.class }, webEnvironment = WebEnvironment.MOCK)
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "test" })
+public class FileUploadApiControllerSecurityTest {
+
+    private @MockBean FileStorageService storageService;
+    private @MockBean DataUploadService uploadService;
+    private @MockBean ApiResponseMapper mapper;
+
+    private @Autowired FileUploadApi controller;
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = "testuser", roles = "INVALIDROLE")
+    public void testUploadFilesInvalidUser() {
+        controller.uploadFiles(Collections.emptyList());
+    }
+
+    @Test(expected = AuthenticationCredentialsNotFoundException.class)
+    public void testUploadFiles_unauthenticated() {
+        controller.uploadFiles(Collections.emptyList());
+    }
+
+    @Test(expected = AuthenticationCredentialsNotFoundException.class)
+    public void testFindAllUploadJobs_unauthenticated() {
+        controller.findAllUploadJobs();
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testFindAllUploadJobs_user_is_not_administrator() {
+        controller.findAllUploadJobs();
+    }
+
+    @Test(expected = AuthenticationCredentialsNotFoundException.class)
+    public void testFindUserUploadJobs_unauthenticated() {
+        controller.findUserUploadJobs();
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = "testuser", roles = "SOMEROLE")
+    public void testFindUserUploadJobs_invalid_role() {
+        controller.findUserUploadJobs();
+    }
+
+    @Test(expected = AuthenticationCredentialsNotFoundException.class)
+    public void testRemoveJob_unauthenticated() {
+        controller.removeJob(null, null);
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = "testuser", roles = "SOMEROLE")
+    public void testRemoveJob_invalid_role() {
+        controller.removeJob(null, null);
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
@@ -1,0 +1,427 @@
+package org.georchestra.datafeeder.api;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.georchestra.datafeeder.model.UploadStatus.ANALYZING;
+import static org.georchestra.datafeeder.model.UploadStatus.DONE;
+import static org.georchestra.datafeeder.model.UploadStatus.ERROR;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.georchestra.datafeeder.app.DataFeederApplicationConfiguration;
+import org.georchestra.datafeeder.model.DataUploadState;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.model.UploadStatus;
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.test.MultipartTestSupport;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.NonNull;
+
+@SpringBootTest(classes = { DataFeederApplicationConfiguration.class }, webEnvironment = WebEnvironment.MOCK)
+@EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class)
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "test" })
+public class FileUploadApiControllerTest {
+
+    private @Autowired DataUploadService uploadService;
+
+    public @Rule MultipartTestSupport multipartSupport = new MultipartTestSupport();
+
+    private @Autowired FileUploadApi controller;
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testUploadFiles_SingleShapefile() {
+
+        List<MultipartFile> shapefileFiles = multipartSupport.archSitesShapefile();
+
+        testUploadSuccess(shapefileFiles, "archsites");
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testUploadFiles_ZipfileWithMultipleShapefiles() throws IOException {
+        List<MultipartFile> archsites = multipartSupport.archSitesShapefile();
+        List<MultipartFile> bugsites = multipartSupport.bugSitesShapefile();
+        List<MultipartFile> roads = multipartSupport.roadsShapefile();
+        List<MultipartFile> statepop = multipartSupport.statePopShapefile();
+        List<MultipartFile> chinesePoly = multipartSupport.chinesePolyShapefile();
+
+        MultipartFile zipFile = multipartSupport.createZipFile("shapefiles.zip", archsites, bugsites, roads, statepop,
+                chinesePoly);
+
+        List<MultipartFile> uploadedFiles = Collections.singletonList(zipFile);
+        testUploadSuccess(uploadedFiles, "archsites", "bugsites", "roads", "statepop", "chinese_poly");
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testUploadFiles_TwoZipFilesWithShapefiles() throws IOException {
+
+        List<MultipartFile> archsites = multipartSupport.archSitesShapefile();
+        List<MultipartFile> bugsites = multipartSupport.bugSitesShapefile();
+        List<MultipartFile> roads = multipartSupport.roadsShapefile();
+        List<MultipartFile> statepop = multipartSupport.statePopShapefile();
+        List<MultipartFile> chinesePoly = multipartSupport.chinesePolyShapefile();
+
+        MultipartFile zipFile1 = multipartSupport.createZipFile("zipfile1.zip", archsites, bugsites);
+        MultipartFile zipFile2 = multipartSupport.createZipFile("zipfile2.zip", roads, statepop, chinesePoly);
+
+        List<MultipartFile> uploadedFiles = Arrays.asList(zipFile1, zipFile2);
+
+        testUploadSuccess(uploadedFiles, "archsites", "bugsites", "roads", "statepop", "chinese_poly");
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testUploadFiles_CorruptShapefile() {
+        List<MultipartFile> received = Arrays.asList(//
+                multipartSupport.createFakeFile("test.shp", 4096), //
+                multipartSupport.createFakeFile("test.shx", 1024), //
+                multipartSupport.createFakeFile("test.prj", 128), //
+                multipartSupport.createFakeFile("test.dbf", 1024)//
+        );
+
+        ResponseEntity<UploadJobStatus> response = controller.uploadFiles(received);
+
+        assertEquals(ACCEPTED, response.getStatusCode());
+        UploadJobStatus initialStatus = response.getBody();
+        assertEquals(UploadJobStatus.StatusEnum.PENDING, initialStatus.getStatus());
+        assertTrue(initialStatus.getDatasets().isEmpty());
+
+        UUID id = initialStatus.getJobId();
+        DataUploadState job = awaitUntilJobIsOneOf(id, 3, ERROR);
+        assertEquals(1, job.getDatasets().size());
+        assertEquals("failed job should report full progress", 1d, job.getProgress(), 0d);
+        assertNotNull(job.getError());
+
+        assertDataset(job.getDatasets(), "test", ERROR);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testUploadFiles_ZipfileWithMultipleShapefiles_SomeFilesCorrupted() throws IOException {
+        MultipartFile zipFile;
+        {
+            List<MultipartFile> corruptFile = Arrays.asList(//
+                    multipartSupport.createFakeFile("test.shp", 4096), //
+                    multipartSupport.createFakeFile("test.shx", 1024), //
+                    multipartSupport.createFakeFile("test.prj", 128), //
+                    multipartSupport.createFakeFile("test.dbf", 1024)//
+            );
+            List<MultipartFile> archsites = multipartSupport.archSitesShapefile();
+            List<MultipartFile> bugsites = multipartSupport.bugSitesShapefile();
+
+            zipFile = multipartSupport.createZipFile("shapefiles.zip", archsites, bugsites, corruptFile);
+        }
+
+        final List<MultipartFile> received = Collections.singletonList(zipFile);
+        final ResponseEntity<UploadJobStatus> response = controller.uploadFiles(received);
+
+        assertEquals(ACCEPTED, response.getStatusCode());
+        UploadJobStatus initialStatus = response.getBody();
+        assertEquals(UploadJobStatus.StatusEnum.PENDING, initialStatus.getStatus());
+        assertTrue(initialStatus.getDatasets().isEmpty());
+
+        final UUID id = initialStatus.getJobId();
+        awaitUntilJobDatasetStateIs(id, "test", 3, ERROR);
+
+        DataUploadState job = awaitUntilJobIsOneOf(id, 3, ERROR);
+        assertEquals(3, job.getDatasets().size());
+        assertEquals("failed job should report full progress", 1d, job.getProgress(), 0d);
+        assertNotNull(job.getError());
+
+        assertDataset(job.getDatasets(), "test", ERROR);
+        assertDataset(job.getDatasets(), "archsites", DONE);
+        assertDataset(job.getDatasets(), "bugsites", DONE);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testFindUploadJob() {
+        UploadJobStatus archsitesJob = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus statepopJob = upload(multipartSupport.statePopShapefile());
+
+        ResponseEntity<UploadJobStatus> response;
+        response = controller.findUploadJob(archsitesJob.getJobId());
+        assertEquals(archsitesJob.getJobId(), response.getBody().getJobId());
+
+        response = controller.findUploadJob(statepopJob.getJobId());
+        assertEquals(statepopJob.getJobId(), response.getBody().getJobId());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testFindUploadJob_non_existent_job_id_returns_404() {
+        UUID invalidId = UUID.randomUUID();
+        ResponseEntity<UploadJobStatus> response = controller.findUploadJob(invalidId);
+        assertEquals(NOT_FOUND, response.getStatusCode());
+    }
+
+    private UploadJobStatus upload(List<MultipartFile> files) {
+        ResponseEntity<UploadJobStatus> response = controller.uploadFiles(files);
+        assertEquals(ACCEPTED, response.getStatusCode());
+        return response.getBody();
+    }
+
+    @Test
+    @WithMockUser(username = "testadmin", roles = "ADMINISTRATOR")
+    public void testFindAllUploadJobs() {
+        setCallingUser("user1", "USER");
+        UploadJobStatus user1Job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user1Job2 = upload(multipartSupport.roadsShapefile());
+
+        setCallingUser("user2", "USER");
+        UploadJobStatus user2Job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user2Job2 = upload(multipartSupport.chinesePolyShapefile());
+
+        ResponseEntity<List<UploadJobStatus>> response = controller.findAllUploadJobs();
+        assertEquals(OK, response.getStatusCode());
+
+        Set<UUID> expected = Arrays.asList(user1Job1, user1Job2, user2Job1, user2Job2).stream()
+                .map(UploadJobStatus::getJobId).collect(Collectors.toSet());
+        Set<UUID> actual = response.getBody().stream().map(UploadJobStatus::getJobId).collect(Collectors.toSet());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testFindUserUploadJobs_returns_only_calling_user_jobs() {
+        setCallingUser("user1", "USER");
+        UploadJobStatus user1Job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user1Job2 = upload(multipartSupport.roadsShapefile());
+
+        setCallingUser("user2", "USER");
+        UploadJobStatus user2Job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user2Job2 = upload(multipartSupport.chinesePolyShapefile());
+
+        setCallingUser("user1", "USER");
+        assertUserJobs(user1Job1, user1Job2);
+
+        setCallingUser("user2", "USER");
+        assertUserJobs(user2Job1, user2Job2);
+
+        setCallingUser("user3", "USER");
+        assertUserJobs();
+    }
+
+    private void assertUserJobs(UploadJobStatus... expectedUserJobs) {
+        ResponseEntity<List<UploadJobStatus>> response = controller.findUserUploadJobs();
+        assertEquals(OK, response.getStatusCode());
+        List<UploadJobStatus> jobs = response.getBody();
+        Set<UUID> expected = Arrays.stream(expectedUserJobs).map(UploadJobStatus::getJobId).collect(Collectors.toSet());
+        Set<UUID> actual = jobs.stream().map(UploadJobStatus::getJobId).collect(Collectors.toSet());
+        assertEquals(expected, actual);
+    }
+
+    private void setCallingUser(@NonNull String username, @NonNull String... roles) {
+        List<GrantedAuthority> authorities = Arrays.stream(roles).map(role -> {
+            assertFalse(role.startsWith("ROLE_"));
+            return new SimpleGrantedAuthority("ROLE_" + role);
+        }).collect(Collectors.toList());
+
+        Authentication auth = new TestingAuthenticationToken(username, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testRemoveJob_ok_when_job_is_done() {
+        UploadJobStatus job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus job2 = upload(multipartSupport.roadsShapefile());
+        UUID id1 = job1.getJobId();
+        UUID id2 = job2.getJobId();
+
+        awaitUntilJobIsOneOf(id1, 3, DONE);
+        awaitUntilJobIsOneOf(id2, 3, DONE);
+
+        final Boolean abort = null;
+
+        assertEquals(OK, controller.findUploadJob(id1).getStatusCode());
+        assertEquals(OK, controller.removeJob(id1, abort));
+        assertEquals(NOT_FOUND, controller.findUploadJob(id1).getStatusCode());
+
+        assertEquals(OK, controller.findUploadJob(id2).getStatusCode());
+        assertEquals(OK, controller.removeJob(id2, abort));
+        assertEquals(NOT_FOUND, controller.findUploadJob(id2).getStatusCode());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testRemoveJob_ok_when_running_and_abort_is_true() {
+        UploadJobStatus job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus job2 = upload(multipartSupport.roadsShapefile());
+        UUID id1 = job1.getJobId();
+        UUID id2 = job2.getJobId();
+
+        final Boolean abort = true;
+        assertEquals(OK, controller.removeJob(id1, abort));
+        assertEquals(OK, controller.removeJob(id2, abort));
+
+        assertEquals(NOT_FOUND, controller.findUploadJob(id1).getStatusCode());
+        assertEquals(NOT_FOUND, controller.findUploadJob(id2).getStatusCode());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testRemoveJob_conflict_if_running_and_abort_not_specified() {
+        UploadJobStatus job1 = upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus job2 = upload(multipartSupport.roadsShapefile());
+        UUID id1 = job1.getJobId();
+        UUID id2 = job2.getJobId();
+
+        final Boolean abort = true;
+        assertEquals(OK, controller.removeJob(id1, abort));
+        assertEquals(OK, controller.removeJob(id2, abort));
+
+        assertEquals(NOT_FOUND, controller.findUploadJob(id1).getStatusCode());
+        assertEquals(NOT_FOUND, controller.findUploadJob(id2).getStatusCode());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testRemoveJob_forbidden_when_job_is_owned_by_another_user() {
+        UploadJobStatus job = upload(multipartSupport.archSitesShapefile());
+        setCallingUser("user2", "USER", "SOMEOTHERROLE");
+        final Boolean abort = true;
+        ResponseEntity<Void> response = controller.removeJob(job.getJobId(), abort);
+        assertEquals(FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    public void testRemoveJob_administrator_can_remove_other_users_jobs() {
+        setCallingUser("testuser", "USER", "SOMEOTHERROLE");
+        UploadJobStatus job = upload(multipartSupport.archSitesShapefile());
+
+        setCallingUser("testadmin", "ADMINISTRATOR", "SOMEOTHERROLE");
+        final Boolean abort = true;
+        ResponseEntity<Void> response = controller.removeJob(job.getJobId(), abort);
+        assertEquals(OK, response.getStatusCode());
+    }
+
+    private void testUploadSuccess(List<MultipartFile> uploadedFiles, String... expectedDatasetNames) {
+
+        ResponseEntity<UploadJobStatus> response = controller.uploadFiles(uploadedFiles);
+
+        assertEquals(ACCEPTED, response.getStatusCode());
+        UploadJobStatus initialStatus = response.getBody();
+        assertNotNull(initialStatus);
+        assertNotNull(initialStatus.getJobId());
+        assertEquals(UploadJobStatus.StatusEnum.PENDING, initialStatus.getStatus());
+        assertNotNull(initialStatus.getDatasets());
+        assertTrue(initialStatus.getDatasets().isEmpty());
+
+        final UUID id = initialStatus.getJobId();
+        awaitUntilJobIsOneOf(id, 1, ANALYZING, DONE);
+        awaitUntilJobIsOneOf(id, 5, DONE);
+
+        DataUploadState state = uploadService.findJobState(id);
+        assertNull(state.getError());
+        assertEquals(1d, state.getProgress(), 0d);
+        List<DatasetUploadState> datasets = state.getDatasets();
+
+        assertEquals(expectedDatasetNames.length, datasets.size());
+        for (String datasetName : expectedDatasetNames) {
+            assertDataset(datasets, datasetName, DONE);
+        }
+    }
+
+    private void assertDataset(@NonNull List<DatasetUploadState> datasets, @NonNull String name,
+            @NonNull UploadStatus expectedStatus) {
+
+        DatasetUploadState datasetState = datasets.stream().filter(d -> name.equals(d.getName())).findFirst()
+                .orElseThrow(() -> new NoSuchElementException("Expected dataset not returned: " + name));
+        datasetState.getEncoding();
+        datasetState.getNativeBounds();
+        datasetState.getSampleGeometryWKT();
+        datasetState.getSampleProperties();
+        assertEquals(expectedStatus, datasetState.getStatus());
+        if (DONE == expectedStatus) {
+            assertNotNull(datasetState.getEncoding());
+            assertNull(datasetState.getError());
+            assertNotNull(datasetState.getNativeBounds());
+            assertNotNull(datasetState.getSampleGeometryWKT());
+            assertNotNull(datasetState.getSampleProperties());
+            assertFalse(datasetState.getSampleProperties().isEmpty());
+        } else if (ERROR == expectedStatus || ANALYZING == expectedStatus) {
+            assertNull(datasetState.getEncoding());
+            assertNull(datasetState.getError());
+            assertNull(datasetState.getNativeBounds());
+            assertNull(datasetState.getSampleGeometryWKT());
+            assertNotNull(datasetState.getSampleProperties());
+            assertTrue(datasetState.getSampleProperties().isEmpty());
+        }
+    }
+
+    private DataUploadState awaitUntilJobIsOneOf(final UUID jobId, int seconds, UploadStatus... oneof) {
+        final AtomicReference<DataUploadState> jobStatus = new AtomicReference<>();
+        await().atMost(seconds, SECONDS).untilAsserted(() -> {
+            DataUploadState jobState = uploadService.findJobState(jobId);
+            jobStatus.set(jobState);
+
+            UploadStatus status = jobState.getStatus();
+            List<Matcher<? super UploadStatus>> matchers;
+            matchers = Arrays.stream(oneof).map(Matchers::equalTo).collect(Collectors.toList());
+            assertThat(status, anyOf(matchers));
+        });
+        return jobStatus.get();
+    }
+
+    private DatasetUploadState awaitUntilJobDatasetStateIs(final UUID jobId, final String datasetName,
+            final int seconds, final UploadStatus expectedStatus) {
+
+        final AtomicReference<DatasetUploadState> datasetStatus = new AtomicReference<>();
+        await().atMost(seconds, SECONDS).untilAsserted(() -> {
+            DataUploadState jobState = uploadService.findJobState(jobId);
+            List<DatasetUploadState> datasets = jobState.getDatasets();
+            Optional<DatasetUploadState> dataset = datasets.stream().filter(ds -> datasetName.equals(ds.getName()))
+                    .findFirst();
+            if (dataset.isPresent()) {
+                DatasetUploadState state = dataset.get();
+                datasetStatus.set(state);
+                assertThat(state, equalTo(expectedStatus));
+            }
+        });
+        return datasetStatus.get();
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
@@ -383,6 +383,8 @@ public class FileUploadApiControllerTest {
             assertNotNull(datasetState.getSampleGeometryWKT());
             assertNotNull(datasetState.getSampleProperties());
             assertFalse(datasetState.getSampleProperties().isEmpty());
+            assertNotNull(datasetState.getNativeCrs());
+            assertNotNull(datasetState.getNativeCrs().getWKT());
         } else if (ERROR == expectedStatus || ANALYZING == expectedStatus) {
             assertNull(datasetState.getEncoding());
             assertNull(datasetState.getError());
@@ -390,6 +392,7 @@ public class FileUploadApiControllerTest {
             assertNull(datasetState.getSampleGeometryWKT());
             assertNotNull(datasetState.getSampleProperties());
             assertTrue(datasetState.getSampleProperties().isEmpty());
+            assertNull(datasetState.getNativeCrs());
         }
     }
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/GeorchestraSecurityTestController.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/GeorchestraSecurityTestController.java
@@ -29,10 +29,13 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import springfox.documentation.annotations.ApiIgnore;
+
 /**
  *
  * @see GeorchestraSecurityProxyAuthenticationConfigurationTest
  */
+@ApiIgnore
 @RequestMapping(path = "/test/security/georchestra")
 public @Controller class GeorchestraSecurityTestController {
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -1,16 +1,42 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.datafeeder.autoconf;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
-import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.MultipartConfig;
-import org.georchestra.datafeeder.test.BaseTestConfig;
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.FileUploadConfig;
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,11 +46,14 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Test suite for {@link GeorchestraIntegrationAutoConfiguration}, which shall
  * be enabled through the {@code georchestra} spring profile
  */
-@SpringBootTest(classes = BaseTestConfig.class)
-@EnableAutoConfiguration
+@SpringBootTest(classes = DataFeederApiConfiguration.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class)
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = { "georchestra", "test" })
 public class GeorchestraIntegrationAutoConfigurationTest {
+
+    private @MockBean DataUploadService dataUploadService;
+    private @MockBean FileStorageService fileStorageService;
 
     private @Autowired ApplicationContext context;
 
@@ -38,12 +67,18 @@ public class GeorchestraIntegrationAutoConfigurationTest {
 
     public @Test void testDataFeederPropertiesFromGeorchestraDatadir() {
         DataFeederConfigurationProperties props = context.getBean(DataFeederConfigurationProperties.class);
-        MultipartConfig fileUpload = props.getFileUpload();
+        FileUploadConfig fileUpload = props.getFileUpload();
         assertNotNull(fileUpload);
 
-        long maxFileSize = fileUpload.getMaxFileSize();
+        final String msg = "is default.properties loaded from src/test/resources/datadir/datafeeder?";
+        assertEquals(msg, "5MB", fileUpload.getMaxFileSize());
+        assertEquals(msg, "10MB", fileUpload.getMaxRequestSize());
+        assertEquals(msg, "1MB", fileUpload.getFileSizeThreshold());
 
-        assertEquals("is default.properties loaded from src/test/resources/datadir/datafeeder?", //
-                5, maxFileSize);
+        String expectedTmp = System.getProperty("java.io.tmpdir") + "/datafeeder/tmp";
+        assertEquals(msg, expectedTmp, fileUpload.getTemporaryLocation());
+
+        Path expectedPersistent = Paths.get(System.getProperty("java.io.tmpdir") + "/datafeeder/uploads");
+        assertEquals(msg, expectedPersistent, fileUpload.getPersistentLocation());
     }
 }

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/DataUploadServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/DataUploadServiceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@SpringBootTest(classes = DataFeederServiceConfiguration.class, webEnvironment = WebEnvironment.NONE)
+@EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class)
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "test" })
+@Ignore(value = "not yet implemented")
+public class DataUploadServiceTest {
+
+    private DataUploadService service;
+
+    public @Test void testAddFileToPackage() {
+        fail("Not yet implemented");
+    }
+
+    public @Test void testAnalyze() {
+        fail("Not yet implemented");
+    }
+
+    public @Test void testFindJobState() {
+        fail("Not yet implemented");
+    }
+
+    public @Test void testFindAllJobs() {
+        fail("Not yet implemented");
+    }
+
+    public @Test void testFindUserJobs() {
+        fail("Not yet implemented");
+    }
+
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/FileStorageServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/FileStorageServiceTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.google.common.collect.Sets;
+
+import lombok.NonNull;
+
+public class FileStorageServiceTest {
+
+    public @Rule TemporaryFolder tmp = new TemporaryFolder();
+
+    private FileStorageService service;
+
+    private Path root;
+
+    public @Before void setUp() {
+        root = tmp.getRoot().toPath();
+        service = new FileStorageService(root);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNonExistentDirectory() {
+        new FileStorageService(Paths.get("/non-existent-directory_aaaa"));
+    }
+
+    public @Test void testInitializePackage() throws IOException {
+        UploadPackage p1 = service.initializePackage();
+        UploadPackage p2 = service.initializePackage();
+        assertNotNull(p1);
+        assertNotNull(p2);
+        assertNotNull(p1.getId());
+        assertNotNull(p2.getId());
+        assertNotEquals(p1.getId(), p2.getId());
+        assertTrue(Files.isDirectory(root.resolve(p1.getId().toString())));
+        assertTrue(Files.isDirectory(root.resolve(p2.getId().toString())));
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void testFindNotFound() throws IOException {
+        service.find(UUID.randomUUID());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFind() throws IOException {
+        UploadPackage p1 = service.initializePackage();
+        UploadPackage p2 = service.initializePackage();
+
+        UploadPackage found1 = service.find(p1.getId());
+        UploadPackage found2 = service.find(p2.getId());
+        assertNotNull(found1);
+        assertNotNull(found2);
+        assertEquals(p1.getId(), found1.getId());
+        assertEquals(p2.getId(), found2.getId());
+
+        service.find(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDeletePackage() throws IOException {
+        UploadPackage p1 = service.initializePackage();
+        UploadPackage p2 = service.initializePackage();
+
+        Path root1 = root.resolve(p1.getId().toString());
+        Path root2 = root.resolve(p2.getId().toString());
+
+        Files.createDirectory(root1.resolve("dir"));
+        Files.createFile(root1.resolve("test.shp"));
+        Files.createFile(root1.resolve("dir/test.shp"));
+
+        service.deletePackage(p1.getId());
+        assertFalse(Files.exists(root1));
+        assertTrue(Files.exists(root2));
+
+        // verify idempotency
+        service.deletePackage(p1.getId());
+        assertFalse(Files.exists(root1));
+        assertTrue(Files.exists(root2));
+
+        service.deletePackage(null);
+    }
+
+    public @Test void testResolve() {
+        UUID id = UUID.randomUUID();
+        assertEquals(root.resolve(id.toString()), service.resolve(id));
+    }
+
+    public @Test void testSaveUploadsNoFiles() throws IOException {
+        List<MultipartFile> received = Collections.emptyList();
+        UUID id = service.saveUploads(received);
+        assertNotNull(id);
+        UploadPackage pack = service.find(id);
+        assertNotNull(pack);
+        Path path = service.resolve(id);
+        assertTrue(Files.isDirectory(path));
+        assertTrue(pack.findAll().isEmpty());
+    }
+
+    public @Test void testSaveUploadsSingleFile() throws IOException {
+        List<MultipartFile> received = Arrays.asList(createMultipartFile("test.geojson", 1024));
+        UUID id = service.saveUploads(received);
+        verifyUploads(id, received);
+    }
+
+    public @Test void testSaveUploadsMultipleFiles() throws IOException {
+        List<MultipartFile> received = Arrays.asList(//
+                createMultipartFile("test.shp", 4096), //
+                createMultipartFile("test.shx", 1024), //
+                createMultipartFile("test.prj", 128), //
+                createMultipartFile("test.dbf", 1024 * 1024)//
+        );
+        UUID id = service.saveUploads(received);
+        verifyUploads(id, received);
+    }
+
+    public @Test void testSaveUploadsZipFileIsExtractedAutomatically() throws IOException {
+        List<MultipartFile> zipped = Arrays.asList(//
+                createMultipartFile("test.shp", 4096), //
+                createMultipartFile("test.shx", 1024), //
+                createMultipartFile("test.prj", 128), //
+                createMultipartFile("test.dbf", 1024 * 1024), //
+
+                createMultipartFile("test2.shp", 2048), //
+                createMultipartFile("test2.shx", 512), //
+                createMultipartFile("test2.prj", 256), //
+                createMultipartFile("test2.dbf", 2 * 1024 * 1024), //
+
+                createMultipartFile("test3.geojson", 1024)//
+        );
+        MultipartFile zipFile = createZipFile("test.zip", zipped);
+        final UUID id = service.saveUploads(Collections.singletonList(zipFile));
+
+        List<MultipartFile> expected = new ArrayList<>(zipped);
+        expected.add(zipFile);
+        verifyUploads(id, expected);
+
+        UploadPackage pack = service.find(id);
+        Set<String> actual = pack.findDatasets();
+        assertEquals(Sets.newHashSet("test.shp", "test2.shp", "test3.geojson"), actual);
+    }
+
+    private void verifyUploads(UUID id, List<MultipartFile> received) throws IOException {
+        UploadPackage pack = service.find(id);
+        for (MultipartFile mpf : received) {
+            byte[] expectedContent = mpf.getBytes();
+            String fileName = mpf.getName();
+            Path path = pack.resolve(fileName);
+            assertTrue(Files.isRegularFile(path));
+            assertEquals(expectedContent.length, Files.size(path));
+            byte[] actualContent = Files.readAllBytes(path);
+            assertArrayEquals(expectedContent, actualContent);
+        }
+    }
+
+    private MultipartFile createMultipartFile(@NonNull String name, int fileSize) {
+        byte[] content = createContents(fileSize);
+        return createMultipartFile(name, content);
+    }
+
+    private MultipartFile createMultipartFile(String name, byte[] content) {
+        String contentType = null;
+        String originalFilename = null;
+        return new MockMultipartFile(name, originalFilename, contentType, content);
+    }
+
+    private byte[] createContents(int fileSize) {
+        byte[] content = new byte[fileSize];
+        for (int i = 0; i < fileSize; content[i] = (byte) i, i++)
+            ;
+        return content;
+    }
+
+    private MultipartFile createZipFile(String zipfileName, List<MultipartFile> files) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (MultipartFile zipped : files) {
+                String name = zipped.getName();
+                byte[] content = zipped.getBytes();
+                ZipEntry entry = new ZipEntry(name);
+                zos.putNextEntry(entry);
+                zos.write(content);
+                zos.closeEntry();
+            }
+        }
+        byte[] zipfileContent = baos.toByteArray();
+        return createMultipartFile(zipfileName, zipfileContent);
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/UploadPackageTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/UploadPackageTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.collect.Sets;
+
+public class UploadPackageTest {
+
+    public @Rule TemporaryFolder tmp = new TemporaryFolder();
+
+    private UploadPackage pack;
+    private FileStorageService service;
+
+    public @Before void setUp() throws IOException {
+        service = mock(FileStorageService.class);
+        final UUID id = UUID.randomUUID();
+        Path root = tmp.getRoot().toPath().resolve(id.toString());
+        Files.createDirectory(root);
+        when(service.resolve(eq(id))).thenReturn(root);
+
+        pack = new UploadPackage(service, id);
+    }
+
+    public @Test void testIsArchive() {
+        assertTrue(pack.isArchive("filename.tar"));
+        assertTrue(pack.isArchive("File Name.TAR"));
+        assertTrue(pack.isArchive("filename.zip"));
+        assertTrue(pack.isArchive("filename.ZiP"));
+        assertTrue(pack.isArchive("filename.gz"));
+        assertTrue(pack.isArchive("filename.tgz"));
+        assertTrue(pack.isArchive("filename.tar.gz"));
+        assertTrue(pack.isArchive("filename.bz2"));
+
+        assertFalse(pack.isArchive("File Name.shp"));
+        assertFalse(pack.isArchive("File Name.json"));
+    }
+
+    public @Test void testFindDatasets() throws IOException {
+        createTestEmptyFiles(//
+                "test.shp", "test.dbf", "test.shx", "test.prj", //
+                "test2.shp", "test2.dbf", "test2.shx", "test2.prj", //
+                "dir/test2.shp", "dir/test2.dbf", "dir/test2.shx", "dir/test2.prj"//
+        );
+
+        Set<String> datasets = pack.findDatasets();
+        Set<String> expected = Sets.newHashSet("test.shp", "test2.shp", "dir/test2.shp");
+        assertEquals(expected, datasets);
+    }
+
+    public @Test void testResolve() {
+        Path root = pack.root();
+        assertEquals(root.resolve("f1"), pack.resolve("f1"));
+    }
+
+    public @Test void testFindAll() throws IOException {
+        String[] fileNames = new String[] { //
+                "test.shp", "test.dbf", "test.shx", "test.prj", //
+                "test2.shp", "test2.dbf", "test2.shx", "test2.prj", //
+                "dir/test2.shp", "dir/test2.dbf", "dir/test2.shx", "dir/test2.prj"//
+        };
+        createTestEmptyFiles(fileNames);
+
+        Set<String> all = pack.findAll();
+        for (String relativeName : fileNames) {
+            assertTrue(relativeName + " not found", all.contains(relativeName));
+        }
+    }
+
+    public @Test void testUnpack() throws IOException {
+        String[] fileNames = new String[] { //
+                "test.shp", "test.dbf", "test.shx", "test.prj", //
+                "test2.shp", "test2.dbf", "test2.shx", "test2.prj", //
+                "dir/test2.shp", "dir/test2.dbf", "dir/test2.shx", "dir/test2.prj"//
+        };
+        byte[] zfContents = createZipFile(fileNames);
+        String zipName = "uploadFile.zip";
+        Path zip = pack.resolve(zipName);
+        Files.write(zip, zfContents);
+
+        pack.unpack(zipName);
+        Set<String> all = pack.findAll();
+        assertTrue(all.contains(zipName));
+        for (String relativeName : fileNames) {
+            assertTrue(relativeName + " not found", all.contains(relativeName));
+        }
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void testUnpackNonExistentArchive() throws IOException {
+        pack.unpack("invalid.zip");
+    }
+
+    private byte[] createZipFile(String... names) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (String name : names) {
+                ZipEntry entry = new ZipEntry(name);
+                zos.putNextEntry(entry);
+                zos.write(new byte[] {});
+                zos.closeEntry();
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private void createTestEmptyFiles(String... names) throws IOException {
+        Path root = pack.root();
+        for (String name : names) {
+            Path path = root.resolve(name);
+            Files.createDirectories(path.getParent());
+            Files.createFile(path);
+        }
+    }
+}

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -1,10 +1,12 @@
 # Datafeeder specific properties
 
-# maximum size allowed for uploaded files.
-file-upload.max-file-size=5
-# maximum size allowed for multipart/form-data requests
-file-upload.max-request-size=1GB
+# maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)
+file-upload.max-file-size=5MB
+# maximum size allowed for multipart/form-data requests (e.g. 128MB, GB can't be used, only KB or MB)
+file-upload.max-request-size=10MB
 # size threshold after which files will be written to disk.
-file-upload.file-size-threshold=
+file-upload.file-size-threshold=1MB
+# directory location where files will be stored by the servlet container once the request exceeds the {@link #fileSizeThreshold}
+file-upload.temporary-location=${java.io.tmpdir}/datafeeder/tmp
 # directory location where files will be stored.
-file-upload.location=
+file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads


### PR DESCRIPTION
Calls to `POST /import/upload` with content-type `multipart/form-data` receive a list of uploaded files with the `filename` parameter.
    
The files are stored to a persistent location under a job identifier (UUID).
    
The persistence root directory is configured though the
`datafeeder.file-upload.persistent-location` configuration property,
which differs from `datafeeder.file-upload.temporary-location` in that
the former is guaranteed to be persistent until explicitly deleted, and
the later is where the servlet container will save files _if_ their size
exceed the configured size threshold, otherwise it keeps them in memory.
    
Uploading archived in .zip, .tar, .tar.gz, .tar.bz2 formats is supported
through commons-vfs2 and automatically extracted when uploaded.
    
Uploaded datasets are recognized using simple filename heuristics by
file name extension: .shp, .geojson, .gpkg.

## TODO:
- WIP: loading datasets metadata using GeoTools
- Fake analysys and file upload functional testing (controller)
