### PR TITLE
Datafeeder: geonetwork template fixes

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataPublishingService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataPublishingService.java
@@ -56,17 +56,21 @@ public class DataPublishingService {
                 publishing = new PublishSettings();
                 dset.setPublishing(publishing);
             }
-            DatasetMetadata md = dreq.getMetadata();
             String requestedPublishedName = dreq.getPublishedName() == null ? nativeName : dreq.getPublishedName();
             publishing.setPublishedName(requestedPublishedName);
             String srs = dreq.getSrs();
+            if (srs == null && null != dset.getNativeBounds() && null != dset.getNativeBounds().getCrs()) {
+                srs = dset.getNativeBounds().getCrs().getSrs();
+            }
             publishing.setSrs(srs);
             publishing.setSrsReproject(dreq.getSrsReproject());
             String encoding = dreq.getEncoding();
-            if (null == encoding)
+            if (null == encoding) {
                 encoding = dset.getEncoding();
+            }
             publishing.setEncoding(encoding);
 
+            DatasetMetadata md = dreq.getMetadata();
             publishing.setTitle(md.getTitle());
             publishing.setAbstract(md.getAbstract());
             publishing.setDatasetCreationDate(md.getCreationDate());

--- a/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
+++ b/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
@@ -34,6 +34,12 @@ Default template to apply MetadataRecordProperties.java properties to a record t
     </xsl:attribute>
   </xsl:template>
 
+  <xsl:template match="gmd:dateStamp">
+    <gmd:dateStamp>
+      <gco:DateTime><xsl:value-of select="$props//metadataTimestamp" /></gco:DateTime>
+    </gmd:dateStamp>
+  </xsl:template>
+
   <xsl:template
     match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString">
     <gco:CharacterString>
@@ -202,7 +208,9 @@ Default template to apply MetadataRecordProperties.java properties to a record t
   <xsl:template
     match="gmd:referenceSystemInfo//gmd:MD_ReferenceSystem//gmd:referenceSystemIdentifier//gmd:RS_Identifier/gmd:code">
     <gmd:code>
-      <gco:CharacterString><xsl:value-of select="$props//coordinateReferenceSystem" /></gco:CharacterString>
+      <gco:CharacterString>
+        <xsl:value-of select="$props//coordinateReferenceSystem" />
+      </gco:CharacterString>
     </gmd:code>
   </xsl:template>
    

--- a/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
+++ b/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
@@ -36,7 +36,9 @@ Default template to apply MetadataRecordProperties.java properties to a record t
 
   <xsl:template match="gmd:dateStamp">
     <gmd:dateStamp>
-      <gco:DateTime><xsl:value-of select="$props//metadataTimestamp" /></gco:DateTime>
+      <gco:DateTime>
+        <xsl:value-of select="$props//metadataTimestamp" />
+      </gco:DateTime>
     </gmd:dateStamp>
   </xsl:template>
 
@@ -62,6 +64,38 @@ Default template to apply MetadataRecordProperties.java properties to a record t
           </gco:CharacterString>
         </gmd:keyword>
       </xsl:for-each>
+      <gmd:type>
+        <gmd:MD_KeywordTypeCode
+          codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+          codeListValue="theme" />
+      </gmd:type>
+      <gmd:thesaurusName>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2008-06-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode
+                  codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                  codeListValue="publication" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gmx:Anchor
+                  xlink:href="https://sdi.eea.europa.eu/catalogue/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+        </gmd:CI_Citation>
+      </gmd:thesaurusName>
     </gmd:MD_Keywords>
   </xsl:template>
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/TemplateMapperTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/TemplateMapperTest.java
@@ -103,8 +103,8 @@ public class TemplateMapperTest {
         String crs = "MD_Metadata/referenceSystemInfo/MD_ReferenceSystem/referenceSystemIdentifier/RS_Identifier/code/CharacterString[text()='%s']";
         assertXpath(dom, crs, mdprops.getCoordinateReferenceSystem());
 
-        // metadata timestamp, computed, now()::ISO8601 (REVISIT?)
-        assertXpath(dom, "MD_Metadata/dateStamp/DateTime");
+        // metadata timestamp, computed, now()::ISO8601
+        assertXpath(dom, "MD_Metadata/dateStamp/DateTime[text()='%s']", mdprops.getMetadataTimestamp());
 
         // metadata language, provided by metadata template, typically "eng" or "fre"
         assertXpath(dom, "MD_Metadata/language/LanguageCode[@codeListValue='eng']");


### PR DESCRIPTION
As mentioned in https://github.com/georchestra/georchestra/pull/3335#issuecomment-810281470:

- [x] EPSG code is empty
Resolution: a232c78, ensure published SRS defaults to native if none is provided
- [x] Keywords should be listed from a thesaurus. 
Resolution: 8ccc739. Added to `.xsl`, you can change the thesaurus properties once we load the template and transform from georchestra's data directory.
- [x] `<gmd:dateStamp>` not set to `now()`, having template's value `<gco:DateTime>1970-01-01T00:00:00</gco:DateTime>`. 
Resolution: 59eb1c0, Add missing template to `.xsl` file.
- [x] Contacts are empty (while I have fake SEC headers)
Resolution: **to be addressed by a separate issue**
The xml snippet below shows we're mapping the info we do have from `sec-*` request headers:
- `individualName`
- `organisationName`
- `electronicMailAddress`
The ones we miss were initially thought of to be built from user information queried from LDAP.
As discussed in slack, though, that information is gonna be sent as extra `sec-*` headers by the security proxy, in order to keep the application agnostic of the underlying authentication/authorization subsystem.

For instance:
- `gmd:deliveryPoint`
- `gmd:city`
- `gmd:postalCode`
- `gmd:country`
- `gmd:CI_OnlineResource/gmd:linkage`

```xml
<gmd:contact>
  <gmd:CI_ResponsibleParty>
    <gmd:individualName>
      <gco:CharacterString>Test ADMIN</gco:CharacterString>
    </gmd:individualName>
    <gmd:organisationName>
      <gco:CharacterString>Project Steering Committee</gco:CharacterString>
    </gmd:organisationName>
    <gmd:contactInfo>
      <gmd:CI_Contact>
        <gmd:address>
          <gmd:CI_Address>
            <gmd:deliveryPoint>
              <gco:CharacterString />
            </gmd:deliveryPoint>
            <gmd:city>
              <gco:CharacterString />
            </gmd:city>
            <gmd:postalCode>
              <gco:CharacterString />
            </gmd:postalCode>
            <gmd:country>
              <gco:CharacterString />
            </gmd:country>
            <gmd:electronicMailAddress>
              <gco:CharacterString>psc+testadmin@georchestra.org</gco:CharacterString>
            </gmd:electronicMailAddress>
          </gmd:CI_Address>
        </gmd:address>
        <gmd:onlineResource>
          <gmd:CI_OnlineResource>
            <gmd:linkage>
              <gmd:URL />
            </gmd:linkage>
            <gmd:protocol>
              <gco:CharacterString>URL</gco:CharacterString>
            </gmd:protocol>
            <gmd:name>
              <gco:CharacterString>Project Steering Committee</gco:CharacterString>
            </gmd:name>
          </gmd:CI_OnlineResource>
        </gmd:onlineResource>
        <gmd:contactInstructions />
      </gmd:CI_Contact>
    </gmd:contactInfo>
    <gmd:role>
      <gmd:CI_RoleCode
        codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode"
        codeListValue="pointOfContact" />
    </gmd:role>
  </gmd:CI_ResponsibleParty>
</gmd:contact>
```
