### PR TITLE
Mapstore2 - Allow access to gs_* tables and hibernate_sequence

### DIFF
--- a/postgresql/110-mapstore.sql
+++ b/postgresql/110-mapstore.sql
@@ -214,4 +214,7 @@ INSERT into gs_category (id ,name) values (6, 'USERSESSION');
 INSERT into gs_category (id ,name) values (7, 'GEOSTORY');
 INSERT into gs_category (id ,name) values (8, 'CONTEXT');
 
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mapstore TO georchestra;
+GRANT USAGE, SELECT ON SEQUENCE hibernate_sequence TO georchestra;
+
 COMMIT;


### PR DESCRIPTION
Fix #3244 by set access right on mapstore tables and hibernate sequence.