### PR TITLE
Bump to geoserver v2.16.2

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -11,12 +11,12 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.16.1</gs.version>
-    <gt.version>22.1</gt.version>
+    <gs.version>2.16.2</gs.version>
+    <gt.version>22.2</gt.version>
     <geofence.version>3.4.2</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.10.1</jackson.version>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
     <spring.version>5.1.1.RELEASE</spring.version>
     <spring-security.version>5.1.5.RELEASE</spring-security.version>


### PR DESCRIPTION
This update is needed to have the web-resources plugin working (see https://osgeo-org.atlassian.net/browse/GEOS-9348).

Tests:
* compilation with tests OK
* runtime test OK (webapp is able to bootstrap, GS UI can load, I did not test further to be honest)