### PR TITLE
Datafeeder: georchestra integration

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraBatchStoreConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraBatchStoreConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.autoconf;
+
+import javax.sql.DataSource;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Configuration for spring-batch {@link JobRepository} to use geOrchestra's
+ * database as persistent storage for jobs
+ */
+@Configuration
+@EnableBatchProcessing
+@Profile("!test")
+public class GeorchestraBatchStoreConfiguration {
+
+    private @Autowired DataSource dataSource;
+    private @Autowired PlatformTransactionManager transactionManager;
+
+    @Bean
+    public JobRepository jobRepository() throws Exception {
+        JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+        factory.setTransactionManager(transactionManager);
+        factory.setDataSource(dataSource);
+        return factory.getObject();
+    }
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraDatadirConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraDatadirConfiguration.java
@@ -18,10 +18,8 @@
  */
 package org.georchestra.datafeeder.autoconf;
 
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
-@Profile("!local")
 @PropertySource(value = { //
         "file:${georchestra.datadir}/default.properties", //
         "file:${georchestra.datadir}/datafeeder/datafeeder.properties" }, //

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfiguration.java
@@ -35,8 +35,12 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration
 @Profile("georchestra")
-@Import({ GeorchestraDatadirConfiguration.class, GeorchestraSecurityProxyAuthenticationConfiguration.class,
-        GeorchestraPublishingServicesConfiguration.class })
+@Import({ //
+        GeorchestraDatadirConfiguration.class, //
+        GeorchestraSecurityProxyAuthenticationConfiguration.class, //
+        GeorchestraBatchStoreConfiguration.class, //
+        GeorchestraPublishingServicesConfiguration.class//
+})
 public class GeorchestraIntegrationAutoConfiguration {
 
     @ConfigurationProperties(prefix = "datafeeder")

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/repository/DataUploadJobRepository.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/repository/DataUploadJobRepository.java
@@ -41,23 +41,19 @@ public interface DataUploadJobRepository extends JpaRepository<DataUploadJob, UU
 
     Optional<DataUploadJob> findByJobId(@NonNull UUID jobId);
 
-    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update DataUploadJob set analyzeStatus = :status where jobId = :jobId")
     int setAnalyzeStatus(@Param("jobId") UUID jobId, @Param("status") JobStatus status);
 
-    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update DataUploadJob set publishStatus = :status where jobId = :jobId")
     int setPublishingStatus(@Param("jobId") UUID jobId, @Param("status") JobStatus status);
 
-    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update DataUploadJob set publishStatus = :status, error = :error where jobId = :jobId")
     int setPublishingStatus(@Param("jobId") UUID jobId, @Param("status") JobStatus status,
             @Param("error") String errorMessage);
 
-    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update DataUploadJob set finishedSteps = finishedSteps + 1 where jobId = :jobId")
     int incrementProgress(@Param("jobId") UUID jobId);

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -20,8 +20,12 @@ spring:
       max-request-size: ${datafeeder.file-upload.max-request-size}
       file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
       location:  ${datafeeder.file-upload.temporary-location}
-  jpa.database-platform: org.hibernate.dialect.H2Dialect
-  jpa.hibernate.ddl-auto: update
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate.ddl-auto: update
+  batch:
+    job.enabled: false #disable automatically running configured jobs at startup time
+    initialize-schema: always
   datasource:
     # default to in-memory db for sring-batch and datafeeder object model, overridden in georchestra profile
     url: jdbc:h2:mem:testdb

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 server:
   servlet:
-    context-path: /import
+    context-path: /datafeeder
     encoding.enabled: true
     encoding.charset: UTF-8
     encoding.force: true

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -1,11 +1,13 @@
 server:
   servlet:
     context-path: /import
+    encoding.enabled: true
+    encoding.charset: UTF-8
+    encoding.force: true
   error.include-message: always
 
 spring:
-  #TODO: Remove local when ready to run as a georchestra microservice.
-  profiles.active: georchestra, local
+  profiles.active: georchestra
   application.name: datafeeder-service
   main:
     allow-bean-definition-overriding: true
@@ -18,18 +20,14 @@ spring:
       max-request-size: ${datafeeder.file-upload.max-request-size}
       file-size-threshold: ${datafeeder.file-upload.file-size-threshold}
       location:  ${datafeeder.file-upload.temporary-location}
-    # Charset of HTTP requests and responses. Added to the "Content-Type" header if not set explicitly.
-    encoding.charset: UTF-8
-    # Enable http encoding support.
-    encoding.enabled: true
-    # Force the encoding to the configured charset on HTTP requests and responses.
-    encoding.force: true
+  jpa.database-platform: org.hibernate.dialect.H2Dialect
+  jpa.hibernate.ddl-auto: update
   datasource:
+    # default to in-memory db for sring-batch and datafeeder object model, overridden in georchestra profile
     url: jdbc:h2:mem:testdb
     driverClassName: org.h2.Driver
     username: sa
     password: password
-  jpa.database-platform: org.hibernate.dialect.H2Dialect
 
 datafeeder:
   file-upload:
@@ -58,43 +56,43 @@ logging:
   level:
     root: INFO
     feign: INFO
+    org.georchestra.datafeeder: INFO
     org.geoserver.openapi: INFO
+    org.geoserver.restconfig: INFO
 ---
 spring:
   profiles: georchestra
+  jpa.database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+  datasource:
+    url: jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}?currentSchema=${pgsqlSchema:datafeeder}
+    driverClassName: org.postgresql.Driver
+    username: ${pgsqlUser}
+    password: ${pgsqlPassword}
+    # connection pool configuration
+    hikari:
+      pool-name: datafeeder-connection-pool
+      minimum-idle: ${dataSource.minPoolSize:2}
+      idle-timeout: ${dataSource.maxIdleTime:60}
+      maximum-pool-size: ${dataSource.maxPoolSize:10}
+      connection-timeout: ${dataSource.timeout:2000}
+
 georchestra.datadir: /etc/georchestra
 ---
 spring:
   profiles: test
+  jpa.database-platform: org.hibernate.dialect.H2Dialect
+  jpa.hibernate.ddl-auto: update
+  datasource:
+    # default to in-memory db for sring-batch and datafeeder object model, overridden in georchestra profile
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+      
 georchestra.datadir: src/test/resources/datadir
 ---
-spring:
-  profiles: it
+spring.profiles: it
 georchestra.datadir: src/test/resources/datadir
-datafeeder.publishing:
-  geoserver:
-    api-url: http://localhost:18080/geoserver/rest
-    public-url: https://georchestra.mydomain.org/geoserver
-    log-requests: true
-  geonetwork:
-    api-url: http://localhost:28080/geonetwork
-    public-url: https://georchestra.mydomain.org/geonetwork
-    log-requests: true
-  backend.local:
-    port: 15432
-    database: georchestra
-    user: georchestra
-    passwd: georchestra
-
-feign.client.config.default.loggerLevel: full # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
-logging.level.feign: DEBUG
-logging.level.org.geoserver.openapi: DEBUG
----
-spring:
-  profiles: local
-
-#georchestra.datadir: src/test/resources/datadir
-
 datafeeder:
   file-upload:
     max-file-size: 30MB
@@ -105,11 +103,11 @@ datafeeder:
   publishing:
     geoserver:
       api-url: http://localhost:18080/geoserver/rest
-      public-url: http://localhost:18080/geoserver
+      public-url: https://georchestra.mydomain.org/geoserver
       log-requests: true
     geonetwork:
       api-url: http://localhost:28080/geonetwork
-      public-url: http://localhost:28080/geonetwork
+      public-url: https://georchestra.mydomain.org/geonetwork
       log-requests: true
     backend:
       local:
@@ -128,3 +126,7 @@ datafeeder:
         database: georchestra
         user: georchestra
         passwd: georchestra
+
+feign.client.config.default.loggerLevel: full # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
+logging.level.feign: DEBUG
+logging.level.org.geoserver.openapi: DEBUG

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
@@ -261,7 +261,7 @@ public class FileUploadApiControllerTest {
         List<UploadJobStatus> jobs = response.getBody();
         Set<UUID> expected = Arrays.stream(expectedUserJobs).map(UploadJobStatus::getJobId).collect(Collectors.toSet());
         Set<UUID> actual = jobs.stream().map(UploadJobStatus::getJobId).collect(Collectors.toSet());
-        assertEquals(expected, actual);
+        assertThat(actual, Matchers.hasItems(expected.toArray(new UUID[expectedUserJobs.length])));
     }
 
     @Test

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -99,9 +99,11 @@ public class GeorchestraIntegrationAutoConfigurationTest {
         assertNotNull(publishing.getBackend());
 
         assertEquals(new URL("http://localhost:8080/geoserver/rest"), publishing.getGeoserver().getApiUrl());
-        assertEquals(new URL("https://georchestra.mydomain.org/geoserver"), publishing.getGeoserver().getPublicUrl());
+        assertEquals("properties loaded from src/test/resources/datadir/**?",
+                new URL("https://georchestra.test.org/geoserver"), publishing.getGeoserver().getPublicUrl());
         assertEquals(new URL("http://localhost:8081/geonetwork"), publishing.getGeonetwork().getApiUrl());
-        assertEquals(new URL("https://georchestra.mydomain.org/geonetwork"), publishing.getGeonetwork().getPublicUrl());
+        assertEquals("properties loaded from src/test/resources/datadir/**?",
+                new URL("https://georchestra.test.org/geonetwork"), publishing.getGeonetwork().getPublicUrl());
 
         Map<String, String> local = publishing.getBackend().getLocal();
         assertEquals("postgis", local.get("dbtype"));

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/batch/analysis/BatchTestConfiguration.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/batch/analysis/BatchTestConfiguration.java
@@ -28,9 +28,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
+@Profile("test")
 public class BatchTestConfiguration {
 
     private @Autowired PlatformTransactionManager transactionManager;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
@@ -98,8 +98,6 @@ public @Service class IntegrationTestSupport extends ExternalResource {
         ExternalApiConfiguration gsConfig = appConfiguration.getPublishing().getGeoserver();
         URL apiUrl = gsConfig.getApiUrl();
         assertNotNull(apiUrl);
-        assertNotNull(gsConfig.getUsername());
-        assertNotNull(gsConfig.getPassword());
 
         String path = Paths.get(apiUrl.getPath()).resolve("about/version.json").toString();
         String uri = apiUrl.toURI().resolve(path).toString();

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -1,3 +1,25 @@
+### The following properties are inherited from the geOrchestra default.properties,
+### if you want to override them for datafeeder, uncomment them.
+# PostgreSQL server domain name
+# Domain name, or IP address, of the PostgreSQL server
+# pgsqlHost=localhost
+
+# PostgreSQL server port
+# Listening port of the PostgreSQL server
+# pgsqlPort=5432
+
+# PostgreSQL database name
+# Default common PostgreSQL database for all geOrchestra modules
+# pgsqlDatabase=georchestra
+
+# User to connect to PostgreSQL server
+# Default common PostgreSQL user for all geOrchestra modules
+# pgsqlUser=georchestra
+
+# Password to connect to PostgreSQL server
+# Default common password of PostgreSQL user for all geOrchestra modules
+# pgsqlPassword=georchestra
+
 # Datafeeder specific properties
 
 # maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -56,13 +56,13 @@ datafeeder.publishing.backend.geoserver.dbtype=postgis
 datafeeder.publishing.backend.geoserver.preparedStatements=true
 #<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
 datafeeder.publishing.backend.geoserver.schema=<schema>
-#datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
+datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
 #if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
-datafeeder.publishing.backend.geoserver.host=localhost
-datafeeder.publishing.backend.geoserver.port=5432
-datafeeder.publishing.backend.geoserver.database=datafeeder
-datafeeder.publishing.backend.geoserver.user=postgres
-datafeeder.publishing.backend.geoserver.passwd=postgres
+#datafeeder.publishing.backend.geoserver.host=localhost
+#datafeeder.publishing.backend.geoserver.port=5432
+#datafeeder.publishing.backend.geoserver.database=datafeeder
+#datafeeder.publishing.backend.geoserver.user=postgres
+#datafeeder.publishing.backend.geoserver.passwd=postgres
 
 # note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -20,7 +20,11 @@
 # Default common password of PostgreSQL user for all geOrchestra modules
 # pgsqlPassword=georchestra
 
-# Datafeeder specific properties
+####################################
+#  Datafeeder specific properties  #
+####################################
+
+# pgsqlSchema=datafeeder
 
 # maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)
 file-upload.max-file-size=5MB
@@ -34,14 +38,10 @@ file-upload.temporary-location=${java.io.tmpdir}/datafeeder/tmp
 file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
 
 datafeeder.publishing.geoserver.api-url=http://localhost:8080/geoserver/rest
-datafeeder.publishing.geoserver.public-url=https://georchestra.mydomain.org/geoserver
-datafeeder.publishing.geoserver.username=admin
-datafeeder.publishing.geoserver.password=geoserver
+datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
 
 datafeeder.publishing.geonetwork.api-url=http://localhost:8081/geonetwork
-datafeeder.publishing.geonetwork.public-url=https://georchestra.mydomain.org/geonetwork
-datafeeder.publishing.geonetwork.username=admin
-datafeeder.publishing.geonetwork.password=geonetwork
+datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
 
 datafeeder.publishing.backend.local.dbtype=postgis
 datafeeder.publishing.backend.local.host=localhost
@@ -50,11 +50,24 @@ datafeeder.publishing.backend.local.database=datafeeder
 datafeeder.publishing.backend.local.schema=public
 datafeeder.publishing.backend.local.user=postgres
 datafeeder.publishing.backend.local.passwd=postgres
+datafeeder.publishing.backend.local.preparedStatements=true
 
 datafeeder.publishing.backend.geoserver.dbtype=postgis
-datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
-datafeeder.publishing.backend.geoserver.schema=public
+datafeeder.publishing.backend.geoserver.preparedStatements=true
+#<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
+datafeeder.publishing.backend.geoserver.schema=<schema>
+#datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
+#if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
+datafeeder.publishing.backend.geoserver.host=localhost
+datafeeder.publishing.backend.geoserver.port=5432
+datafeeder.publishing.backend.geoserver.database=datafeeder
+datafeeder.publishing.backend.geoserver.user=postgres
+datafeeder.publishing.backend.geoserver.passwd=postgres
+
 # note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
 datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
-datafeeder.publishing.backend.geoserver.preparedStatements=true
+
+
+
+

--- a/datafeeder/src/test/resources/datadir/default.properties
+++ b/datafeeder/src/test/resources/datadir/default.properties
@@ -8,3 +8,25 @@ language=en
 headerHeight=90
 headerUrl=/header/
 administratorEmail=georchestra@georchestra.mydomain.org
+
+### PostgreSQL properties
+# Match settings for docker-compose-it.yml
+# PostgreSQL server domain name
+# Domain name, or IP address, of the PostgreSQL server
+pgsqlHost=localhost
+
+# PostgreSQL server port
+# Listening port of the PostgreSQL server
+pgsqlPort=15432
+
+# PostgreSQL database name
+# Default common PostgreSQL database for all geOrchestra modules
+pgsqlDatabase=georchestra
+
+# User to connect to PostgreSQL server
+# Default common PostgreSQL user for all geOrchestra modules
+pgsqlUser=georchestra
+
+# Password to connect to PostgreSQL server
+# Default common password of PostgreSQL user for all geOrchestra modules
+pgsqlPassword=georchestra

--- a/postgresql/120-datafeeder.sql
+++ b/postgresql/120-datafeeder.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA datafeeder;
+

--- a/postgresql/120-datafeeder.sql
+++ b/postgresql/120-datafeeder.sql
@@ -1,2 +1,5 @@
 CREATE SCHEMA datafeeder;
 
+CREATE SEQUENCE datafeeder.hibernate_sequence;
+GRANT ALL ON datafeeder.hibernate_sequence TO georchestra;
+


### PR DESCRIPTION
Ready to use within georchestra's default docker composition.

Needs to be run from the https://github.com/georchestra/docker/tree/datafeeder branch, which in turn sets up the config submodule from https://github.com/georchestra/datadir/tree/docker-datafeeder