### PR TITLE
Fix weird char in console js

### DIFF
--- a/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
+++ b/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
@@ -101,5 +101,5 @@
     </tbody>
     </table>
 
-    <dir-pagination-controls ng-if="!logger.log.changed && !logger.log.trusted"></dir-pagination-controls>
+    <dir-pagination-controls ng-if="!logger.log.changed && !logger.log.trusted"></dir-pagination-controls>
 </section>


### PR DESCRIPTION
We had this weird error in the browser console :

```
angular.js:15635 Error: [$parse:lexerr] Lexer Error: Unexpected next character at columns 22-22 [Â] in expression [!logger.log.changed &&Â !logger.log.trusted].
https://errors.angularjs.org/1.8.0/$parse/lexerr?p0=Unexpected%20next%20character%20&p1=s%2022-22%20%5B%C3%82%5D&p2=!logger.log.changed%20%26%26%C3%82%C2%A0!logger.log.trusted
at angular.js:138
at Lexer.throwError (angular.js:15814)
at Lexer.lex (angular.js:15737)
at AST.ast (angular.js:15938)
at Parser.getAst (angular.js:17302)
at Parser.parse (angular.js:17285)
at $parse (angular.js:17443)
at Scope.$watch (angular.js:18775)
at Object.link (angular.js:29551)
at angular.js:1391 "<!-- ngIf: !logger.log.changed &&Â !logger.log.trusted -->"
```