### PR TITLE
[geoserver] docker, turn off logs for oshi module

### DIFF
--- a/geoserver/webapp/src/docker/docker-entrypoint.d/00-geoserver-bootstrap
+++ b/geoserver/webapp/src/docker/docker-entrypoint.d/00-geoserver-bootstrap
@@ -16,4 +16,7 @@ else
 
     echo 'Change log config according to docker setup'
     sed -i 's:stdOutLogging>false:stdOutLogging>true:g' /mnt/geoserver_datadir/logging.xml
+
+    echo 'deactivate oshi logs (hardware monitoring, fails on docker, the error logs pollute the geoserver logs)'
+    echo "log4j.category.oshi.hardware.platform.linux=OFF" >> /mnt/geoserver_datadir/logs/PRODUCTION_LOGGING.properties
 fi


### PR DESCRIPTION
The oshi.hardware.platform.linux is causing, on the docker instance, non-critical and non-useful errors, that tend to pollute the geoserver logs. By turning them off, we get more readable logs, and less logging traffic