### PR TITLE
Fix UserController npe in tests

### DIFF
--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: "Running tests"
       working-directory: console/
-      run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none
+      run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none -Dskip.npm
 
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra'

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -130,6 +130,10 @@ public class UsersController {
         this.delegationDao = delegationDao;
     }
 
+    public void setAdvancedDelegationDao(AdvancedDelegationDao advancedDelegationDao) {
+        this.advancedDelegationDao = advancedDelegationDao;
+    }
+
     public void setRoleDao(RoleDao roleDao) {
         this.roleDao = roleDao;
     }

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersExportTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/users/UsersExportTest.java
@@ -118,10 +118,11 @@ import org.georchestra.console.dto.orgs.OrgExt;
 import org.georchestra.console.ws.backoffice.users.CSVAccountExporter.OutlookCSVHeaderField;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.ldap.core.LdapTemplate;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 
@@ -176,7 +177,9 @@ public class UsersExportTest {
         Authentication auth = mock(Authentication.class);
         Collection<GrantedAuthority> authorities = Collections.singleton(AdvancedDelegationDao.ROLE_SUPERUSER);
         doReturn(authorities).when(auth).getAuthorities();
-        SecurityContextHolder.getContext().setAuthentication(auth);
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(securityContext);
 
         when(accDao.findByUID(eq(account1.getUid()))).thenReturn(account1);
         when(accDao.findByUID(eq(account2.getUid()))).thenReturn(account2);


### PR DESCRIPTION
Fix tests in CI
    
It appears that creating a security context was not enough, we needed to
mock it too.

Also skip npm build when tests are run (save time and compute).
