### PR TITLE
datafeeder: add /config/frontend api entry point to load frontend app config from georchestra data dir

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -15,6 +15,22 @@ tags:
     description: 'API to control jobs related to publishing geospatial datasets previously uploaded'
 
 paths:
+  /config/frontend:
+    get:
+      tags:
+        - Config
+      description: 'Get the front-end application configuration object'
+      operationId: getFrontendConfig
+      responses:
+        200:
+          description: Front-end application configuration object
+          content:
+            application/json:
+              schema:
+                type: object
+        401:
+          description: 'Not authenticated'
+
   /upload:
     post:
       tags:

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiException.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/ApiException.java
@@ -20,6 +20,7 @@ package org.georchestra.datafeeder.api;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.springframework.http.HttpStatus;
@@ -46,6 +47,20 @@ public abstract class ApiException extends RuntimeException {
 
     public static ApiException badRequest(String format, Object... args) {
         throw new BadRequest(String.format(format, args));
+    }
+
+    public static InternalServerError internalServerError(Throwable cause, String format, Object... args) {
+        throw new InternalServerError(String.format(format, args), cause);
+    }
+
+    @ResponseStatus(value = INTERNAL_SERVER_ERROR)
+    static class InternalServerError extends ApiException {
+        private @Getter final HttpStatus status = INTERNAL_SERVER_ERROR;;
+
+        public InternalServerError(String reason, Throwable cause) {
+            super(reason);
+            super.initCause(cause);
+        }
     }
 
     @ResponseStatus(value = NOT_FOUND)

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/ConfigApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/ConfigApiController.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.ByteStreams;
+
+import io.swagger.annotations.Api;
+
+@Controller
+@Api(tags = { "Config" }) // hides the empty *-api-controller entry in swagger-ui.html
+public class ConfigApiController implements ConfigApi {
+
+    private static final String CONFIG_PROPERTY_NAME = "datafeeder.front-end-config-file";
+
+    private @Autowired DataFeederConfigurationProperties props;
+
+    public @Override ResponseEntity<Object> getFrontendConfig() {
+        URI uri = props.getFrontEndConfigFile();
+        if (null == uri) {
+            throw ApiException.internalServerError(null, "Invalid config: %s=%s", CONFIG_PROPERTY_NAME, uri);
+        }
+
+        final boolean isFile = null == uri.getScheme() || "file".equalsIgnoreCase(uri.getScheme());
+        final byte[] contents = isFile ? loadFile(uri) : loadURL(uri);
+
+        JsonNode node;
+        try {
+            node = new ObjectMapper().reader().readTree(contents);
+        } catch (Exception e) {
+            throw ApiException.internalServerError(e, "Invalid parsing file from config: %s=%s", CONFIG_PROPERTY_NAME,
+                    uri);
+        }
+        return ResponseEntity.ok(node);
+    }
+
+    private byte[] loadURL(URI uri) {
+        URL url;
+        try {
+            url = uri.toURL();
+        } catch (MalformedURLException e) {
+            throw ApiException.internalServerError(e, "Invalid config: %s=%s", CONFIG_PROPERTY_NAME, uri);
+        }
+        try (InputStream in = url.openStream()) {
+            return ByteStreams.toByteArray(in);
+        } catch (IOException e) {
+            throw ApiException.internalServerError(e, "Error loading: %s=%s", CONFIG_PROPERTY_NAME, uri);
+        }
+    }
+
+    private byte[] loadFile(URI uri) {
+        Path path = Paths.get(uri.getRawSchemeSpecificPart()).toAbsolutePath();
+        if (!Files.exists(path)) {
+            throw ApiException.internalServerError(null, "File does not exist: %s=%s, file:%s", CONFIG_PROPERTY_NAME,
+                    uri, path.toAbsolutePath().toString());
+        }
+        uri = path.toUri();
+        return loadURL(uri);
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -18,6 +18,7 @@
  */
 package org.georchestra.datafeeder.config;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,6 +35,7 @@ import lombok.Data;
  */
 public @Data class DataFeederConfigurationProperties {
 
+    private URI frontEndConfigFile;
     private FileUploadConfig fileUpload = new FileUploadConfig();
     private PublishingConfiguration publishing = new PublishingConfiguration();
 

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -32,6 +32,7 @@ spring:
   jpa.database-platform: org.hibernate.dialect.H2Dialect
 
 datafeeder:
+  front-end-config-file: front-end.config.uri
   file-upload:
     # maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)
     max-file-size: ${file-upload.max-file-size:30MB}
@@ -63,6 +64,8 @@ logging:
 spring:
   profiles: georchestra
 georchestra.datadir: /etc/georchestra
+datafeeder:
+  front-end-config-file: ${front-end.config.uri:${georchestra.datadir}/datafeeder/frontend-config.json}
 ---
 spring:
   profiles: test

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/ConfigApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/ConfigApiControllerTest.java
@@ -1,0 +1,56 @@
+package org.georchestra.datafeeder.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+@SpringBootTest(classes = { ConfigApiController.class }, webEnvironment = WebEnvironment.MOCK)
+@EnableAutoConfiguration
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = { "georchestra", "test", "mock" })
+public class ConfigApiControllerTest {
+
+    private @Autowired ConfigApiController controller;
+    private @Autowired DataFeederConfigurationProperties config;
+    private @Value("${georchestra.datadir}") String datadir;
+
+    public @After void reset() {
+        String expected = String.format("file:%s/datafeeder/frontend-config.json", datadir);
+        config.setFrontEndConfigFile(URI.create(expected));
+    }
+
+    public @Test void verifyConfiguration() {
+        URI frontEndConfigFile = config.getFrontEndConfigFile();
+        assertNotNull("frontEndConfigFile");
+
+        String expected = String.format("file:%s/datafeeder/frontend-config.json", datadir);
+        assertEquals(URI.create(expected), frontEndConfigFile);
+    }
+
+    public @Test void getFrontendConfig() {
+        ResponseEntity<Object> frontendConfig = controller.getFrontendConfig();
+        assertEquals(HttpStatus.OK, frontendConfig.getStatusCode());
+        assertNotNull(frontendConfig.getBody());
+        assertThat(frontendConfig.getBody(), instanceOf(JsonNode.class));
+    }
+
+}

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -10,6 +10,8 @@ file-upload.file-size-threshold=1MB
 file-upload.temporary-location=${java.io.tmpdir}/datafeeder/tmp
 # directory location where files will be stored.
 file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
+# select the file to serve as the front-end application configuration
+front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
 datafeeder.publishing.geoserver.api-url=http://localhost:8080/geoserver/rest
 datafeeder.publishing.geoserver.public-url=https://georchestra.mydomain.org/geoserver

--- a/datafeeder/src/test/resources/datadir/datafeeder/frontend-config.json
+++ b/datafeeder/src/test/resources/datadir/datafeeder/frontend-config.json
@@ -1,0 +1,26 @@
+{
+  "encodings": [
+    {
+      "label": "UTF-8",
+      "value": "UTF-8"
+    },
+    {
+      "label": "ISO-8859-1",
+      "value": "ISO-8859-1"
+    }
+  ],
+  "projections": [
+    {
+      "label": "WGS84",
+      "value": "EPSG:4326"
+    },
+    {
+      "label": "Lambert 93",
+      "value": "EPSG:2154"
+    },
+    {
+      "label": "Web Mercator",
+      "value": "EPSG:3857"
+    }
+  ]
+}


### PR DESCRIPTION
Needs to be run from the https://github.com/georchestra/docker/tree/datafeeder branch, which in turn sets up the config submodule from https://github.com/georchestra/datadir/tree/docker-datafeeder

The front-end app JSON configuration file can be located anywhere,
usually in the same directory than datafeeder.properties.

In datafeeder.properties, the location of such file is indicated through
the `front-end.config.uri` configuraion property.

The default value is:
`front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json`