### PR TITLE
[LDAP] docker, allow passing admin password as a secret 

### DIFF
--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -31,8 +31,4 @@ ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD [ "sh", "-c", "exec slapd -d ${SLAPD_LOG_LEVEL:-32768} -u ${RUN_AS_UID} -g ${RUN_AS_GID}" ]
 
 HEALTHCHECK --interval=30s --timeout=10s \
-  CMD ldapsearch \
-      -D "cn=admin,dc=georchestra,dc=org" \
-      -w "${SLAPD_PASSWORD}" \
-      -b "dc=georchestra,dc=org" \
-      "cn=geoserver_privileged_user,ou=users,dc=georchestra,dc=org"
+  CMD ldapsearch -xLLL uid=geoserver_privileged_user

--- a/ldap/docker-compose.yml
+++ b/ldap/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     build: ./
     secrets:
       - slapd_password
+      - gs_master_passwd
     environment:
       - SLAPD_DOMAIN=georchestra.org
       - SLAPD_ORGANIZATION=georchestra
@@ -27,3 +28,5 @@ services:
 secrets:
   slapd_password:
     file: ./secrets/slapd_password.txt
+  gs_master_passwd:
+    file: ./secrets/gs_master_passwd.txt

--- a/ldap/docker-compose.yml
+++ b/ldap/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 
 volumes:
   ldap_data_test:
@@ -8,14 +8,21 @@ services:
   ldap:
     image: georchestra/ldap:latest
     build: ./
+    secrets:
+      - slapd_password
     environment:
       - SLAPD_DOMAIN=georchestra.org
       - SLAPD_ORGANIZATION=georchestra
       - SLAPD_ADDITIONAL_MODULES=groupofmembers,openssh
-      - SLAPD_PASSWORD=secret
+      - SLAPD_PASSWORD_FILE=/run/secrets/slapd_password
+      - SLAPD_PASSWORD=
       - SLAPD_LOG_LEVEL=32768
     volumes:
       - ldap_data_test:/var/lib/ldap
       - ldap_config_test:/etc/ldap
     ports:
       - '10389:389'
+
+secrets:
+  slapd_password:
+    file: ./secrets/slapd_password.txt

--- a/ldap/docker-compose.yml
+++ b/ldap/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - SLAPD_ADDITIONAL_MODULES=groupofmembers,openssh
       - SLAPD_PASSWORD_FILE=/run/secrets/slapd_password
       - SLAPD_PASSWORD=
+      - GS_MASTER_PASSWORD_FILE=/run/secrets/gs_master_passwd
       - SLAPD_LOG_LEVEL=32768
     volumes:
       - ldap_data_test:/var/lib/ldap

--- a/ldap/docker-root/docker-entrypoint.d/00-init
+++ b/ldap/docker-root/docker-entrypoint.d/00-init
@@ -6,6 +6,8 @@ ulimit -n 8192
 
 set -e
 
+source /docker-entrypoint.d/utils/load_secrets.sh
+
 SLAPD_FORCE_RECONFIGURE="${SLAPD_FORCE_RECONFIGURE:-false}"
 
 first_run=true

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -3,6 +3,8 @@
 # test if already initialized
 if [ ! -f /etc/ldap/slapd.d/initialized ]; then
 
+    source /docker-entrypoint.d/utils/load_secrets.sh
+
     # start slapd in background
     echo -n "Starting slapd daemon in background..."
     slapd -u ${RUN_AS_UID} -g ${RUN_AS_GID} -h "ldapi:/// ldap://127.0.0.1/"

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -39,6 +39,15 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
     if [ "$IGNORE_DATA" = 'true' ]; then
         echo "$0: ignoring /georchestra.ldif";
     else
+        if [ -n "$GS_MASTER_PASSWORD" ]; then
+            # Allow changing the geoserver master password.
+            # Works on first run only
+            echo "replacing geoserver master password"
+            GS_MASTER_PASSWORD=`slappasswd -s "$GS_MASTER_PASSWORD"`
+            GS_MASTER_PASSWORD=`echo $GS_MASTER_PASSWORD |base64 -`
+            perl -p -i -e "s/e1NIQX1XMlY4d2UrOFdNanpma28rMUtZVDFZcWZFVDQ9/${GS_MASTER_PASSWORD}/" /georchestra.ldif
+        fi
+
         perl -p -i -e "s/georchestra.org/${SLAPD_DOMAIN}/"        /georchestra.ldif
         perl -p -i -e "s/dc=georchestra,dc=org/${dc_string}/"     /georchestra.ldif
         ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /georchestra.ldif

--- a/ldap/docker-root/docker-entrypoint.d/utils/load_secrets.sh
+++ b/ldap/docker-root/docker-entrypoint.d/utils/load_secrets.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# Accept SLAPD_PASSWORD_FILE containing the password
+# (usual way of passing secrets)
+file_env 'SLAPD_PASSWORD'

--- a/ldap/docker-root/docker-entrypoint.d/utils/load_secrets.sh
+++ b/ldap/docker-root/docker-entrypoint.d/utils/load_secrets.sh
@@ -25,3 +25,7 @@ file_env() {
 # Accept SLAPD_PASSWORD_FILE containing the password
 # (usual way of passing secrets)
 file_env 'SLAPD_PASSWORD'
+
+# Accept GS_MASTER_PASSWORD_FILE containing the password
+# Allows to change the geoserver master password on first run
+file_env 'GS_MASTER_PASSWORD'

--- a/ldap/secrets/gs_master_passwd.txt
+++ b/ldap/secrets/gs_master_passwd.txt
@@ -1,0 +1,1 @@
+cqdsfoiuqezq;fjsdhvlj

--- a/ldap/secrets/slapd_password.txt
+++ b/ldap/secrets/slapd_password.txt
@@ -1,0 +1,1 @@
+slap_secret


### PR DESCRIPTION
We shouldn't be passing, on docker, the passwords as plain environment variables. This PR allows : 

- the use of SLAPD_PASSWORD_FILE instead of SLAPD_PASSWORD
- the use of GS_MASTER_PASSWORD_FILE to be able to midify the password of geoserver_privileged_user on first run (modifying it on the datadir is not sufficient. We should provide a way to do it seamlessly here too)

This uses the same script used by  [postgresql](https://github.com/docker-library/postgres/blob/ba302205a1300a5ad262ee770f7ac8a1038e8fde/13/docker-entrypoint.sh#L5-L25) 

The use of secrets is demonstrated in the docker-compose.yml