### PR TITLE
Datafeeder: use geoserver rest openapi community module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,3 @@
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
 	branch = 2.17.5-georchestra
-[submodule "datafeeder/geoserver-rest-openapi"]
-	path = datafeeder/geoserver-rest-openapi
-	url = https://github.com/camptocamp/geoserver-rest-openapi
-	branch = master

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,6 @@ docker-build-mapfishapp: build-deps docker-pull-jetty
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl mapfishapp
 
 docker-build-datafeeder: 
-	# build geoserver-rest-openapi just until we find a public maven repo for it
-	mvn clean install -DskipTests -f datafeeder/geoserver-rest-openapi/ && \
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl datafeeder
 
 docker-build-georchestra: build-deps docker-pull-jetty docker-build-database docker-build-ldap docker-build-geoserver docker-build-geowebcache docker-build-gn3

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -27,7 +27,7 @@
     <formatter-maven-plugin.version>2.10.0</formatter-maven-plugin.version>
     <fmt.skip>false</fmt.skip>
     <fmt.action>format</fmt.action><!-- or fmt.action 'validate' -->
-    <gs-rest-java-client.version>2.19-SNAPSHOT</gs-rest-java-client.version>
+    <gs-rest-java-client.version>2.20-SNAPSHOT</gs-rest-java-client.version>
   </properties>
   <repositories>
     <repository>
@@ -63,8 +63,8 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.geoserver.openapi</groupId>
-        <artifactId>gs-rest-java-client</artifactId>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-rest-openapi-java-client</artifactId>
         <version>${gs-rest-java-client.version}</version>
       </dependency>
       <dependency>
@@ -167,8 +167,8 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.geoserver.openapi</groupId>
-      <artifactId>gs-rest-java-client</artifactId>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-rest-openapi-java-client</artifactId>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>


### PR DESCRIPTION
After https://github.com/geoserver/geoserver/pull/4903, project donated to GeoServer as a community module, update Datafeeder to use that library.