### PR TITLE
Datafeeder dataset publication initial job definition

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -375,33 +375,24 @@ components:
           items:
             $ref: '#/components/schemas/DatasetPublishRequest'
 
-    DatasetPublishRequest:
+    DatasetMetadata:
       type: object
-      description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
+      description: User supplied dataset metadata information
+      required:
+      - title 
+      - abstract
       properties:
-        nativeName:
-          type: string
-          description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
-        publishedName:
-          type: string
-          description: 
         title:
           type: string
-          description: 
+          description: Metadata title for the dataset
         abstract:
           type: string
-          description: 
-        encoding:
-          type: string
-          description: 
+          description: Metadata abtract text for the dataset 
         tags:
           type: array
-          description: 
+          description: metadata keyworkds for the dataset
           items:           
             type: string
-        crs:
-          description: Optional, Coordinate Reference System to publish the dataset in
-          $ref: '#/components/schemas/CRS'
         creationDate:
           description: Dataset creation date, in RFC3339 format
           type: string
@@ -414,6 +405,35 @@ components:
           example: 25000
         creationProcessDescription:
           type: string
+          description: textual description of dataset lineage
+
+    DatasetPublishRequest:
+      type: object
+      description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
+      required:
+      - nativeName
+      - metadata 
+      properties:
+        nativeName:
+          type: string
+          description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
+        publishedName:
+          type: string
+          description: Name under which the dataset is published to GeoServer, defaults to nativeName
+        encoding:
+          type: string
+          description: Specify which charset (e.g. ISO-8859-1, UTF-8, etc.) to interpret the dataset alphanumeric properties with. Takes effect only for uploaded shapefiles.
+        srs:
+          description: Optional, Coordinate Reference System identifier to publish the dataset in. If not provided, the dataset is published using the CRS inferred
+                       during the upload analysis process. If no CRS identifier was determined, the job will fail.
+          type: string
+        srs_reproject:
+          description: Optional, whether to reproject from the native CRS to the one provided in the srs parameter.
+                       If false or not provided, the srs parameter overrides the native CRS without reprojection.
+          type: boolean
+          default: false
+        metadata:
+          $ref: '#/components/schemas/DatasetMetadata'
 
     PublishJobStatus:
       type: object

--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -209,29 +209,6 @@ paths:
           description: 'Forbidden. User has no priviledges access the requested job'
         409:
           description: 'Conflict. The upload is not ready for publishing.'
-    put:
-      tags:
-        - Data Publishing
-      description: 'Save a draft state for the publication of the dataset(s) from the given upload'
-      operationId: saveDraft
-      parameters:
-      - $ref: '#/components/parameters/jobId'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PublishRequest'
-      responses:
-        202:
-          $ref: '#/components/responses/PublishStatusResponse'
-        400:
-          description: 'Bad request. Some parameter is not acceptable or missing'
-        401:
-          description: 'Not authenticated'
-        403:
-          description: 'Forbidden. User has no priviledges access the requested job'
-        409:
-          description: 'Conflict. The upload is not ready for publishing.'
     get:
       tags:
         - Data Publishing
@@ -400,19 +377,26 @@ components:
 
     DatasetPublishRequest:
       type: object
+      description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
       properties:
         nativeName:
           type: string
+          description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
         publishedName:
           type: string
+          description: 
         title:
           type: string
+          description: 
         abstract:
           type: string
+          description: 
         encoding:
           type: string
+          description: 
         tags:
           type: array
+          description: 
           items:           
             type: string
         crs:
@@ -463,7 +447,7 @@ components:
       properties:
         nativeName:
           type: string
-          description: Name of the dataset in the uploaded package
+          description: Name of the dataset in the uploaded package, necessary to identify which dataset to publish from the UploadJobStatus
         publishedName:
           type: string
           description: Name of the dataset in the uploaded package

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/AuthorizationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/AuthorizationService.java
@@ -16,12 +16,12 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.datafeeder.service;
+package org.georchestra.datafeeder.api;
 
 import java.util.UUID;
 
-import org.georchestra.datafeeder.api.ApiException;
 import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.service.DataUploadService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -37,7 +37,7 @@ import lombok.NonNull;
  *
  */
 @Component
-public class DataUploadValidityService {
+public class AuthorizationService {
 
     private @Autowired DataUploadService uploadService;
 
@@ -48,7 +48,7 @@ public class DataUploadValidityService {
         return userName;
     }
 
-    public DataUploadJob getOrNotFound(UUID uploadId) {
+    private DataUploadJob getOrNotFound(UUID uploadId) {
         DataUploadJob state = this.uploadService.findJob(uploadId)
                 .orElseThrow(() -> ApiException.notFound("upload %s does not exist", uploadId));
         return state;
@@ -61,12 +61,11 @@ public class DataUploadValidityService {
                 .anyMatch("ROLE_ADMINISTRATOR"::equals);
     }
 
-    public DataUploadJob getAndCheckAccessRights(UUID uploadId) {
+    public void checkAccessRights(UUID uploadId) {
         DataUploadJob state = getOrNotFound(uploadId);
         final String userName = getUserName();
         if (!userName.equals(state.getUsername()) && !isAdministrator()) {
             throw ApiException.forbidden("User %s has no access rights to this upload", userName);
         }
-        return state;
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 by the geOrchestra PSC
+ * Copyright (C) 2020, 2021 by the geOrchestra PSC
  *
  * This file is part of geOrchestra.
  *
@@ -18,22 +18,36 @@
  */
 package org.georchestra.datafeeder.api;
 
-import java.util.Optional;
+import java.util.UUID;
 
+import javax.annotation.security.RolesAllowed;
+
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.service.DataPublishingService;
+import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.annotations.Api;
 
 @Controller
+@RolesAllowed({ "ROLE_USER", "ROLE_ADMINISTRATOR" })
 @Api(tags = { "Data Publishing" }) // hides the empty data-publishing-api-controller entry in swagger-ui.html
 public class DataPublishingApiController implements DataPublishingApi {
 
-    private @Autowired NativeWebRequest currentRequest;
+    private @Autowired DataUploadValidityService validityService;
+    private @Autowired DataPublishingService dataPublishingService;
 
-    public @Override Optional<NativeWebRequest> getRequest() {
-        return Optional.of(currentRequest);
+    public ResponseEntity<PublishJobStatus> publish(@PathVariable("jobId") UUID jobId,
+            @RequestBody(required = false) PublishRequest publishRequest) {
+        DataUploadJob uploadPacket = validityService.getAndCheckAccessRights(jobId);
+        dataPublishingService.publish(uploadPacket);
+        //TODO: Response from the service
+        return ResponseEntity.ok(null);
+
     }
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
@@ -18,12 +18,14 @@
  */
 package org.georchestra.datafeeder.api;
 
+import java.util.List;
 import java.util.UUID;
 
 import javax.annotation.security.RolesAllowed;
 
 import org.georchestra.datafeeder.service.DataPublishingService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,12 +41,21 @@ public class DataPublishingApiController implements DataPublishingApi {
     private @Autowired AuthorizationService validityService;
     private @Autowired DataPublishingService dataPublishingService;
 
+    @Override
+    public ResponseEntity<PublishJobStatus> getPublishingStatus(@PathVariable("jobId") UUID jobId) {
+        validityService.checkAccessRights(jobId);
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    @Override
     public ResponseEntity<PublishJobStatus> publish(@PathVariable("jobId") UUID jobId,
             @RequestBody(required = false) PublishRequest publishRequest) {
         validityService.checkAccessRights(jobId);
-        // dataPublishingService.publish(uploadPacket);
+
+        List<DatasetPublishRequest> datasets = publishRequest.getDatasets();
+        dataPublishingService.publish(null);
         // TODO: Response from the service
-        return ResponseEntity.ok(null);
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
@@ -18,12 +18,17 @@
  */
 package org.georchestra.datafeeder.api;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import javax.annotation.security.RolesAllowed;
 
+import org.georchestra.datafeeder.api.DatasetPublishingStatus.StatusEnum;
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.service.DataPublishingService;
+import org.georchestra.datafeeder.service.DataUploadService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,25 +43,51 @@ import io.swagger.annotations.Api;
 @Api(tags = { "Data Publishing" }) // hides the empty data-publishing-api-controller entry in swagger-ui.html
 public class DataPublishingApiController implements DataPublishingApi {
 
-    private @Autowired AuthorizationService validityService;
-    private @Autowired DataPublishingService dataPublishingService;
+	private @Autowired AuthorizationService validityService;
+	private @Autowired DataPublishingService dataPublishingService;
+	private @Autowired DataUploadService uploadService;
 
-    @Override
-    public ResponseEntity<PublishJobStatus> getPublishingStatus(@PathVariable("jobId") UUID jobId) {
-        validityService.checkAccessRights(jobId);
-        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
-    }
+	@Override
+	public ResponseEntity<PublishJobStatus> getPublishingStatus(@PathVariable("jobId") UUID jobId) {
+		validityService.checkAccessRights(jobId);
+		DataUploadJob upload = this.uploadService.findJob(jobId)
+				.orElseThrow(() -> ApiException.notFound("upload %s does not exist", jobId));
 
-    @Override
-    public ResponseEntity<PublishJobStatus> publish(@PathVariable("jobId") UUID jobId,
-            @RequestBody(required = false) PublishRequest publishRequest) {
-        validityService.checkAccessRights(jobId);
+		PublishJobStatus mock = new PublishJobStatus();
+		mock.setJobId(jobId);
+		mock.setDatasets(mockPublishStatus(upload.getDatasets()));
+		mock.setStatus(org.georchestra.datafeeder.api.PublishJobStatus.StatusEnum.RUNNING);
+		return new ResponseEntity<>(mock, HttpStatus.NOT_IMPLEMENTED);
+	}
 
-        List<DatasetPublishRequest> datasets = publishRequest.getDatasets();
-        dataPublishingService.publish(null);
-        // TODO: Response from the service
-        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+	private List<DatasetPublishingStatus> mockPublishStatus(List<DatasetUploadState> datasets) {
+		List<DatasetPublishingStatus> ret = new ArrayList<>();
+		for (DatasetUploadState d : datasets) {
+			DatasetPublishingStatus p = new DatasetPublishingStatus();
+			p.setNativeName(d.getName());
+			p.setPublishedName(d.getName());
+			p.setStatus(StatusEnum.IMPORTING);
+		}
+		return ret;
+	}
 
-    }
+	@Override
+	public ResponseEntity<PublishJobStatus> publish(@PathVariable("jobId") UUID jobId,
+			@RequestBody(required = false) PublishRequest publishRequest) {
+		validityService.checkAccessRights(jobId);
+
+		DataUploadJob upload = this.uploadService.findJob(jobId)
+				.orElseThrow(() -> ApiException.notFound("upload %s does not exist", jobId));
+
+		PublishJobStatus mock = new PublishJobStatus();
+		mock.setJobId(jobId);
+		mock.setDatasets(mockPublishStatus(upload.getDatasets()));
+		mock.setStatus(org.georchestra.datafeeder.api.PublishJobStatus.StatusEnum.RUNNING);
+		return new ResponseEntity<>(mock, HttpStatus.NOT_IMPLEMENTED);
+
+		// dataPublishingService.publish(null);
+		// TODO: Response from the service
+		// return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+	}
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
@@ -45,7 +45,7 @@ public class DataPublishingApiController implements DataPublishingApi {
             @RequestBody(required = false) PublishRequest publishRequest) {
         DataUploadJob uploadPacket = validityService.getAndCheckAccessRights(jobId);
         dataPublishingService.publish(uploadPacket);
-        //TODO: Response from the service
+        // TODO: Response from the service
         return ResponseEntity.ok(null);
 
     }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/DataPublishingApiController.java
@@ -22,9 +22,7 @@ import java.util.UUID;
 
 import javax.annotation.security.RolesAllowed;
 
-import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.service.DataPublishingService;
-import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -38,13 +36,13 @@ import io.swagger.annotations.Api;
 @Api(tags = { "Data Publishing" }) // hides the empty data-publishing-api-controller entry in swagger-ui.html
 public class DataPublishingApiController implements DataPublishingApi {
 
-    private @Autowired DataUploadValidityService validityService;
+    private @Autowired AuthorizationService validityService;
     private @Autowired DataPublishingService dataPublishingService;
 
     public ResponseEntity<PublishJobStatus> publish(@PathVariable("jobId") UUID jobId,
             @RequestBody(required = false) PublishRequest publishRequest) {
-        DataUploadJob uploadPacket = validityService.getAndCheckAccessRights(jobId);
-        dataPublishingService.publish(uploadPacket);
+        validityService.checkAccessRights(jobId);
+        // dataPublishingService.publish(uploadPacket);
         // TODO: Response from the service
         return ResponseEntity.ok(null);
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/PublishingStatus.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/PublishingStatus.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.model;
+
+public enum PublishingStatus {
+    PENDING, RUNNING, DONE, ERROR;
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 by the geOrchestra PSC
+ * Copyright (C) 2020, 2021 by the geOrchestra PSC
  *
  * This file is part of geOrchestra.
  *
@@ -103,4 +103,9 @@ public class DataFeederServiceConfiguration {
     public @Bean DatasetsService datasetsService() {
         return new DatasetsService();
     }
+
+    public @Bean DataUploadValidityService dataUploadValidityService() {
+        return new DataUploadValidityService();
+    }
+
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
@@ -108,4 +108,8 @@ public class DataFeederServiceConfiguration {
         return new DataUploadValidityService();
     }
 
+    public @Bean DataPublishingService dataPublishingService() {
+        return new DataPublishingService();
+    }
+
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataFeederServiceConfiguration.java
@@ -104,10 +104,6 @@ public class DataFeederServiceConfiguration {
         return new DatasetsService();
     }
 
-    public @Bean DataUploadValidityService dataUploadValidityService() {
-        return new DataUploadValidityService();
-    }
-
     public @Bean DataPublishingService dataPublishingService() {
         return new DataPublishingService();
     }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataPublishingService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataPublishingService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020, 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.service.batch.publish.PublishingBatchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DataPublishingService {
+
+    private @Autowired PublishingBatchService publishingBatchService;
+
+    @Async
+    public void publish(DataUploadJob uploadPacket) {
+        publishingBatchService.runJob(uploadPacket.getJobId());
+
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataPublishingService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataPublishingService.java
@@ -18,12 +18,20 @@
  */
 package org.georchestra.datafeeder.service;
 
+import org.georchestra.datafeeder.api.DataPublishingApiController;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.service.batch.publish.PublishingBatchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service provider for {@link DataPublishingApiController}
+ * <p>
+ * Acts as a facade for internal processing of business processes required by
+ * the controller, which in turn only takes care of the HTTP API layer,
+ * delegating all processing to this service.
+ */
 @Service
 public class DataPublishingService {
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadValidityService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadValidityService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service;
+
+import java.util.UUID;
+
+import org.georchestra.datafeeder.api.ApiException;
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+
+/**
+ * Utility service that checks existence of a DataUpload
+ * and verifies access rights.
+ *
+ */
+@Component
+public class DataUploadValidityService {
+    
+    private @Autowired DataUploadService uploadService;
+    
+    public String getUserName() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication auth = context.getAuthentication();
+        String userName = auth.getName();
+        return userName;
+    }
+    
+    public DataUploadJob getOrNotFound(UUID uploadId) {
+        DataUploadJob state = this.uploadService.findJob(uploadId)
+                .orElseThrow(() -> ApiException.notFound("upload %s does not exist", uploadId));
+        return state;
+    }
+    
+    private @NonNull boolean isAdministrator() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication auth = context.getAuthentication();
+        return auth.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                .anyMatch("ROLE_ADMINISTRATOR"::equals);
+    }
+    
+    public DataUploadJob getAndCheckAccessRights(UUID uploadId) {
+        DataUploadJob state = getOrNotFound(uploadId);
+        final String userName = getUserName();
+        if (!userName.equals(state.getUsername()) && !isAdministrator()) {
+            throw ApiException.forbidden("User %s has no access rights to this upload", userName);
+        }
+        return state;
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadValidityService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadValidityService.java
@@ -32,35 +32,35 @@ import org.springframework.stereotype.Component;
 import lombok.NonNull;
 
 /**
- * Utility service that checks existence of a DataUpload
- * and verifies access rights.
+ * Utility service that checks existence of a DataUpload and verifies access
+ * rights.
  *
  */
 @Component
 public class DataUploadValidityService {
-    
+
     private @Autowired DataUploadService uploadService;
-    
+
     public String getUserName() {
         SecurityContext context = SecurityContextHolder.getContext();
         Authentication auth = context.getAuthentication();
         String userName = auth.getName();
         return userName;
     }
-    
+
     public DataUploadJob getOrNotFound(UUID uploadId) {
         DataUploadJob state = this.uploadService.findJob(uploadId)
                 .orElseThrow(() -> ApiException.notFound("upload %s does not exist", uploadId));
         return state;
     }
-    
+
     private @NonNull boolean isAdministrator() {
         SecurityContext context = SecurityContextHolder.getContext();
         Authentication auth = context.getAuthentication();
         return auth.getAuthorities().stream().map(GrantedAuthority::getAuthority)
                 .anyMatch("ROLE_ADMINISTRATOR"::equals);
     }
-    
+
     public DataUploadJob getAndCheckAccessRights(UUID uploadId) {
         DataUploadJob state = getOrNotFound(uploadId);
         final String userName = getUserName();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/PublishingBatchService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/PublishingBatchService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.batch.publish;
+
+import static org.georchestra.datafeeder.service.batch.publish.DataPublishingConfiguration.JOB_NAME;
+import static org.georchestra.datafeeder.service.batch.publish.DataPublishingConfiguration.JOB_PARAM_ID;
+
+import java.util.UUID;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PublishingBatchService {
+
+
+    private @Autowired JobLauncher jobLauncher;
+    private @Autowired @Qualifier(JOB_NAME) Job job;
+
+    public void runJob(@NonNull UUID jobId) {
+        final String paramName = JOB_PARAM_ID;
+        final String paramValue = jobId.toString();
+        final boolean identifying = true;
+
+        final JobParameters params = new JobParametersBuilder()//
+                .addString(paramName, paramValue, identifying)//
+                .toJobParameters();
+        log.info("Launching publishing job {}", jobId);
+        JobExecution execution;
+        try {
+            execution = jobLauncher.run(job, params);
+        } catch (JobExecutionAlreadyRunningException | JobRestartException | JobInstanceAlreadyCompleteException
+                | JobParametersInvalidException e) {
+            log.error("Error running job {}", jobId, e);
+            throw new RuntimeException("Error running job " + jobId, e);
+        }
+        log.info("Publishing job {} finished with status {}", jobId, execution.getStatus());
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/PublishingBatchService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/PublishingBatchService.java
@@ -43,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PublishingBatchService {
 
-
     private @Autowired JobLauncher jobLauncher;
     private @Autowired @Qualifier(JOB_NAME) Job job;
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoNetworkTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoNetworkTasklet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.batch.publish.task;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GeoNetworkTasklet implements Tasklet, StepExecutionListener {
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // TODO Do something here.
+        log.info("before step execution");
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        // FIXME: Implement postgis copying
+        log.info("I would now publish Metadata to GeoNetwork.");
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("after step execution");
+        // TODO: Implement something useful
+        stepExecution.getJobExecution().getExecutionContext().put("result", true);
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoServerGeoNetworkUpdateTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoServerGeoNetworkUpdateTasklet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.batch.publish.task;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GeoServerGeoNetworkUpdateTasklet implements Tasklet, StepExecutionListener {
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // TODO Do something here.
+        log.info("before step execution");
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        // FIXME: Implement postgis copying
+        log.info("I would update GeoServer and add Metadata-Reference.");
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("after step execution");
+        // TODO: Implement something useful
+        stepExecution.getJobExecution().getExecutionContext().put("result", true);
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoServerTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoServerTasklet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ package org.georchestra.datafeeder.service.batch.publish.task;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GeoServerTasklet implements Tasklet, StepExecutionListener {
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // TODO Do something here.
+        log.info("before step execution");
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        // FIXME: Implement postgis copying
+        log.info("I would now publish layer to GeoServer.");
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("after step execution");
+        // TODO: Implement something useful
+        stepExecution.getJobExecution().getExecutionContext().put("result", true);
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoServerTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/GeoServerTasklet.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
- package org.georchestra.datafeeder.service.batch.publish.task;
+package org.georchestra.datafeeder.service.batch.publish.task;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepContribution;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/PostGisTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/PostGisTasklet.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.batch.publish.task;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Tasklet to copy Datasets into PostGIS database.
+
+ */
+@Slf4j
+public class PostGisTasklet implements Tasklet, StepExecutionListener {
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // TODO Do something here.
+        log.info("before step execution");
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        // FIXME: Implement postgis copying
+        log.info("I would now copy data to PostGIS database.");
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("after step execution");
+        // TODO: Implement something useful
+        stepExecution.getJobExecution().getExecutionContext().put("result", true);
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/PostGisTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/batch/publish/task/PostGisTasklet.java
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * Tasklet to copy Datasets into PostGIS database.
-
+ * 
  */
 @Slf4j
 public class PostGisTasklet implements Tasklet, StepExecutionListener {

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -24,7 +24,9 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Arrays;
 
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,6 +62,8 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
 
     private @MockBean DataUploadService dataUploadService;
     private @MockBean FileStorageService fileStorageService;
+    private @MockBean DataUploadValidityService mockDataUploadValidityService;
+    private @MockBean DataPublishingService mockDataPublishingService;
 
     private @LocalServerPort int port;
     private @Value("${server.context-path}") String contextPath;

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -24,9 +24,9 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Arrays;
 
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.georchestra.datafeeder.api.AuthorizationService;
 import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
-import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
 
     private @MockBean DataUploadService dataUploadService;
     private @MockBean FileStorageService fileStorageService;
-    private @MockBean DataUploadValidityService mockDataUploadValidityService;
+    private @MockBean AuthorizationService mockDataUploadValidityService;
     private @MockBean DataPublishingService mockDataPublishingService;
 
     private @LocalServerPort int port;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/ApiTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/ApiTestSupport.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.api;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.georchestra.datafeeder.model.AnalysisStatus.ANALYZING;
+import static org.georchestra.datafeeder.model.AnalysisStatus.DONE;
+import static org.georchestra.datafeeder.model.AnalysisStatus.ERROR;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.georchestra.datafeeder.model.AnalysisStatus;
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.service.DataPublishingService;
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.test.MultipartTestSupport;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.NonNull;
+
+@Service
+public class ApiTestSupport {
+
+    private @Autowired DataUploadService uploadService;
+    private @Autowired DataPublishingService publishingService;
+
+    public @Rule MultipartTestSupport multipartSupport = new MultipartTestSupport();
+
+    private @Autowired FileUploadApi uploadController;
+    private @Autowired DataPublishingApi publishingController;
+
+    public void setCallingUser(@NonNull String username, @NonNull String... roles) {
+        List<GrantedAuthority> authorities = Arrays.stream(roles).map(role -> {
+            assertFalse(role.startsWith("ROLE_"));
+            return new SimpleGrantedAuthority("ROLE_" + role);
+        }).collect(Collectors.toList());
+
+        Authentication auth = new TestingAuthenticationToken(username, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    public UploadJobStatus upload(List<MultipartFile> files) {
+        ResponseEntity<UploadJobStatus> response = uploadController.uploadFiles(files);
+        assertEquals(ACCEPTED, response.getStatusCode());
+        return response.getBody();
+    }
+
+    public void assertUserJobs(UploadJobStatus... expectedUserJobs) {
+        ResponseEntity<List<UploadJobStatus>> response = uploadController.findUserUploadJobs();
+        assertEquals(OK, response.getStatusCode());
+        List<UploadJobStatus> jobs = response.getBody();
+        Set<UUID> expected = Arrays.stream(expectedUserJobs).map(UploadJobStatus::getJobId).collect(Collectors.toSet());
+        Set<UUID> actual = jobs.stream().map(UploadJobStatus::getJobId).collect(Collectors.toSet());
+        assertEquals(expected, actual);
+    }
+
+    public DataUploadJob uploadAndWaitForSuccess(List<MultipartFile> uploadedFiles, String... expectedDatasetNames) {
+
+        ResponseEntity<UploadJobStatus> response = uploadController.uploadFiles(uploadedFiles);
+
+        assertEquals(ACCEPTED, response.getStatusCode());
+        UploadJobStatus initialStatus = response.getBody();
+        assertNotNull(initialStatus);
+        assertNotNull(initialStatus.getJobId());
+        assertEquals(UploadJobStatus.StatusEnum.PENDING, initialStatus.getStatus());
+        assertNotNull(initialStatus.getDatasets());
+        assertTrue(initialStatus.getDatasets().isEmpty());
+
+        final UUID id = initialStatus.getJobId();
+        awaitUntilJobIsOneOf(id, 1, ANALYZING, DONE);
+        awaitUntilJobIsOneOf(id, 5, DONE);
+
+        Optional<DataUploadJob> state = uploadService.findJob(id);
+        assertTrue(state.isPresent());
+        assertNull(state.get().getError());
+        assertEquals(1d, state.get().getProgress(), 0d);
+        List<DatasetUploadState> datasets = state.get().getDatasets();
+
+        assertEquals(expectedDatasetNames.length, datasets.size());
+        for (String datasetName : expectedDatasetNames) {
+            assertDataset(datasets, datasetName, DONE);
+        }
+        return state.get();
+    }
+
+    public void assertDataset(@NonNull List<DatasetUploadState> datasets, @NonNull String name,
+            @NonNull AnalysisStatus expectedStatus) {
+
+        DatasetUploadState datasetState = datasets.stream().filter(d -> name.equals(d.getName())).findFirst()
+                .orElseThrow(() -> new NoSuchElementException("Expected dataset not returned: " + name));
+        datasetState.getEncoding();
+        datasetState.getNativeBounds();
+        datasetState.getSampleGeometryWKT();
+        datasetState.getSampleProperties();
+        assertEquals(expectedStatus, datasetState.getStatus());
+        if (DONE == expectedStatus) {
+            assertNotNull(datasetState.getEncoding());
+            assertNull(datasetState.getError());
+            assertNotNull(datasetState.getNativeBounds());
+            assertNotNull(datasetState.getSampleGeometryWKT());
+            assertNotNull(datasetState.getSampleProperties());
+            assertFalse(datasetState.getSampleProperties().isEmpty());
+            assertNotNull(datasetState.getNativeBounds());
+            assertNotNull(datasetState.getNativeBounds().getCrs());
+            assertNotNull(datasetState.getNativeBounds().getCrs().getWKT());
+        } else if (ERROR == expectedStatus) {
+            assertNull(datasetState.getEncoding());
+            assertNotNull(datasetState.getError());
+            assertNull(datasetState.getNativeBounds());
+            assertNull(datasetState.getSampleGeometryWKT());
+            assertNotNull(datasetState.getSampleProperties());
+            assertTrue(datasetState.getSampleProperties().isEmpty());
+            assertNull(datasetState.getNativeBounds());
+        }
+    }
+
+    public DataUploadJob awaitUntilJobIsOneOf(final UUID jobId, int seconds, AnalysisStatus... oneof) {
+        final AtomicReference<DataUploadJob> jobStatus = new AtomicReference<>();
+        await().atMost(seconds, SECONDS).untilAsserted(() -> {
+            DataUploadJob jobState = uploadService.findJob(jobId).orElseThrow(NoSuchElementException::new);
+            jobStatus.set(jobState);
+
+            AnalysisStatus status = jobState.getStatus();
+            List<Matcher<? super AnalysisStatus>> matchers;
+            matchers = Arrays.stream(oneof).map(Matchers::equalTo).collect(Collectors.toList());
+            assertThat(status, anyOf(matchers));
+        });
+        return jobStatus.get();
+    }
+
+    public DatasetUploadState awaitUntilJobDatasetUploadStatusIs(final UUID jobId, final String datasetName,
+            final int seconds, final AnalysisStatus expectedStatus) {
+
+        final AtomicReference<DatasetUploadState> datasetStatus = new AtomicReference<>();
+        await().atMost(seconds, SECONDS).untilAsserted(() -> {
+            DataUploadJob jobState = uploadService.findJob(jobId).orElseThrow(NoSuchElementException::new);
+            List<DatasetUploadState> datasets = jobState.getDatasets();
+            Optional<DatasetUploadState> dataset = datasets.stream().filter(ds -> datasetName.equals(ds.getName()))
+                    .findFirst();
+            if (dataset.isPresent()) {
+                DatasetUploadState state = dataset.get();
+                datasetStatus.set(state);
+                assertThat(state.getStatus(), equalTo(expectedStatus));
+            }
+        });
+        return datasetStatus.get();
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/DataPublishingApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/DataPublishingApiControllerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.api;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.georchestra.datafeeder.app.DataFeederApplicationConfiguration;
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.test.MultipartTestSupport;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opengis.feature.simple.SimpleFeature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.multipart.MultipartFile;
+
+@SpringBootTest(classes = { DataFeederApplicationConfiguration.class }, webEnvironment = WebEnvironment.MOCK)
+@EnableAutoConfiguration
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "test" })
+public class DataPublishingApiControllerTest {
+
+    private @Autowired ApiTestSupport testSupport;
+    private @Autowired DataUploadService datasets;
+    public @Rule MultipartTestSupport multipartSupport = new MultipartTestSupport();
+
+    private @Autowired DataPublishingApi controller;
+
+    @Test
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testPublish_SingleShapefile() {
+        List<MultipartFile> shapefileFiles = multipartSupport.chinesePolyShapefile();
+        DataUploadJob upload = testSupport.uploadAndWaitForSuccess(shapefileFiles, "chinese_poly");
+        // correct chinese_poly's dbf charset: GB18030, NAME: 黑龙江省
+        SimpleFeature sampleFeature = datasets.sampleFeature(upload.getJobId(), "chinese_poly", 0,
+                Charset.forName("GB18030"), null, false);
+        System.err.println(sampleFeature.getAttribute("NAME"));
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
@@ -20,7 +20,9 @@ package org.georchestra.datafeeder.api;
 
 import java.util.Collections;
 
+import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +44,8 @@ public class FileUploadApiControllerSecurityTest {
     private @MockBean FileStorageService storageService;
     private @MockBean DataUploadService uploadService;
     private @MockBean ApiResponseMapper mapper;
+    private @MockBean DataUploadValidityService mockDataUploadValidityService;
+    private @MockBean DataPublishingService mockDataPublishingService;
 
     private @Autowired FileUploadApi controller;
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 
 import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
-import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +43,7 @@ public class FileUploadApiControllerSecurityTest {
     private @MockBean FileStorageService storageService;
     private @MockBean DataUploadService uploadService;
     private @MockBean ApiResponseMapper mapper;
-    private @MockBean DataUploadValidityService mockDataUploadValidityService;
+    private @MockBean AuthorizationService mockDataUploadValidityService;
     private @MockBean DataPublishingService mockDataPublishingService;
 
     private @Autowired FileUploadApi controller;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
@@ -18,17 +18,10 @@
  */
 package org.georchestra.datafeeder.api;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
-import static org.georchestra.datafeeder.model.AnalysisStatus.ANALYZING;
 import static org.georchestra.datafeeder.model.AnalysisStatus.DONE;
 import static org.georchestra.datafeeder.model.AnalysisStatus.ERROR;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -41,20 +34,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.georchestra.datafeeder.app.DataFeederApplicationConfiguration;
-import org.georchestra.datafeeder.model.AnalysisStatus;
 import org.georchestra.datafeeder.model.DataUploadJob;
-import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.test.MultipartTestSupport;
-import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -65,17 +52,10 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.multipart.MultipartFile;
-
-import lombok.NonNull;
 
 @SpringBootTest(classes = { DataFeederApplicationConfiguration.class }, webEnvironment = WebEnvironment.MOCK)
 @EnableAutoConfiguration
@@ -83,6 +63,7 @@ import lombok.NonNull;
 @ActiveProfiles(value = { "georchestra", "test" })
 public class FileUploadApiControllerTest {
 
+    private @Autowired ApiTestSupport testSupport;
     private @Autowired DataUploadService uploadService;
 
     public @Rule MultipartTestSupport multipartSupport = new MultipartTestSupport();
@@ -95,7 +76,7 @@ public class FileUploadApiControllerTest {
 
         List<MultipartFile> shapefileFiles = multipartSupport.archSitesShapefile();
 
-        testUploadSuccess(shapefileFiles, "archsites");
+        testSupport.uploadAndWaitForSuccess(shapefileFiles, "archsites");
     }
 
     @Test
@@ -111,7 +92,8 @@ public class FileUploadApiControllerTest {
                 chinesePoly);
 
         List<MultipartFile> uploadedFiles = Collections.singletonList(zipFile);
-        testUploadSuccess(uploadedFiles, "archsites", "bugsites", "roads", "statepop", "chinese_poly");
+        testSupport.uploadAndWaitForSuccess(uploadedFiles, "archsites", "bugsites", "roads", "statepop",
+                "chinese_poly");
     }
 
     @Test
@@ -129,7 +111,8 @@ public class FileUploadApiControllerTest {
 
         List<MultipartFile> uploadedFiles = Arrays.asList(zipFile1, zipFile2);
 
-        testUploadSuccess(uploadedFiles, "archsites", "bugsites", "roads", "statepop", "chinese_poly");
+        testSupport.uploadAndWaitForSuccess(uploadedFiles, "archsites", "bugsites", "roads", "statepop",
+                "chinese_poly");
     }
 
     @Test
@@ -150,13 +133,13 @@ public class FileUploadApiControllerTest {
         assertTrue(initialStatus.getDatasets().isEmpty());
 
         UUID id = initialStatus.getJobId();
-        DataUploadJob job = awaitUntilJobIsOneOf(id, 3, ERROR);
+        DataUploadJob job = testSupport.awaitUntilJobIsOneOf(id, 3, ERROR);
         job = uploadService.findJob(job.getJobId()).orElse(null);
         assertEquals(1, job.getDatasets().size());
         assertEquals("failed job should report full progress", 1d, job.getProgress(), 0d);
         assertNotNull(job.getError());
 
-        assertDataset(job.getDatasets(), "test", ERROR);
+        testSupport.assertDataset(job.getDatasets(), "test", ERROR);
     }
 
     @Test
@@ -185,24 +168,24 @@ public class FileUploadApiControllerTest {
         assertTrue(initialStatus.getDatasets().isEmpty());
 
         final UUID id = initialStatus.getJobId();
-        awaitUntilJobDatasetUploadStatusIs(id, "test", 3, ERROR);
+        testSupport.awaitUntilJobDatasetUploadStatusIs(id, "test", 3, ERROR);
 
-        DataUploadJob job = awaitUntilJobIsOneOf(id, 3, ERROR);
+        DataUploadJob job = testSupport.awaitUntilJobIsOneOf(id, 3, ERROR);
         job = this.uploadService.findJob(job.getJobId()).orElse(null);
         assertEquals(3, job.getDatasets().size());
         assertEquals("failed job should report full progress", 1d, job.getProgress(), 0d);
         assertNotNull(job.getError());
 
-        assertDataset(job.getDatasets(), "archsites", DONE);
-        assertDataset(job.getDatasets(), "bugsites", DONE);
-        assertDataset(job.getDatasets(), "test", ERROR);
+        testSupport.assertDataset(job.getDatasets(), "archsites", DONE);
+        testSupport.assertDataset(job.getDatasets(), "bugsites", DONE);
+        testSupport.assertDataset(job.getDatasets(), "test", ERROR);
     }
 
     @Test
     @WithMockUser(username = "testuser", roles = "USER")
     public void testFindUploadJob() {
-        UploadJobStatus archsitesJob = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus statepopJob = upload(multipartSupport.statePopShapefile());
+        UploadJobStatus archsitesJob = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus statepopJob = testSupport.upload(multipartSupport.statePopShapefile());
 
         ResponseEntity<UploadJobStatus> response;
         response = controller.findUploadJob(archsitesJob.getJobId());
@@ -224,24 +207,18 @@ public class FileUploadApiControllerTest {
         }
     }
 
-    private UploadJobStatus upload(List<MultipartFile> files) {
-        ResponseEntity<UploadJobStatus> response = controller.uploadFiles(files);
-        assertEquals(ACCEPTED, response.getStatusCode());
-        return response.getBody();
-    }
-
     @Test
     @WithMockUser(username = "testadmin", roles = "ADMINISTRATOR")
     public void testFindAllUploadJobs() {
-        setCallingUser("user1", "USER");
-        UploadJobStatus user1Job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus user1Job2 = upload(multipartSupport.roadsShapefile());
+        testSupport.setCallingUser("user1", "USER");
+        UploadJobStatus user1Job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user1Job2 = testSupport.upload(multipartSupport.roadsShapefile());
 
-        setCallingUser("user2", "USER");
-        UploadJobStatus user2Job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus user2Job2 = upload(multipartSupport.chinesePolyShapefile());
+        testSupport.setCallingUser("user2", "USER");
+        UploadJobStatus user2Job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user2Job2 = testSupport.upload(multipartSupport.chinesePolyShapefile());
 
-        setCallingUser("testadmin", "ADMINISTRATOR");
+        testSupport.setCallingUser("testadmin", "ADMINISTRATOR");
         ResponseEntity<List<UploadJobStatus>> response = controller.findAllUploadJobs();
         assertEquals(OK, response.getStatusCode());
 
@@ -253,21 +230,21 @@ public class FileUploadApiControllerTest {
 
     @Test
     public void testFindUserUploadJobs_returns_only_calling_user_jobs() {
-        setCallingUser("user1", "USER");
-        UploadJobStatus user1Job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus user1Job2 = upload(multipartSupport.roadsShapefile());
+        testSupport.setCallingUser("user1", "USER");
+        UploadJobStatus user1Job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user1Job2 = testSupport.upload(multipartSupport.roadsShapefile());
 
-        setCallingUser("user2", "USER");
-        UploadJobStatus user2Job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus user2Job2 = upload(multipartSupport.chinesePolyShapefile());
+        testSupport.setCallingUser("user2", "USER");
+        UploadJobStatus user2Job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus user2Job2 = testSupport.upload(multipartSupport.chinesePolyShapefile());
 
-        setCallingUser("user1", "USER");
+        testSupport.setCallingUser("user1", "USER");
         assertUserJobs(user1Job1, user1Job2);
 
-        setCallingUser("user2", "USER");
+        testSupport.setCallingUser("user2", "USER");
         assertUserJobs(user2Job1, user2Job2);
 
-        setCallingUser("user3", "USER");
+        testSupport.setCallingUser("user3", "USER");
         assertUserJobs();
     }
 
@@ -280,26 +257,16 @@ public class FileUploadApiControllerTest {
         assertEquals(expected, actual);
     }
 
-    private void setCallingUser(@NonNull String username, @NonNull String... roles) {
-        List<GrantedAuthority> authorities = Arrays.stream(roles).map(role -> {
-            assertFalse(role.startsWith("ROLE_"));
-            return new SimpleGrantedAuthority("ROLE_" + role);
-        }).collect(Collectors.toList());
-
-        Authentication auth = new TestingAuthenticationToken(username, null, authorities);
-        SecurityContextHolder.getContext().setAuthentication(auth);
-    }
-
     @Test
     @WithMockUser(username = "testuser", roles = "USER")
     public void testRemoveJob_ok_when_job_is_done() {
-        UploadJobStatus job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus job2 = upload(multipartSupport.roadsShapefile());
+        UploadJobStatus job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus job2 = testSupport.upload(multipartSupport.roadsShapefile());
         UUID id1 = job1.getJobId();
         UUID id2 = job2.getJobId();
 
-        awaitUntilJobIsOneOf(id1, 3, DONE);
-        awaitUntilJobIsOneOf(id2, 3, DONE);
+        testSupport.awaitUntilJobIsOneOf(id1, 3, DONE);
+        testSupport.awaitUntilJobIsOneOf(id2, 3, DONE);
 
         final Boolean abort = null;
 
@@ -326,8 +293,8 @@ public class FileUploadApiControllerTest {
     @Test
     @WithMockUser(username = "testuser", roles = "USER")
     public void testRemoveJob_ok_when_running_and_abort_is_true() {
-        UploadJobStatus job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus job2 = upload(multipartSupport.roadsShapefile());
+        UploadJobStatus job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus job2 = testSupport.upload(multipartSupport.roadsShapefile());
         UUID id1 = job1.getJobId();
         UUID id2 = job2.getJobId();
 
@@ -343,8 +310,8 @@ public class FileUploadApiControllerTest {
     @Test
     @WithMockUser(username = "testuser", roles = "USER")
     public void testRemoveJob_conflict_if_running_and_abort_not_specified() {
-        UploadJobStatus job1 = upload(multipartSupport.archSitesShapefile());
-        UploadJobStatus job2 = upload(multipartSupport.roadsShapefile());
+        UploadJobStatus job1 = testSupport.upload(multipartSupport.archSitesShapefile());
+        UploadJobStatus job2 = testSupport.upload(multipartSupport.roadsShapefile());
         UUID id1 = job1.getJobId();
         UUID id2 = job2.getJobId();
 
@@ -359,8 +326,8 @@ public class FileUploadApiControllerTest {
     @Test
     @WithMockUser(username = "testuser", roles = "USER")
     public void testRemoveJob_forbidden_when_job_is_owned_by_another_user() {
-        UploadJobStatus job = upload(multipartSupport.archSitesShapefile());
-        setCallingUser("user2", "USER", "SOMEOTHERROLE");
+        UploadJobStatus job = testSupport.upload(multipartSupport.archSitesShapefile());
+        testSupport.setCallingUser("user2", "USER", "SOMEOTHERROLE");
         final Boolean abort = true;
         try {
             controller.removeJob(job.getJobId(), abort);
@@ -374,103 +341,12 @@ public class FileUploadApiControllerTest {
     @Ignore("waiting for implementation of remove as part of GSGEODPT43-88")
     @Test
     public void testRemoveJob_administrator_can_remove_other_users_jobs() {
-        setCallingUser("testuser", "USER", "SOMEOTHERROLE");
-        UploadJobStatus job = upload(multipartSupport.archSitesShapefile());
+        testSupport.setCallingUser("testuser", "USER", "SOMEOTHERROLE");
+        UploadJobStatus job = testSupport.upload(multipartSupport.archSitesShapefile());
 
-        setCallingUser("testadmin", "ADMINISTRATOR", "SOMEOTHERROLE");
+        testSupport.setCallingUser("testadmin", "ADMINISTRATOR", "SOMEOTHERROLE");
         final Boolean abort = true;
         ResponseEntity<Void> response = controller.removeJob(job.getJobId(), abort);
         assertEquals(OK, response.getStatusCode());
-    }
-
-    private void testUploadSuccess(List<MultipartFile> uploadedFiles, String... expectedDatasetNames) {
-
-        ResponseEntity<UploadJobStatus> response = controller.uploadFiles(uploadedFiles);
-
-        assertEquals(ACCEPTED, response.getStatusCode());
-        UploadJobStatus initialStatus = response.getBody();
-        assertNotNull(initialStatus);
-        assertNotNull(initialStatus.getJobId());
-        assertEquals(UploadJobStatus.StatusEnum.PENDING, initialStatus.getStatus());
-        assertNotNull(initialStatus.getDatasets());
-        assertTrue(initialStatus.getDatasets().isEmpty());
-
-        final UUID id = initialStatus.getJobId();
-        awaitUntilJobIsOneOf(id, 1, ANALYZING, DONE);
-        awaitUntilJobIsOneOf(id, 5, DONE);
-
-        Optional<DataUploadJob> state = uploadService.findJob(id);
-        assertTrue(state.isPresent());
-        assertNull(state.get().getError());
-        assertEquals(1d, state.get().getProgress(), 0d);
-        List<DatasetUploadState> datasets = state.get().getDatasets();
-
-        assertEquals(expectedDatasetNames.length, datasets.size());
-        for (String datasetName : expectedDatasetNames) {
-            assertDataset(datasets, datasetName, DONE);
-        }
-    }
-
-    private void assertDataset(@NonNull List<DatasetUploadState> datasets, @NonNull String name,
-            @NonNull AnalysisStatus expectedStatus) {
-
-        DatasetUploadState datasetState = datasets.stream().filter(d -> name.equals(d.getName())).findFirst()
-                .orElseThrow(() -> new NoSuchElementException("Expected dataset not returned: " + name));
-        datasetState.getEncoding();
-        datasetState.getNativeBounds();
-        datasetState.getSampleGeometryWKT();
-        datasetState.getSampleProperties();
-        assertEquals(expectedStatus, datasetState.getStatus());
-        if (DONE == expectedStatus) {
-            assertNotNull(datasetState.getEncoding());
-            assertNull(datasetState.getError());
-            assertNotNull(datasetState.getNativeBounds());
-            assertNotNull(datasetState.getSampleGeometryWKT());
-            assertNotNull(datasetState.getSampleProperties());
-            assertFalse(datasetState.getSampleProperties().isEmpty());
-            assertNotNull(datasetState.getNativeBounds());
-            assertNotNull(datasetState.getNativeBounds().getCrs());
-            assertNotNull(datasetState.getNativeBounds().getCrs().getWKT());
-        } else if (ERROR == expectedStatus) {
-            assertNull(datasetState.getEncoding());
-            assertNotNull(datasetState.getError());
-            assertNull(datasetState.getNativeBounds());
-            assertNull(datasetState.getSampleGeometryWKT());
-            assertNotNull(datasetState.getSampleProperties());
-            assertTrue(datasetState.getSampleProperties().isEmpty());
-            assertNull(datasetState.getNativeBounds());
-        }
-    }
-
-    private DataUploadJob awaitUntilJobIsOneOf(final UUID jobId, int seconds, AnalysisStatus... oneof) {
-        final AtomicReference<DataUploadJob> jobStatus = new AtomicReference<>();
-        await().atMost(seconds, SECONDS).untilAsserted(() -> {
-            DataUploadJob jobState = uploadService.findJob(jobId).orElseThrow(NoSuchElementException::new);
-            jobStatus.set(jobState);
-
-            AnalysisStatus status = jobState.getStatus();
-            List<Matcher<? super AnalysisStatus>> matchers;
-            matchers = Arrays.stream(oneof).map(Matchers::equalTo).collect(Collectors.toList());
-            assertThat(status, anyOf(matchers));
-        });
-        return jobStatus.get();
-    }
-
-    private DatasetUploadState awaitUntilJobDatasetUploadStatusIs(final UUID jobId, final String datasetName,
-            final int seconds, final AnalysisStatus expectedStatus) {
-
-        final AtomicReference<DatasetUploadState> datasetStatus = new AtomicReference<>();
-        await().atMost(seconds, SECONDS).untilAsserted(() -> {
-            DataUploadJob jobState = uploadService.findJob(jobId).orElseThrow(NoSuchElementException::new);
-            List<DatasetUploadState> datasets = jobState.getDatasets();
-            Optional<DatasetUploadState> dataset = datasets.stream().filter(ds -> datasetName.equals(ds.getName()))
-                    .findFirst();
-            if (dataset.isPresent()) {
-                DatasetUploadState state = dataset.get();
-                datasetStatus.set(state);
-                assertThat(state.getStatus(), equalTo(expectedStatus));
-            }
-        });
-        return datasetStatus.get();
     }
 }

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -27,13 +27,14 @@ import java.nio.file.Paths;
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.FileUploadConfig;
+import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
+import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -54,6 +55,8 @@ public class GeorchestraIntegrationAutoConfigurationTest {
 
     private @MockBean DataUploadService dataUploadService;
     private @MockBean FileStorageService fileStorageService;
+    private @MockBean DataUploadValidityService mockDataUploadValidityService;
+    private @MockBean DataPublishingService mockDataPublishingService;
 
     private @Autowired ApplicationContext context;
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -25,11 +25,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.georchestra.datafeeder.api.AuthorizationService;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.FileUploadConfig;
 import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
-import org.georchestra.datafeeder.service.DataUploadValidityService;
 import org.georchestra.datafeeder.service.FileStorageService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +55,7 @@ public class GeorchestraIntegrationAutoConfigurationTest {
 
     private @MockBean DataUploadService dataUploadService;
     private @MockBean FileStorageService fileStorageService;
-    private @MockBean DataUploadValidityService mockDataUploadValidityService;
+    private @MockBean AuthorizationService mockDataUploadValidityService;
     private @MockBean DataPublishingService mockDataPublishingService;
 
     private @Autowired ApplicationContext context;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/batch/analysis/BatchTestConfiguration.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/batch/analysis/BatchTestConfiguration.java
@@ -33,10 +33,10 @@ public class BatchTestConfiguration {
 
     private @Autowired PlatformTransactionManager transactionManager;
 
-    @Bean
-    public JobLauncherTestUtils jobLauncherTestUtils() {
-        return new JobLauncherTestUtils();
-    }
+//    @Bean
+//    public JobLauncherTestUtils jobLauncherTestUtils() {
+//        return new JobLauncherTestUtils();
+//    }
 
     @Bean
     public JobRepository jobRepository() throws Exception {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/batch/analysis/BatchTestConfiguration.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/batch/analysis/BatchTestConfiguration.java
@@ -18,12 +18,14 @@
  */
 package org.georchestra.datafeeder.service.batch.analysis;
 
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -33,10 +35,18 @@ public class BatchTestConfiguration {
 
     private @Autowired PlatformTransactionManager transactionManager;
 
-//    @Bean
-//    public JobLauncherTestUtils jobLauncherTestUtils() {
-//        return new JobLauncherTestUtils();
-//    }
+    @Bean
+    public UploadJobLauncherTestUtils analyzeUploadJobLauncherTestUtils() throws Exception {
+        return new UploadJobLauncherTestUtils();
+    }
+
+    public static class UploadJobLauncherTestUtils extends JobLauncherTestUtils {
+        @Autowired
+        @Qualifier(UploadAnalysisConfiguration.JOB_NAME)
+        public @Override void setJob(Job job) {
+            super.setJob(job);
+        }
+    }
 
     @Bean
     public JobRepository jobRepository() throws Exception {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/batch/analysis/UploadAnalysisConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/batch/analysis/UploadAnalysisConfigurationTest.java
@@ -34,14 +34,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.georchestra.datafeeder.model.AnalysisStatus;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
-import org.georchestra.datafeeder.model.AnalysisStatus;
 import org.georchestra.datafeeder.repository.DataUploadJobRepository;
 import org.georchestra.datafeeder.repository.DatasetUploadStateRepository;
 import org.georchestra.datafeeder.service.DataFeederServiceConfiguration;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.FileStorageService;
+import org.georchestra.datafeeder.service.batch.analysis.BatchTestConfiguration.UploadJobLauncherTestUtils;
 import org.georchestra.datafeeder.test.MultipartTestSupport;
 import org.junit.Before;
 import org.junit.Rule;
@@ -51,7 +52,6 @@ import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -65,11 +65,13 @@ import org.springframework.web.multipart.MultipartFile;
 @EnableAutoConfiguration
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = { "georchestra", "test" })
+//@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class UploadAnalysisConfigurationTest {
 
     public @Rule MultipartTestSupport multipartSupport = new MultipartTestSupport();
 
-    private @Autowired JobLauncherTestUtils jobLauncherTestUtils;
+    private @Autowired UploadJobLauncherTestUtils jobLauncherTestUtils;
+
     private @Autowired DataUploadService uploadService;
     private @Autowired FileStorageService storageService;
     private @Autowired DataUploadJobRepository repository;


### PR DESCRIPTION
Publish API change:

`DatasetPublishRequest`:

- replace "crs" property by "srs" (identifier) and "srs_reproject" (flag
indicating whether the srs identifier overrides or reprojects to the
published CRS)
- extract out user supplied dataset metadata properties to its own
schema "DatasetMetadata" under the DatasetPublishRequest.metadata
property
