### PR TITLE
datafeeder: upgrade spring-boot to 2.3.3.RELEASE

### DIFF
--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -2,11 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.georchestra</groupId>
-    <artifactId>root</artifactId>
-    <version>20.2-SNAPSHOT</version>
-  </parent>
+<!--   <parent> -->
+<!--     <groupId>org.georchestra</groupId> -->
+<!--     <artifactId>root</artifactId> -->
+<!--     <version>20.2-SNAPSHOT</version> -->
+<!--   </parent> -->
+  <version>20.2-SNAPSHOT</version>
+  <groupId>org.georchestra</groupId>
   <artifactId>datafeeder</artifactId>
   <packaging>jar</packaging>
   <name>Data-Feeder microservice</name>
@@ -14,13 +16,65 @@
     <maven.test.skip>false</maven.test.skip>
     <context.name>${project.artifactId}</context.name>
     <packageDatadirScmVersion>datafeeder</packageDatadirScmVersion>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>1.8</java.version>
+    <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
+
+    <gt.version>24.2</gt.version>
     <openapi-generator-maven-plugin.version>4.3.1</openapi-generator-maven-plugin.version>
     <swagger.version>1.5.21</swagger.version>
     <springfox.version>2.9.2</springfox.version>
     <mapstruct.version>1.4.1.Final</mapstruct.version>
+    <lombok.version>1.18.12</lombok.version>
+    <formatter-maven-plugin.version>2.10.0</formatter-maven-plugin.version>
+    <fmt.skip>false</fmt.skip>
+    <fmt.action>format</fmt.action><!-- or fmt.action 'validate' -->
   </properties>
+  <repositories>
+    <!-- geotools -->
+    <repository>
+      <id>osgeo</id>
+      <name>OSGeo Nexus Release Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>osgeo-snapshot</id>
+      <name>OSGeo Nexus Snapshot Repository</name>
+      <url>https://repo.osgeo.org/repository/snapshot/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.openapi</groupId>
+        <artifactId>gs-rest-java-client</artifactId>
+        <version>${gs-rest-java-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct</artifactId>
@@ -99,6 +153,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
+      <version>2.10.10</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -132,10 +187,12 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
+      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-epsg-hsql</artifactId>
+      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <!-- upgrade hsqldb to avoid "data exception: string data, right truncation" error on @Lob columns -->
@@ -146,18 +203,22 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-shapefile</artifactId>
+      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-geojson</artifactId>
+      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-geopkg</artifactId>
+      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools.jdbc</groupId>
       <artifactId>gt-jdbc-postgis</artifactId>
+      <version>${gt.version}</version>
     </dependency>
     <!--SpringFox dependencies -->
     <dependency>
@@ -232,6 +293,35 @@
             <generatorName>spring</generatorName>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>net.revelc.code.formatter</groupId>
+          <artifactId>formatter-maven-plugin</artifactId>
+          <version>${formatter-maven-plugin.version}</version>
+          <inherited>true</inherited>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${fmt.action}</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <skip>${fmt.skip}</skip>
+            <configFile>${maven.multiModuleProjectDirectory}/.mvn/formatter.xml</configFile>
+            <compilerSource>${java.version}</compilerSource>
+            <compilerCompliance>${java.version}</compilerCompliance>
+            <compilerTargetPlatform>${java.version}</compilerTargetPlatform>
+            <!-- Use Unix and Mac style line endings -->
+            <lineEnding>LF</lineEnding>
+            <encoding>UTF-8</encoding>
+            <skipJsFormatting>true</skipJsFormatting>
+            <skipCssFormatting>true</skipCssFormatting>
+            <skipHtmlFormatting>true</skipHtmlFormatting>
+            <skipJsonFormatting>true</skipJsonFormatting>
+            <skipXmlFormatting>true</skipXmlFormatting>
+            <skipJavaFormatting>false</skipJavaFormatting>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -242,6 +332,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
         <configuration>
           <mainClass>org.georchestra.datafeeder.app.DataFeederApplication</mainClass>
           <classifier>bin</classifier>
@@ -294,6 +385,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <dependencies>
           <dependency>
             <groupId>org.mapstruct</groupId>
@@ -304,6 +396,7 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <encoding>UTF-8</encoding>
           <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
@@ -405,6 +498,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.0.0-M5</version>
             <executions>
               <execution>
                 <goals>

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/AuthorizationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/AuthorizationService.java
@@ -20,12 +20,11 @@ package org.georchestra.datafeeder.api;
 
 import java.util.UUID;
 
-import javax.annotation.Nullable;
-
 import org.georchestra.config.security.GeorchestraUserDetails;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/analysis/UploadAnalysisJobConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/analysis/UploadAnalysisJobConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
+import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -92,10 +93,12 @@ public class UploadAnalysisJobConfiguration {
     public @Bean Step analyzeDatasets(DataUploadAnalysisService service, DatasetUploadStateItemReader reader,
             DatasetUploadStateUpdateListener itemStatusUpdater) {
 
+        ItemProcessor<? super DatasetUploadState, ? extends DatasetUploadState> processor = service::analyze;
+
         TaskletStep step = steps.get("analyzeDataset")//
                 .<DatasetUploadState, DatasetUploadState>chunk(1)//
                 .reader(reader)//
-                .processor(service::analyze)//
+                .processor(processor)//
                 .writer(service::save)//
                 .listener(itemStatusUpdater)//
                 .transactionManager(platformTransactionManager)//

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/DataUploadAnalysisService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/DataUploadAnalysisService.java
@@ -45,6 +45,7 @@ import org.geotools.util.Converters;
 import org.locationtech.jts.geom.Geometry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.NonNull;
 import lombok.Setter;
@@ -187,9 +188,10 @@ public class DataUploadAnalysisService {
     }
 
     public void save(List<? extends DatasetUploadState> items) {
-        this.datasetRepository.save(items);
+        this.datasetRepository.saveAll(items);
     }
 
+    @Transactional
     public void summarize(@NonNull UUID uploadId) {
         datasetRepository.flush();
         jobRepository.flush();
@@ -210,8 +212,7 @@ public class DataUploadAnalysisService {
     }
 
     private JobStatus determineJobStatus(List<DatasetUploadState> datasets) {
-        for (DatasetUploadState s : datasets) {
-            DatasetUploadState d = this.datasetRepository.findOne(s.getId());
+        for (DatasetUploadState d : datasets) {
             JobStatus status = d.getAnalyzeStatus();
             if (JobStatus.ERROR == status) {
                 return JobStatus.ERROR;
@@ -220,8 +221,6 @@ public class DataUploadAnalysisService {
             }
         }
         return JobStatus.DONE;
-//        boolean anyFailed = datasets.stream().map(DatasetUploadState::getStatus).anyMatch(UploadStatus.ERROR::equals);
-//        return anyFailed ? UploadStatus.ERROR : UploadStatus.DONE;
     }
 
     private List<SampleProperty> sampleProperties(Map<String, Object> sampleProperties) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/SampleProperty.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/SampleProperty.java
@@ -18,7 +18,9 @@
  */
 package org.georchestra.datafeeder.model;
 
+import javax.persistence.Basic;
 import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
 import javax.persistence.Lob;
 
 import lombok.Data;
@@ -29,6 +31,7 @@ public class SampleProperty {
 
     private String name;
     @Lob
+    @Basic(fetch = FetchType.EAGER)
     private String value;
     private String type;
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/repository/JpaAuditingConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/repository/JpaAuditingConfiguration.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.datafeeder.repository;
 
+import java.util.Optional;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -32,11 +34,7 @@ public class JpaAuditingConfiguration {
     public @Bean AuditorAware<String> jpaAuditorProvider() {
         return () -> {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-            if (auth == null) {
-                return "annonymous";
-            }
-            String name = auth.getName();
-            return name;
+            return Optional.ofNullable(auth).map(Authentication::getName);
         };
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -79,7 +79,7 @@ public class DataUploadService {
     }
 
     public void remove(@NonNull UUID jobId) {
-        repository.delete(jobId);
+        repository.deleteById(jobId);
     }
 
     public SimpleFeature sampleFeature(@NonNull UUID jobId, @NonNull String typeName, int featureN, Charset encoding,

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
@@ -34,8 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-
 import org.georchestra.datafeeder.model.BoundingBoxMetadata;
 import org.georchestra.datafeeder.model.CoordinateReferenceSystemMetadata;
 import org.georchestra.datafeeder.model.DatasetUploadState;
@@ -61,6 +59,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.springframework.lang.Nullable;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -1,28 +1,14 @@
-server:
-  context-path: /import
-  servlet:
-    # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
-    # spring 2.x style, for forward compatibility
-    multipart:
-      max-file-size: ${datafeeder.file-upload.max-file-size}
-      max-request-size: ${datafeeder.file-upload.max-request-size}
-      file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
-      location:  ${datafeeder.file-upload.temporary-location}
-    # Charset of HTTP requests and responses. Added to the "Content-Type" header if not set explicitly.
-    encoding.charset: UTF-8
-    # Enable http encoding support.
-    encoding.enabled: true
-    # Force the encoding to the configured charset on HTTP requests and responses.
-    encoding.force: true
-
 spring:
   #TODO: remove 'mock' when external service implementations are ready. Remove local when ready to run as a georchestra microservice.
   profiles.active: georchestra, local, mock
-  application:
-    name: datafeeder-service
-  http:
+  application.name: datafeeder-service
+  main.allow-bean-definition-overriding: true
+  batch.job.enabled: false #disable automatically running configured jobs at startup time
+
+server:
+  servlet:
+    context-path: /import
     # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
-    # spring 1.4+ style
     multipart:
       max-file-size: ${datafeeder.file-upload.max-file-size}
       max-request-size: ${datafeeder.file-upload.max-request-size}
@@ -34,9 +20,6 @@ spring:
     encoding.enabled: true
     # Force the encoding to the configured charset on HTTP requests and responses.
     encoding.force: true
-  batch:
-    job.enabled: false #disable automatically running configured jobs at startup time
-
 
 datafeeder:
   file-upload:

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -35,11 +35,11 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -68,7 +68,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     private @MockBean DatasetsService mockDatasetsService;
 
     private @LocalServerPort int port;
-    private @Value("${server.context-path}") String contextPath;
+    private @Value("${server.servlet.context-path}") String contextPath;
 
     private @Autowired TestRestTemplate template;
 

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -32,7 +32,7 @@ datafeeder.publishing.backend.local.passwd=postgres
 datafeeder.publishing.backend.geoserver.dbtype=postgis
 datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
 datafeeder.publishing.backend.geoserver.schema=public
-# note the unicode escape sequence for space: \u0020
-datafeeder.publishing.backend.geoserver.Loose\u0020bbox=false
-datafeeder.publishing.backend.geoserver.Estimated\u0020extends=true
+# note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
+datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
+datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
 datafeeder.publishing.backend.geoserver.preparedStatements=true


### PR DESCRIPTION
The spring-boot dependencies (1.5.19) currently used by geOrchestra,
besides being too old, make working with the geoserver REST client
imposible due to too old jackson dependencies.

Upgrading to spring-boot 2 also makes the project future proof in case
it needs to be deployed outside geOrchestra's environment.