### PR TITLE
Datafeeder: allow requesting the sample feature and bounds dynamically

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -345,13 +345,6 @@ components:
           type: integer
           format: int32
           description: Number of features in the dataset
-        sampleProperties:
-          type: array
-          items:
-            $ref: '#/components/schemas/Property'
-        sampleGeometryWKT:
-          type: string
-          description: Well Known Text representation of an exemplar geometry extracted from the dataset
         nativeBounds:
           $ref: '#/components/schemas/BoundingBox'
         encoding:

--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -106,6 +106,53 @@ paths:
         409:
           description: 'Conflict. The abort=true parameter was not provided and the analysis or publishing job is running'
 
+  /upload/{jobId}/{typeName}/sampleFeature:
+    get:
+      tags:
+        - File Upload
+      operationId: getSampleFeature
+      description: Obtain a sample dataset feature in GeoJSON format, optionally specifying a feature index, crs, and/or dataset's character encoding.
+                   The response encoding is always UTF-8. The 'encoding' parameter can be used to force reading the native data in a different charset.
+      parameters:
+      - $ref: '#/components/parameters/jobId'
+      - $ref: '#/components/parameters/typeName'
+      - name: featureIndex
+        in: query
+        description: Optional feature index, if unspecified, the first feature (index 0) is returned
+        required: false
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+      - name: encoding
+        in: query
+        description: Optional, force dataset encoding
+        required: false
+        schema:
+          type: string
+      - name: srs
+        in: query
+        description: Optional, coordinate reference system (e.g. 'EPSG:3857')
+        required: false
+        schema:
+          type: string
+      - name: srs_reproject
+        in: query
+        description: Optional, whether to reproject from the native CRS to the one provided in the srs parameter. If false or not provided, the srs parameter overrides the native CRS
+        required: false
+        schema:
+          type: boolean
+          default: false
+      responses:
+        202:
+          $ref: '#/components/responses/SampleFeatureResponse'
+        400:
+          description: 'Bad request. Some parameter is not acceptable or missing'
+        401:
+          description: 'Not authenticated'
+        403:
+          description: 'Forbidden. User has no priviledges access the requested job'
+
   /upload/{jobId}/publish:
     post:
       tags:
@@ -180,6 +227,13 @@ components:
       schema:
         type: string
         format: uuid
+    typeName:
+      name: typeName
+      in: path
+      description: Feature type name
+      required: true
+      schema:
+        type: string
   responses:
     UploadStatusResponseList:
       description: Processing status of a list of dataset upload job
@@ -201,6 +255,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/PublishJobStatus'
+    SampleFeatureResponse:
+      description: Sample feature for an uploaded dataset
+      content:
+        application/geo+json:
+          schema:
+            type: object
   schemas:
     UploadJobStatus:
       type: object

--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -153,6 +153,38 @@ paths:
         403:
           description: 'Forbidden. User has no priviledges access the requested job'
 
+  /upload/{jobId}/{typeName}/bounds:
+    get:
+      tags:
+        - File Upload
+      operationId: getBounds
+      description: Get the bounding box of the dataset, optionally indicating the CRS and whether to reproject from the native CRS to the new one
+      parameters:
+      - $ref: '#/components/parameters/jobId'
+      - $ref: '#/components/parameters/typeName'
+      - name: srs
+        in: query
+        description: Optional, coordinate reference system (e.g. 'EPSG:3857')
+        required: false
+        schema:
+          type: string
+      - name: srs_reproject
+        in: query
+        description: Optional, whether to reproject from the native CRS to the one provided in the srs parameter. If false or not provided, the srs parameter overrides the native CRS
+        required: false
+        schema:
+          type: boolean
+          default: false
+      responses:
+        202:
+          $ref: '#/components/responses/BoundingBoxResponse'
+        400:
+          description: 'Bad request. Some parameter is not acceptable or missing'
+        401:
+          description: 'Not authenticated'
+        403:
+          description: 'Forbidden. User has no priviledges access the requested job'
+
   /upload/{jobId}/publish:
     post:
       tags:
@@ -261,6 +293,12 @@ components:
         application/geo+json:
           schema:
             type: object
+    BoundingBoxResponse:
+      description: dataset bounds in the requested CRS, if given, defaults to the native CRS
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BoundingBox'
   schemas:
     UploadJobStatus:
       type: object

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -51,6 +51,11 @@
         <artifactId>gt-jdbc-postgis</artifactId>
         <version>${gt.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-geojson</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
       <!--SpringFox dependencies -->
       <dependency>
         <groupId>io.springfox</groupId>

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiResponseMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiResponseMapper.java
@@ -18,6 +18,7 @@
  */
 package org.georchestra.datafeeder.api;
 
+import org.georchestra.datafeeder.model.BoundingBoxMetadata;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.mapstruct.Mapper;
@@ -28,5 +29,7 @@ public interface ApiResponseMapper {
     UploadJobStatus toApi(DataUploadJob state);
 
     DatasetUploadStatus toApi(DatasetUploadState dataset);
+
+    BoundingBox toApi(BoundingBoxMetadata bounds);
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 
+import org.georchestra.datafeeder.model.BoundingBoxMetadata;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.FileStorageService;
@@ -123,6 +124,19 @@ public class FileUploadApiController implements FileUploadApi {
         Object body = writer.toString();
         return ResponseEntity.ok(body);
 
+    }
+
+    @Override
+    public ResponseEntity<BoundingBox> getBounds(@PathVariable("jobId") UUID jobId,
+            @PathVariable("typeName") String typeName, @RequestParam(value = "srs", required = false) String srs,
+            @RequestParam(value = "srs_reproject", required = false, defaultValue = "false") Boolean srsReproject) {
+
+        getAndCheckAccessRights(jobId);
+
+        boolean reproject = srsReproject == null ? false : srsReproject.booleanValue();
+        BoundingBoxMetadata bounds = this.uploadService.computeBounds(jobId, typeName, srs, reproject);
+        BoundingBox bbox = mapper.toApi(bounds);
+        return ResponseEntity.ok(bbox);
     }
 
     @Override

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import org.georchestra.datafeeder.api.FileUploadApiController;
 import org.georchestra.datafeeder.model.AnalysisStatus;
+import org.georchestra.datafeeder.model.BoundingBoxMetadata;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.repository.DataUploadJobRepository;
@@ -84,11 +85,25 @@ public class DataUploadService {
     public SimpleFeature sampleFeature(@NonNull UUID jobId, @NonNull String typeName, int featureN, Charset encoding,
             String srs, boolean srsReproject) {
 
+        DatasetUploadState dataset = getDataset(jobId, typeName);
+        Path path = Paths.get(dataset.getAbsolutePath());
+        return datasetsService.getFeature(path, typeName, encoding, featureN, srs, srsReproject);
+    }
+
+    public BoundingBoxMetadata computeBounds(@NonNull UUID jobId, @NonNull String typeName, String srs,
+            boolean reproject) {
+
+        DatasetUploadState dataset = getDataset(jobId, typeName);
+        Path path = Paths.get(dataset.getAbsolutePath());
+        return datasetsService.getBounds(path, typeName, srs, reproject);
+    }
+
+    private DatasetUploadState getDataset(UUID jobId, String typeName) {
         DataUploadJob job = findJob(jobId)
                 .orElseThrow(() -> new IllegalArgumentException("Job " + jobId + " does not exist"));
         DatasetUploadState dataset = job.getDatasets().stream().filter(d -> d.getName().equals(typeName)).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("dataset " + typeName + " does not exist"));
-        Path path = Paths.get(dataset.getAbsolutePath());
-        return datasetsService.getFeature(path, typeName, encoding, featureN, srs, srsReproject);
+        return dataset;
     }
+
 }

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -1,5 +1,19 @@
 server:
   context-path: /import
+  servlet:
+    # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
+    # spring 2.x style, for forward compatibility
+    multipart:
+      max-file-size: ${datafeeder.file-upload.max-file-size}
+      max-request-size: ${datafeeder.file-upload.max-request-size}
+      file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
+      location:  ${datafeeder.file-upload.temporary-location}
+    # Charset of HTTP requests and responses. Added to the "Content-Type" header if not set explicitly.
+    encoding.charset: UTF-8
+    # Enable http encoding support.
+    encoding.enabled: true
+    # Force the encoding to the configured charset on HTTP requests and responses.
+    encoding.force: true
 
 spring:
   profiles.active: georchestra
@@ -13,16 +27,15 @@ spring:
       max-request-size: ${datafeeder.file-upload.max-request-size}
       file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
       location:  ${datafeeder.file-upload.temporary-location}
-  servlet:
-    # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
-    # spring 2.x style, for forward compatibility
-    multipart:
-      max-file-size: ${datafeeder.file-upload.max-file-size}
-      max-request-size: ${datafeeder.file-upload.max-request-size}
-      file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
-      location:  ${datafeeder.file-upload.temporary-location}
+    # Charset of HTTP requests and responses. Added to the "Content-Type" header if not set explicitly.
+    encoding.charset: UTF-8
+    # Enable http encoding support.
+    encoding.enabled: true
+    # Force the encoding to the configured charset on HTTP requests and responses.
+    encoding.force: true
   batch:
     job.enabled: false #disable automatically running configured jobs at startup time
+
 
 datafeeder:
   file-upload:


### PR DESCRIPTION
Remove `DatasetUploadStatus.sampleProperties` and
`DatasetUploadStatus.sampleGeometryWKT`, in favour end point
`/upload/{jobId}/{typeName}/sampleFeature`, which returns GeoJSON and
allows to set the dataset charset and CRS to override or reproject to.

Detect the shapefile's dbf charset from the uploaded .cpg side-car file, if any.

Add the following end points:

* `GET /upload/{jobId}/{typeName}/sampleFeature?[featureIndex=<index>&srs=<srs_code>&srs_reproject=<true|false>]`
    end point to return the sample feature in GeoJSON format, optionally
    specifying the feature index, the coord system identifier, and whether
    to reproject from the native CRS to the one provided.
    
    When `srs_reproject` is not `true`, the provided CRS overrides the
    dataset's native CRS without reprojection.

* `GET /upload/{jobId}/{typeName}/bounds?srs=<srs_code>&srs_reproject=<true|false>]`
    end point to return the dataset bounding box in either the native CRS or
    reprojected to another one.

This allows the UI to experiment/request the sample feature and bounds in different CRS's and encodings, before proceeding with the publication process, where the CRS and the encoding will be parametrized.
