### PR TITLE
[DataFeeder] Initial implementation of dataset publishing to GeoServer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
 	branch = 2.17.2-georchestra
+[submodule "datafeeder/geoserver-rest-openapi"]
+	path = datafeeder/geoserver-rest-openapi
+	url = https://github.com/camptocamp/geoserver-rest-openapi
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ docker-build-mapfishapp: build-deps docker-pull-jetty
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl mapfishapp
 
 docker-build-datafeeder: 
+	# build geoserver-rest-openapi just until we find a public maven repo for it
+	mvn clean install -DskipTests -f datafeeder/geoserver-rest-openapi/ && \
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl datafeeder
 
 docker-build-georchestra: build-deps docker-pull-jetty docker-build-database docker-build-ldap docker-build-geoserver docker-build-geowebcache docker-build-gn3

--- a/datafeeder/README.md
+++ b/datafeeder/README.md
@@ -9,6 +9,21 @@ The separate front-end UI service provides the wizard-like user interface to int
 Build the project:
 
 ```bash
+georchestra$ git submodule update --init
+```
+
+To update the `datafeeder/geoserver-rest-openapi/` git submodule. This is a project dependency that still hasn't got
+a place in a public maven repository, so for the time being we're building it.
+
+The following command will take care of building both the above mentioned dependency as well as the datafeeder application and its docker image:
+
+```bash
+georchestra$ make docker-build-datafeeder
+```
+
+Or if you already did and only want to build datafeeder, run:
+
+```bash
 georchestra$ mvn clean install -f datafeeder/
 ```
 
@@ -18,6 +33,7 @@ Or
 georchestra$ cd datafeeder
 datafeeder$ mvn clean install
 ```
+
 Will compile and run the unit and integration tests.
 
 ### Skipping tests

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -65,6 +65,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.geoserver.openapi</groupId>
+        <artifactId>gs-rest-java-client</artifactId>
+        <version>${gs-rest-java-client.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -13,7 +13,6 @@
   <packaging>jar</packaging>
   <name>Data-Feeder microservice</name>
   <properties>
-    <maven.test.skip>false</maven.test.skip>
     <context.name>${project.artifactId}</context.name>
     <packageDatadirScmVersion>datafeeder</packageDatadirScmVersion>
 
@@ -30,9 +29,9 @@
     <formatter-maven-plugin.version>2.10.0</formatter-maven-plugin.version>
     <fmt.skip>false</fmt.skip>
     <fmt.action>format</fmt.action><!-- or fmt.action 'validate' -->
+    <gs-rest-java-client.version>2.19-SNAPSHOT</gs-rest-java-client.version>
   </properties>
   <repositories>
-    <!-- geotools -->
     <repository>
       <id>osgeo</id>
       <name>OSGeo Nexus Release Repository</name>
@@ -145,6 +144,10 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>org.geoserver.openapi</groupId>
+      <artifactId>gs-rest-java-client</artifactId>
+    </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -88,6 +88,13 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
         <version>2.7.0</version>
+        <exclusions>
+          <!-- hadoop transitive dependency carries over an old version of okhttp that interferes with the geoserver rest client -->
+          <exclusion>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -95,15 +102,22 @@
         <version>1.20</version>
       </dependency>
       <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-geopkg</artifactId>
-        <version>${gt.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.geotools.jdbc</groupId>
         <artifactId>gt-jdbc-postgis</artifactId>
         <version>${gt.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-shapefile</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <!-- 
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-geopkg</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+       -->
       <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-geojson</artifactId>
@@ -206,22 +220,20 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-shapefile</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-geojson</artifactId>
-      <version>${gt.version}</version>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-geopkg</artifactId>
-      <version>${gt.version}</version>
     </dependency>
+    -->
     <dependency>
       <groupId>org.geotools.jdbc</groupId>
       <artifactId>gt-jdbc-postgis</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <!--SpringFox dependencies -->
     <dependency>

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
@@ -43,4 +43,8 @@ public class GeorchestraIntegrationAutoConfiguration {
     public @Bean DataFeederConfigurationProperties configProperties() {
         return new DataFeederConfigurationProperties();
     }
+
+    public @Bean GeorchestraNameNormalizer georchestraNameResolver() {
+        return new GeorchestraNameNormalizer();
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
@@ -1,0 +1,45 @@
+package org.georchestra.datafeeder.autoconf;
+
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+import java.util.regex.Pattern;
+
+import lombok.NonNull;
+
+public class GeorchestraNameNormalizer {
+    private static Pattern BEGINNING_BY_INT_OR_MINUS_OR_DOT_PATTERN = Pattern.compile("^[0-9-.]+");
+    private static Pattern FORBIDDEN_CHARS_PATTERN = Pattern.compile("[^\\w-_.]");
+
+    public @NonNull String resolveDatabaseSchemaName(@NonNull String orgName) {
+        return normalizeName(orgName);
+    }
+
+    public String resolveWorkspaceName(String orgName) {
+        return normalizeName(orgName);
+    }
+
+    public String resolveLayerName(@NonNull String proposedName) {
+        return normalizeName(proposedName);
+    }
+
+    /**
+     * Returns a normalized representation of the argument string
+     * <ul>
+     * <li>spaces removed
+     * <li>accentuated chars replaced by their unaccentuated equivalent letter
+     * <li>special chars removed
+     * <li>lowercased
+     * <li>if the short name starts with a digit, the digit is removed (repeated
+     * until the workspace name starts with a letter)
+     * </ul>
+     */
+    public String normalizeName(@NonNull String name) {
+        // Canonical decomposition.
+        String normalized = Normalizer.normalize(name, Form.NFD);
+        // remove unicode accents and diacritics
+        normalized = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        normalized = FORBIDDEN_CHARS_PATTERN.matcher(normalized).replaceAll("_");
+        normalized = BEGINNING_BY_INT_OR_MINUS_OR_DOT_PATTERN.matcher(normalized).replaceAll("");
+        return normalized;
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
@@ -15,7 +15,7 @@ public class GeorchestraNameNormalizer {
     }
 
     public String resolveWorkspaceName(String orgName) {
-        return normalizeName(orgName);
+        return normalizeName(orgName).toLowerCase();
     }
 
     public String resolveLayerName(@NonNull String proposedName) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/OWSPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/OWSPublicationService.java
@@ -1,11 +1,29 @@
 package org.georchestra.datafeeder.service.publish;
 
 import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.model.PublishSettings;
 
 public interface OWSPublicationService {
 
+    /**
+     * Publishes the given dataset to the OWS Server.
+     * <p>
+     * Once this method returns, {@link PublishSettings#getPublishedName()
+     * dataset.getPublishing().getPublishedName()} may have changed by the service
+     * to avoid layer name duplication, and
+     * {@link PublishSettings#getPublishedWorkspace()
+     * dataset.getPublishing().getPublishedWorkspace()} must not be {@code null}
+     */
     void publish(DatasetUploadState dataset);
 
+    /**
+     * Updates the published dataset metadata on the OWS service for the published
+     * layer given by the {@link DatasetUploadState}'s published
+     * {@link PublishSettings#getPublishedWorkspace() workspace name} and
+     * {@link PublishSettings#getPublishedName() layer name}, adding a metadata-link
+     * pointing to the metadata {@link PublishSettings#getMetadataRecordId() record
+     * id}.
+     */
     void addMetadataLink(DatasetUploadState dataset);
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.publish.impl;
+
+import java.util.Optional;
+
+import org.geoserver.openapi.model.catalog.FeatureTypeInfo;
+import org.geoserver.openapi.model.catalog.WorkspaceInfo;
+import org.geoserver.openapi.v1.model.Layer;
+
+import lombok.NonNull;
+
+public class GeoServerRemoteService {
+
+    public Optional<Layer> findLayerByName(@NonNull String workspace, @NonNull String proposedName) {
+        throw new UnsupportedOperationException();
+    }
+
+    public WorkspaceInfo getOrCreateWorkspace(String workspaceName) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void create(FeatureTypeInfo fti) {
+        // TODO Auto-generated method stub
+
+    }
+
+    public void update(FeatureTypeInfo fti) {
+        // TODO Auto-generated method stub
+
+    }
+
+    public FeatureTypeInfo getFeatureTypeInfo(String publishedWorkspace, String publishedName) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
@@ -40,6 +40,9 @@ import org.geoserver.restconfig.client.LayersClient;
 import org.geoserver.restconfig.client.NamespacesClient;
 import org.geoserver.restconfig.client.ServerException;
 import org.geoserver.restconfig.client.WorkspacesClient;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -47,11 +50,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GeoServerRemoteService {
 
-    private GeoServerClient _client;
+    private @Autowired GeoServerClient _client;
 
     private static final WorkspaceLock LOCKS = new WorkspaceLock();
 
-    private GeoServerClient client() {
+    public @VisibleForTesting GeoServerClient client() {
         return this._client;
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
@@ -18,37 +18,202 @@
  */
 package org.georchestra.datafeeder.service.publish.impl;
 
-import java.util.Optional;
+import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.geoserver.openapi.model.catalog.DataStoreInfo;
 import org.geoserver.openapi.model.catalog.FeatureTypeInfo;
+import org.geoserver.openapi.model.catalog.NamespaceInfo;
 import org.geoserver.openapi.model.catalog.WorkspaceInfo;
+import org.geoserver.openapi.v1.model.DataStoreResponse;
 import org.geoserver.openapi.v1.model.Layer;
+import org.geoserver.restconfig.client.DataStoresClient;
+import org.geoserver.restconfig.client.FeatureTypesClient;
+import org.geoserver.restconfig.client.GeoServerClient;
+import org.geoserver.restconfig.client.LayersClient;
+import org.geoserver.restconfig.client.NamespacesClient;
+import org.geoserver.restconfig.client.ServerException;
+import org.geoserver.restconfig.client.WorkspacesClient;
 
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class GeoServerRemoteService {
 
-    public Optional<Layer> findLayerByName(@NonNull String workspace, @NonNull String proposedName) {
-        throw new UnsupportedOperationException();
+    private GeoServerClient _client;
+
+    private static final WorkspaceLock LOCKS = new WorkspaceLock();
+
+    private GeoServerClient client() {
+        return this._client;
     }
 
-    public WorkspaceInfo getOrCreateWorkspace(String workspaceName) {
-        throw new UnsupportedOperationException();
+    public Optional<Layer> findLayerByName(@NonNull String workspace, @NonNull String layerName) {
+        final LayersClient layersClient = client().layers();
+        return layersClient.getLayer(workspace, layerName);
     }
 
-    public void create(FeatureTypeInfo fti) {
-        // TODO Auto-generated method stub
-
+    private Optional<WorkspaceInfo> findWorkspace(@NonNull String name) {
+        LOCKS.readLock(name).lock();
+        try {
+            return findWorkspaceInternal(name);
+        } catch (ServerException.NotFound notFound) {
+            return Optional.empty();
+        } finally {
+            LOCKS.readLock(name).unlock();
+        }
     }
 
-    public void update(FeatureTypeInfo fti) {
-        // TODO Auto-generated method stub
-
+    // find workspace without locking
+    private Optional<WorkspaceInfo> findWorkspaceInternal(String name) {
+        return client().workspaces().getAsInfo(name);
     }
 
-    public FeatureTypeInfo getFeatureTypeInfo(String publishedWorkspace, String publishedName) {
-        // TODO Auto-generated method stub
-        return null;
+    public @NonNull WorkspaceInfo getOrCreateWorkspace(@NonNull String workspaceName) {
+        Optional<WorkspaceInfo> found = findWorkspace(workspaceName);
+        if (found.isPresent()) {
+            return found.get();
+        }
+        LOCKS.writeLock(workspaceName).lock();
+        try {
+            return findWorkspaceInternal(workspaceName).orElseGet(() -> createWorkspace(workspaceName));
+        } finally {
+            LOCKS.writeLock(workspaceName).unlock();
+        }
     }
 
+    /**
+     * @throws ServerException
+     */
+    private @NonNull WorkspaceInfo createWorkspace(@NonNull String workspaceName) {
+        final WorkspacesClient workspaces = this.client().workspaces();
+
+        LOCKS.writeLock(workspaceName).lock();
+        try {
+            WorkspaceInfo wsInfo = new WorkspaceInfo();
+            // create the workspace
+            wsInfo.setName(workspaceName);
+            wsInfo.setIsolated(Boolean.FALSE);
+            workspaces.create(wsInfo);
+            wsInfo = workspaces.getAsInfo(workspaceName).orElseThrow(
+                    () -> new IllegalStateException("Workspace " + workspaceName + " not found after creation"));
+            try {
+                configureNamespace(wsInfo);
+            } catch (RuntimeException e) {
+                workspaces.delete(workspaceName);
+                throw e;
+            }
+            return wsInfo;
+        } finally {
+            LOCKS.writeLock(workspaceName).unlock();
+        }
+    }
+
+    private void configureNamespace(final WorkspaceInfo wsInfo) {
+        final NamespacesClient namespaces = this.client().namespaces();
+
+        final String workspaceName = wsInfo.getName();
+        String defaultNamespaceURI = "http://georchestra.org/datafeeder/" + wsInfo.getName();
+        // change the namespace URI associated to the workspace
+        NamespaceInfo nsInfo = namespaces.findByPrefix(workspaceName)
+                .orElseThrow(() -> new IllegalStateException("NamespaceInfo not found for workspace " + workspaceName));
+
+        nsInfo.setUri(defaultNamespaceURI);
+        namespaces.update(nsInfo.getPrefix(), nsInfo);
+    }
+
+    public @NonNull DataStoreResponse create(@NonNull DataStoreInfo dataStore) {
+        requireNonNull(dataStore.getName());
+        requireNonNull(dataStore.getConnectionParameters());
+        requireNonNull(dataStore.getWorkspace());
+        requireNonNull(dataStore.getWorkspace().getName());
+
+        final DataStoresClient dataStoresClient = this.client().dataStores();
+        final String workspaceName = dataStore.getWorkspace().getName();
+
+        LOCKS.writeLock(workspaceName).lock();
+        try {
+            return dataStoresClient.create(workspaceName, dataStore);
+        } catch (ServerException e) {
+            log.error("Error creating GeoServer DataStore", e);
+            throw e;
+        } finally {
+            LOCKS.writeLock(workspaceName).unlock();
+        }
+    }
+
+    public FeatureTypeInfo create(@NonNull FeatureTypeInfo fti) {
+        requireNonNull(fti.getStore(), "store required");
+        requireNonNull(fti.getStore().getName(), "store name required");
+        requireNonNull(fti.getName(), "name required");
+        requireNonNull(fti.getNamespace(), "namespace required");
+        requireNonNull(fti.getNamespace().getPrefix(), "namespace.prefix required");
+
+        final String workspaceName = fti.getNamespace().getPrefix();
+        LOCKS.writeLock(workspaceName).lock();
+        try {
+            FeatureTypesClient client = client().featureTypes();
+            FeatureTypeInfo created = client.create(workspaceName, fti);
+            return created;
+        } finally {
+            LOCKS.writeLock(workspaceName).unlock();
+        }
+    }
+
+    public FeatureTypeInfo update(@NonNull FeatureTypeInfo fti) {
+        requireNonNull(fti.getStore(), "store required");
+        requireNonNull(fti.getStore().getName(), "store name required");
+        requireNonNull(fti.getName(), "name required");
+        requireNonNull(fti.getNamespace(), "namespace required");
+        requireNonNull(fti.getNamespace().getPrefix(), "namespace.prefix required");
+
+        final String workspaceName = fti.getNamespace().getPrefix();
+        LOCKS.writeLock(workspaceName).lock();
+        try {
+            FeatureTypesClient client = client().featureTypes();
+            String name = fti.getName();
+            FeatureTypeInfo updated = client.update(workspaceName, name, fti);
+            return updated;
+        } finally {
+            LOCKS.writeLock(workspaceName).unlock();
+        }
+    }
+
+    public Optional<FeatureTypeInfo> findFeatureTypeInfo(@NonNull String publishedWorkspace, @NonNull String storeName,
+            @NonNull String featureTypeName) {
+        return client().featureTypes().getFeatureType(publishedWorkspace, storeName, featureTypeName);
+    }
+
+    public Optional<DataStoreResponse> findDataStore(@NonNull String workspace, @NonNull String dataStore) {
+        return client().dataStores().findByWorkspaceAndName(workspace, dataStore);
+    }
+
+    /**
+     * Per workspace name read-write locks, aids in preventing concurrent
+     * modifications to the same resource at workspace granularity
+     */
+    private static class WorkspaceLock {
+
+        private ConcurrentMap<String, ReadWriteLock> locks = new ConcurrentHashMap<>();
+
+        private ReadWriteLock get(String wsName) {
+            return locks.computeIfAbsent(wsName, lockName -> new ReentrantReadWriteLock());
+        }
+
+        public Lock writeLock(@NonNull String wsName) {
+            return get(wsName).writeLock();
+        }
+
+        public Lock readLock(@NonNull String wsName) {
+            return get(wsName).readLock();
+        }
+
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeoServerRemoteService.java
@@ -123,7 +123,7 @@ public class GeoServerRemoteService {
         final NamespacesClient namespaces = this.client().namespaces();
 
         final String workspaceName = wsInfo.getName();
-        String defaultNamespaceURI = "http://georchestra.org/datafeeder/" + wsInfo.getName();
+        String defaultNamespaceURI = "https://georchestra.org/datafeeder/" + wsInfo.getName();
         // change the namespace URI associated to the workspace
         NamespaceInfo nsInfo = namespaces.findByPrefix(workspaceName)
                 .orElseThrow(() -> new IllegalStateException("NamespaceInfo not found for workspace " + workspaceName));

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
@@ -21,6 +21,7 @@ package org.georchestra.datafeeder.service.publish.impl;
 import java.io.IOException;
 import java.util.Map;
 
+import org.georchestra.datafeeder.autoconf.GeorchestraNameNormalizer;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
@@ -50,6 +51,7 @@ public class GeorchestraDataBackendService implements DataBackendService {
 
     private @Autowired DatasetsService datasetsService;
     private @Autowired DataFeederConfigurationProperties props;
+    private @Autowired GeorchestraNameNormalizer nameResolver;
 
     @Override
     public void prepareBackend(@NonNull DataUploadJob job) {
@@ -74,10 +76,11 @@ public class GeorchestraDataBackendService implements DataBackendService {
 
     private Map<String, String> resolveConnectionParams(DataUploadJob job) {
         Map<String, String> connectionParams = props.getPublishing().getBackend().getLocal();
-        String schema = job.getOrganizationName();
-        if (schema == null) {
+        String orgName = job.getOrganizationName();
+        if (orgName == null) {
             throw new IllegalStateException("Georchestra organization name not provided in job.organizationName");
         }
+        String schema = nameResolver.resolveDatabaseSchemaName(orgName);
         connectionParams.put(PostgisNGDataStoreFactory.SCHEMA.key, schema);
         return connectionParams;
     }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -76,6 +76,10 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
     private @Autowired GeorchestraNameNormalizer nameResolver;
 
     public @Override void publish(@NonNull DatasetUploadState dataset) {
+        requireNonNull(dataset.getJob());
+        requireNonNull(dataset.getJob().getOrganizationName(), "organization name not provided");
+        requireNonNull(dataset.getName(), "dataset native name not provided");
+
         PublishSettings publishing = dataset.getPublishing();
         requireNonNull(publishing);
         requireNonNull(publishing.getPublishedName());
@@ -105,7 +109,7 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         ds.setEnabled(true);
         ds.setWorkspace(new WorkspaceInfo().name(workspaceName));
         ds.setDescription("Datafeeder uploaded datasets");
-        return null;
+        return ds;
     }
 
     private Map<String, String> buildConnectionParameters(@NonNull DatasetUploadState dataset) {
@@ -132,11 +136,13 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         ft.setAbstract(publishing.getAbstract());
         ft.setAdvertised(true);
         ft.setEnabled(true);
-        ft.setKeywords(buildKeywords(publishing.getKeywords()));
+        // ft.setKeywords(buildKeywords(publishing.getKeywords()));
 
         BoundingBoxMetadata nativeBounds = dataset.getNativeBounds();
-        ft.setNativeBoundingBox(buildEnvelope(nativeBounds));
-        ft.setNativeCRS(nativeBounds.getCrs().getSrs());
+        if (nativeBounds != null) {
+            ft.setNativeBoundingBox(buildEnvelope(nativeBounds));
+            ft.setNativeCRS(nativeBounds.getCrs().getSrs());
+        }
         ft.setSrs(publishing.getSrs());
         if (Boolean.TRUE.equals(publishing.getSrsReproject())) {
             ft.setProjectionPolicy(ProjectionPolicy.REPROJECT_TO_DECLARED);

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.service.publish.impl;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.georchestra.datafeeder.autoconf.GeorchestraNameNormalizer;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.model.PublishSettings;
+import org.georchestra.datafeeder.service.publish.MetadataPublicationService;
+import org.georchestra.datafeeder.service.publish.OWSPublicationService;
+import org.geoserver.openapi.model.catalog.FeatureTypeInfo;
+import org.geoserver.openapi.model.catalog.MetadataLinkInfo;
+import org.geoserver.openapi.model.catalog.WorkspaceInfo;
+import org.geoserver.openapi.v1.model.Layer;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import lombok.NonNull;
+
+public class GeorchestraOwsPublicationService implements OWSPublicationService {
+
+    private @Autowired MetadataPublicationService metadataPublicationService;
+
+    private @Autowired GeoServerRemoteService geoserver;
+    private @Autowired GeorchestraNameNormalizer nameResolver;
+
+    public @Override void publish(@NonNull DatasetUploadState dataset) {
+        PublishSettings publishing = dataset.getPublishing();
+        Objects.requireNonNull(publishing);
+        Objects.requireNonNull(publishing.getPublishedName());
+
+        final String workspaceName = resolveWorkspace(dataset);
+        final String publishedLayerName = resolveUniqueLayerName(workspaceName, publishing.getPublishedName());
+
+        FeatureTypeInfo fti = buildPublishingFeatureType(workspaceName, publishedLayerName, dataset);
+        geoserver.create(fti);
+
+        publishing.setPublishedWorkspace(workspaceName);
+        publishing.setPublishedName(publishedLayerName);
+    }
+
+    private FeatureTypeInfo buildPublishingFeatureType(String workspaceName, String publishedLayerName,
+            @NonNull DatasetUploadState dataset) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    private String resolveUniqueLayerName(@NonNull String workspace, @NonNull String proposedName) {
+        String layerName = nameResolver.resolveLayerName(proposedName);
+        Optional<Layer> existing;
+        int deduplicatingCounter = 0;
+        do {
+            existing = geoserver.findLayerByName(workspace, layerName);
+            proposedName += "_" + (++deduplicatingCounter);
+        } while (existing.isPresent());
+        return layerName;
+    }
+
+    private String resolveWorkspace(@NonNull DatasetUploadState dataset) {
+        final @NonNull String orgName = dataset.getJob().getOrganizationName();
+        final String workspaceName = nameResolver.resolveWorkspaceName(orgName);
+
+        WorkspaceInfo ws = geoserver.getOrCreateWorkspace(workspaceName);
+
+        return ws.getName();
+    }
+
+    public @Override void addMetadataLink(@NonNull DatasetUploadState dataset) {
+        PublishSettings publishing = dataset.getPublishing();
+
+        Objects.requireNonNull(publishing);
+        Objects.requireNonNull(publishing.getPublishedWorkspace());
+        Objects.requireNonNull(publishing.getPublishedName());
+        Objects.requireNonNull(publishing.getMetadataRecordId());
+
+        final String workspace = publishing.getPublishedWorkspace();
+        final String layerName = publishing.getPublishedName();
+        final String metadataRecordId = publishing.getMetadataRecordId();
+
+        FeatureTypeInfo fti = geoserver.getFeatureTypeInfo(workspace, layerName);
+
+        MetadataLinkInfo metadatalink = buildMetadataLink(metadataRecordId);
+
+        fti.addMetadatalinksItem(metadatalink);
+
+        geoserver.update(fti);
+    }
+
+    private MetadataLinkInfo buildMetadataLink(String metadataRecordId) {
+        final URI recordURI = metadataPublicationService.buildMetadataRecordURI(metadataRecordId);
+        MetadataLinkInfo info = new MetadataLinkInfo();
+        info.setId(metadataRecordId);
+        info.setContent(recordURI.toString());
+        info.setMetadataType("ISO-19139");// TODO: revisit correct value
+        // info.setAbout("???");
+        return info;
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
@@ -18,9 +18,14 @@
  */
 package org.georchestra.datafeeder.service.publish.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.ExternalApiConfiguration;
 import org.georchestra.datafeeder.service.publish.DataBackendService;
 import org.georchestra.datafeeder.service.publish.OWSPublicationService;
+import org.geoserver.restconfig.client.GeoServerClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -40,11 +45,26 @@ public class GeorchestraPublishingServicesConfiguration {
         return new GeorchestraDataBackendService();
     }
 
-    public @Bean GeoServerRemoteService geoServerRemoteService() {
-        return new GeoServerRemoteService();
-    }
-
     public @Bean OWSPublicationService owsPublicationService() {
         return new GeorchestraOwsPublicationService();
+    }
+
+    public @Bean GeoServerClient geoServerApiClient(DataFeederConfigurationProperties props) {
+        ExternalApiConfiguration config = props.getPublishing().getGeoserver();
+        String restApiEntryPoint = config.getApiUrl().toExternalForm();
+
+        GeoServerClient client = new GeoServerClient(restApiEntryPoint);
+
+        Map<String, String> authHeaders = new HashMap<>();
+        // authHeaders.put("sec-proxy", "true");
+        authHeaders.put("sec-username", "datafeeder-application");
+        authHeaders.put("sec-roles", "ROLE_ADMINISTRATOR");
+
+        client.setRequestHeaderAuth("georchestra", authHeaders);
+        return client;
+    }
+
+    public @Bean GeoServerRemoteService geoServerRemoteService() {
+        return new GeoServerRemoteService();
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
@@ -23,6 +23,7 @@ import org.georchestra.datafeeder.service.publish.DataBackendService;
 import org.georchestra.datafeeder.service.publish.OWSPublicationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 /**
  * Configuration providing strategy beans to publish uploaded datasets to
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
  * @see DataFeederConfigurationProperties
  */
 @Configuration
+@Profile("!mock")
 public class GeorchestraPublishingServicesConfiguration {
 
     public @Bean DataBackendService dataBackendService() {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
@@ -20,9 +20,9 @@ package org.georchestra.datafeeder.service.publish.impl;
 
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.service.publish.DataBackendService;
+import org.georchestra.datafeeder.service.publish.OWSPublicationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 /**
  * Configuration providing strategy beans to publish uploaded datasets to
@@ -32,10 +32,17 @@ import org.springframework.context.annotation.Profile;
  * @see DataFeederConfigurationProperties
  */
 @Configuration
-@Profile({ "!mock" })
 public class GeorchestraPublishingServicesConfiguration {
 
     public @Bean DataBackendService dataBackendService() {
         return new GeorchestraDataBackendService();
+    }
+
+    public @Bean GeoServerRemoteService geoServerRemoteService() {
+        return new GeoServerRemoteService();
+    }
+
+    public @Bean OWSPublicationService owsPublicationService() {
+        return new GeorchestraOwsPublicationService();
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/mock/MockDataBackendService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/mock/MockDataBackendService.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.io.FileUtils;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.service.DatasetsService;
@@ -34,6 +33,7 @@ import org.georchestra.datafeeder.service.publish.DataBackendService;
 import org.geotools.data.shapefile.ShapefileDirectoryFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.FileSystemUtils;
 
 import lombok.NonNull;
 
@@ -53,7 +53,7 @@ public class MockDataBackendService implements DataBackendService, DisposableBea
 
     @Override
     public void destroy() throws Exception {
-        directories.forEach(FileUtils::deleteQuietly);
+        directories.forEach(FileSystemUtils::deleteRecursively);
     }
 
     @Override

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/mock/MockPublishingServicesConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/mock/MockPublishingServicesConfiguration.java
@@ -6,10 +6,8 @@ import org.georchestra.datafeeder.service.publish.OWSPublicationService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("mock")
 public class MockPublishingServicesConfiguration {
 
     @ConditionalOnMissingBean(DataBackendService.class)

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -6,7 +6,9 @@ spring:
   #TODO: remove 'mock' when external service implementations are ready. Remove local when ready to run as a georchestra microservice.
   profiles.active: georchestra, local, mock
   application.name: datafeeder-service
-  main.allow-bean-definition-overriding: true
+  main:
+    allow-bean-definition-overriding: true
+    banner-mode: off
   batch.job.enabled: false #disable automatically running configured jobs at startup time
   servlet:
     # configuration properties for javax.servlet.MultipartConfigElement, derived from datafeeder.file-upload config
@@ -35,6 +37,21 @@ datafeeder:
     # directory location where files will be stored.
     persistent-location: ${file-upload.persistent-location:${java.io.tmpdir}/datafeeder/uploads}
 
+feign:
+  okhttp.enabled: true
+  httpclient.enabled: false 
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+        loggerLevel: basic # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
+
+logging:
+  level:
+    root: INFO
+    feign: INFO
+    org.geoserver.openapi: INFO
 ---
 spring:
   profiles: georchestra
@@ -55,6 +72,10 @@ datafeeder.publishing:
     database: georchestra
     user: georchestra
     passwd: georchestra
+
+feign.client.config.default.loggerLevel: full # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
+logging.level.feign: DEBUG
+logging.level.org.geoserver.openapi: DEBUG
 ---
 spring:
   profiles: local

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -29,6 +29,7 @@ import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.DatasetsService;
 import org.georchestra.datafeeder.service.FileStorageService;
+import org.georchestra.datafeeder.service.publish.MetadataPublicationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,6 +66,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     private @MockBean FileStorageService fileStorageService;
     private @MockBean AuthorizationService mockDataUploadValidityService;
     private @MockBean DataPublishingService mockDataPublishingService;
+    private @MockBean MetadataPublicationService mockMetadataPublicationService;
     private @MockBean DatasetsService mockDatasetsService;
 
     private @LocalServerPort int port;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -36,6 +36,7 @@ import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.DatasetsService;
 import org.georchestra.datafeeder.service.FileStorageService;
+import org.georchestra.datafeeder.service.publish.MetadataPublicationService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +63,7 @@ public class GeorchestraIntegrationAutoConfigurationTest {
     private @MockBean FileStorageService fileStorageService;
     private @MockBean AuthorizationService mockDataUploadValidityService;
     private @MockBean DataPublishingService mockDataPublishingService;
+    private @MockBean MetadataPublicationService mockMetadataPublicationService;
     private @MockBean DatasetsService mockDatasetsService;
 
     private @Autowired ApplicationContext context;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraOwsPublicationServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraOwsPublicationServiceIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import org.georchestra.datafeeder.app.DataFeederApplicationConfiguration;
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
+import org.georchestra.datafeeder.model.BoundingBoxMetadata;
+import org.georchestra.datafeeder.model.CoordinateReferenceSystemMetadata;
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.model.PublishSettings;
+import org.georchestra.datafeeder.service.publish.impl.GeorchestraOwsPublicationService;
+import org.geoserver.openapi.v1.model.WorkspaceSummary;
+import org.geoserver.restconfig.client.DataStoresClient;
+import org.geoserver.restconfig.client.FeatureTypesClient;
+import org.geoserver.restconfig.client.GeoServerClient;
+import org.geoserver.restconfig.client.LayersClient;
+import org.geoserver.restconfig.client.ServerException;
+import org.geoserver.restconfig.client.WorkspacesClient;
+import org.geotools.data.shapefile.ShapefileDataStoreFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@SpringBootTest(classes = { //
+        DataFeederApplicationConfiguration.class, //
+        IntegrationTestSupport.class }, //
+        webEnvironment = WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "it" })
+@Slf4j
+public class GeorchestraOwsPublicationServiceIT {
+
+    public @Autowired @Rule IntegrationTestSupport support;
+
+    private @Autowired GeoServerClient client;
+    private @Autowired GeorchestraOwsPublicationService service;
+    private @Autowired DataFeederConfigurationProperties configProperties;
+
+    private DatasetUploadState shpDataset;
+
+    private static final String ORG_NAME = "TEST org";
+    private static final String EXPECTED_WORKSPACE = "test_org";
+
+    private static final String NATIVE_LAYERNAME = "public_layer";
+    private static final String PULISHED_LAYERNAME = "PublicLayer";
+
+    public @Before void setup() {
+        client.setDebugRequests(true);
+        deleteWorkspace(EXPECTED_WORKSPACE);
+        shpDataset = buildShapefileDatasetFromDefaultGeorchestraDataDirectory();
+
+        // replace the configured geoserver datastore connection parameters by a
+        // "directory of shapefiles" set of parameters
+        Map<String, String> params = configProperties.getPublishing().getBackend().getGeoserver();
+        params.clear();
+        params.put(ShapefileDataStoreFactory.FILE_TYPE.key, "shapefile");
+        params.put(ShapefileDataStoreFactory.URLP.key, "file:data/automated_tests");
+    }
+
+    private void deleteWorkspace(@NonNull String workspaceName) {
+        try {
+            // clean up here instead of at @After in case some failing test remainings need
+            // to be diagnosed in geoserver
+            WorkspacesClient workspaces = client.workspaces();
+            Optional<WorkspaceSummary> workspace = workspaces.findByName(workspaceName);
+            if (workspace.isPresent()) {
+                workspaces.deleteRecursively(workspaceName);
+                assertFalse(workspaces.findByName(workspaceName).isPresent());
+            }
+        } catch (ServerException.NotFound ok) {
+            // doesn't matter
+        } catch (RuntimeException e) {
+            log.warn("Error trying to delete workspace {}", workspaceName, e);
+            throw e;
+        }
+    }
+
+    /**
+     * Expects GeoServer instance to be configured with the default geOrchestra data
+     * directory, having {@code file:data/automated_tests/public_layer.shp}
+     */
+    private DatasetUploadState buildShapefileDatasetFromDefaultGeorchestraDataDirectory() {
+        DataUploadJob job = new DataUploadJob();
+        job.setOrganizationName(ORG_NAME);
+
+        DatasetUploadState dset = new DatasetUploadState();
+        dset.setJob(job);
+        dset.setName(NATIVE_LAYERNAME);
+
+        dset.setNativeBounds(new BoundingBoxMetadata());
+        dset.getNativeBounds().setCrs(new CoordinateReferenceSystemMetadata());
+        dset.getNativeBounds().getCrs().setSrs("EPSG:4326");
+        dset.getNativeBounds().setMinx(-86d);
+        dset.getNativeBounds().setMaxx(77d);
+        dset.getNativeBounds().setMiny(-17d);
+        dset.getNativeBounds().setMaxy(51d);
+
+        PublishSettings publishing = new PublishSettings();
+        dset.setPublishing(publishing);
+        publishing.setPublishedName(PULISHED_LAYERNAME);
+        publishing.setKeywords(Arrays.asList("tag1", "tag 2"));
+        publishing.setSrs("EPSG:4326");
+        return dset;
+    }
+
+    @Test
+    public void testPublishSingleShapefile() {
+        WorkspacesClient workspaces = client.workspaces();
+        DataStoresClient dataStores = client.dataStores();
+        FeatureTypesClient featureTypes = client.featureTypes();
+        LayersClient layers = client.layers();
+        final String hardCodedStoreName = "datafeeder";
+
+        assertFalse(workspaces.findByName(EXPECTED_WORKSPACE).isPresent());
+
+        assertNull(shpDataset.getPublishing().getPublishedWorkspace());
+        service.publish(shpDataset);
+        assertEquals(EXPECTED_WORKSPACE, shpDataset.getPublishing().getPublishedWorkspace());
+
+        assertTrue(workspaces.findByName(EXPECTED_WORKSPACE).isPresent());
+        assertTrue(dataStores.findByWorkspaceAndName(EXPECTED_WORKSPACE, hardCodedStoreName).isPresent());
+        assertTrue(featureTypes.getFeatureType(EXPECTED_WORKSPACE, hardCodedStoreName, PULISHED_LAYERNAME).isPresent());
+        assertTrue(layers.getLayer(EXPECTED_WORKSPACE, PULISHED_LAYERNAME).isPresent());
+    }
+
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
@@ -94,8 +94,7 @@ public @Service class IntegrationTestSupport extends ExternalResource {
 
         ResponseEntity<Map> entity;
         try {
-            entity = doGet(uri, Map.class, "sec-proxy", "true", "sec-username", "datafeeder", "sec-roles",
-                    "ROLE_ADMINISTRATOR");
+            entity = doGet(uri, Map.class, "sec-username", "datafeeder", "sec-roles", "ROLE_ADMINISTRATOR");
         } catch (Exception e) {
             throw new IllegalStateException("Unable to connect to GeoServer at " + uri + ". " + e.getMessage(), e);
         }


### PR DESCRIPTION
* Initial implementation of `GeorchestraOwsPublicationService`, delegating to `GeoServerRemoteService`, which in turn uses the `geoserver-rest-openapi` java client to interact with GeoServer's REST api.

* Adds geoserver-rest-openapi submodule for datafeeder, until it finds its place in a public maven repo.

* Once #3292 is merged, we could add integration tests that target the postgis database in the docker composition used for testing.

* Integration test for GeoServer publishing workflow:
    
Single integration test to publish a dataset through `GeorchestraOwsPublicationService`.
    
Expects the GeoServer instance to be running on geOrchestra's "minimum data directory", with this shapefile:
`file:data/automated_tests/public_layer.shp`
    
Verifies the workspace and datastore are automatically created and the `FeatureTypeInfo`/`Layer` is created in GeoServer.
