### PR TITLE
security proxy encoded headers

### DIFF
--- a/.github/workflows/datafeeder.yml
+++ b/.github/workflows/datafeeder.yml
@@ -35,7 +35,9 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: "Installing & checking formatting"
-      run: ./mvnw -f datafeeder/ --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: |
+          ./mvnw -f commons/ --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+          ./mvnw -f datafeeder/ --no-transfer-progress -B -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: "Running Unit Tests"
       run: ./mvnw -f datafeeder/ test -DskipITs=true -DskipTests=false -ntp -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docker-build-analytics: build-deps docker-pull-jetty
 docker-build-mapfishapp: build-deps docker-pull-jetty
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl mapfishapp
 
-docker-build-datafeeder: 
+docker-build-datafeeder: build-deps
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl datafeeder
 
 docker-build-georchestra: build-deps docker-pull-jetty docker-build-database docker-build-ldap docker-build-geoserver docker-build-geowebcache docker-build-gn3

--- a/commons/src/main/java/org/georchestra/commons/security/SecurityHeaders.java
+++ b/commons/src/main/java/org/georchestra/commons/security/SecurityHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 by the geOrchestra PSC
+ * Copyright (C) 2009-2021 by the geOrchestra PSC
  *
  * This file is part of geOrchestra.
  *
@@ -18,6 +18,9 @@
  */
 
 package org.georchestra.commons.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * A collection of header names commonly used by the security-proxy gateway
@@ -40,6 +43,26 @@ public class SecurityHeaders {
     public static final String IMP_USERNAME = "imp-username";
 
     public static String decode(String headerValue) {
+        if (null == headerValue) {
+            return null;
+        }
+        // very simple implementation, we only support base64 so far
+        if (headerValue.startsWith("{base64}")) {
+            String value = headerValue.substring("{base64}".length());
+            byte[] bytes = Base64.getDecoder().decode(value.getBytes(StandardCharsets.UTF_8));
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
         return headerValue;
+    }
+
+    public static String encodeBase64(String headerValue) {
+        if (headerValue == null) {
+            return null;
+        }
+        if (headerValue.isEmpty()) {
+            return "";
+        }
+        String encoded = Base64.getEncoder().encodeToString(headerValue.getBytes(StandardCharsets.UTF_8));
+        return "{base64}" + encoded;
     }
 }

--- a/commons/src/main/java/org/georchestra/commons/security/SecurityHeaders.java
+++ b/commons/src/main/java/org/georchestra/commons/security/SecurityHeaders.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2018 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.commons.security;
+
+/**
+ * A collection of header names commonly used by the security-proxy gateway
+ * application
+ *
+ * @author Jesse on 5/5/2014.
+ */
+public class SecurityHeaders {
+    // well-known header names
+    public static final String SEC_PROXY = "sec-proxy";
+    public static final String SEC_USERNAME = "sec-username";
+    public static final String SEC_ORG = "sec-org";
+    public static final String SEC_ORGNAME = "sec-orgname";
+    public static final String SEC_ROLES = "sec-roles";
+    public static final String SEC_FIRSTNAME = "sec-firstname";
+    public static final String SEC_LASTNAME = "sec-lastname";
+    public static final String SEC_EMAIL = "sec-email";
+    public static final String SEC_TEL = "sec-tel";
+    public static final String IMP_ROLES = "imp-roles";
+    public static final String IMP_USERNAME = "imp-username";
+
+    public static String decode(String headerValue) {
+        return headerValue;
+    }
+}

--- a/commons/src/test/java/org/georchestra/commons/security/SecurityHeadersTest.java
+++ b/commons/src/test/java/org/georchestra/commons/security/SecurityHeadersTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.commons.security;
+
+import static org.georchestra.commons.security.SecurityHeaders.decode;
+import static org.georchestra.commons.security.SecurityHeaders.encodeBase64;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class SecurityHeadersTest {
+
+    @Test
+    public void encodeBase64_Null() {
+        assertNull(encodeBase64(null));
+    }
+
+    @Test
+    public void encodeBase64_Japanese() {
+        final String givenName = "ガブリエル";
+        final String lastName = "ロルダン";
+
+        final String encodedGivenName = "44Ks44OW44Oq44Ko44Or";
+        final String encodedLastName = "44Ot44Or44OA44Oz";
+
+        assertEquals("{base64}" + encodedGivenName, encodeBase64(givenName));
+        assertEquals("{base64}" + encodedLastName, encodeBase64(lastName));
+    }
+
+    @Test
+    public void encodeBase64_Empty() {
+        assertEquals("empty string should remain empty string", "", encodeBase64(""));
+        assertEquals("", decode(""));
+    }
+
+    @Test
+    public void encodeBase64_Space() {
+        assertEquals("{base64}IA==", encodeBase64(" "));
+        assertEquals(" ", decode("{base64}IA=="));
+    }
+
+    @Test
+    public void encodeBase64_Spaces() {
+        assertEquals("{base64}ICAgICAgICAgIA==", encodeBase64("          "));
+        assertEquals("          ", decode("{base64}ICAgICAgICAgIA=="));
+    }
+
+    @Test
+    public void encodeBase64_PrefixString() {
+        assertEquals("{base64}e2Jhc2U2NH0=", encodeBase64("{base64}"));
+        assertEquals("{base64}", decode("{base64}e2Jhc2U2NH0="));
+    }
+
+    @Test
+    public void encodeBase64_Newlines() {
+        assertEquals("{base64}dGV4dAp3aXRoDQoKZXdsaW5lcwoK", encodeBase64("text\nwith\r\n\newlines\n\n"));
+        assertEquals("text\nwith\r\n\newlines\n\n", decode("{base64}dGV4dAp3aXRoDQoKZXdsaW5lcwoK"));
+    }
+
+    @Test
+    public void testDecodeNull() {
+        assertNull(decode(null));
+    }
+
+    @Test
+    public void testDecodeEmpty() {
+        assertEquals("", decode(""));
+    }
+
+    @Test
+    public void testDecode_NoEncoding() {
+        final String givenName = "ガブリエル";
+        assertEquals(givenName, decode(givenName));
+        assertEquals("{}" + givenName, decode("{}" + givenName));
+        assertEquals("{" + givenName + "}", decode("{" + givenName + "}"));
+    }
+
+    @Test
+    public void testDecode_Base64() {
+        final String givenName = "ガブリエル";
+        final String lastName = "ロルダン";
+
+        assertEquals(givenName, decode(encodeBase64(givenName)));
+        assertEquals(lastName, decode(encodeBase64(lastName)));
+
+        assertEquals("{}" + givenName, decode(encodeBase64("{}" + givenName)));
+        assertEquals("{" + lastName + "}", decode(encodeBase64("{" + lastName + "}")));
+    }
+}

--- a/console/src/main/java/org/georchestra/console/ws/HomeController.java
+++ b/console/src/main/java/org/georchestra/console/ws/HomeController.java
@@ -19,9 +19,9 @@
 
 package org.georchestra.console.ws;
 
-import java.io.File;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+
 import java.io.IOException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,9 +29,9 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.bs.ExpiredTokenManagement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -70,7 +70,7 @@ public class HomeController {
     @RequestMapping(value = "/")
     public void root(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        String roles = request.getHeader("sec-roles");
+        String roles = SecurityHeaders.decode(request.getHeader(SEC_ROLES));
 
         if (roles != null) {
             String redirectUrl;

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/delegations/DelegationController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/delegations/DelegationController.java
@@ -19,8 +19,18 @@
 
 package org.georchestra.console.ws.backoffice.delegations;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.dao.DelegationDao;
 import org.georchestra.console.ds.AccountDao;
 import org.georchestra.console.ds.DataServiceException;
@@ -35,19 +45,12 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
 
 @Controller
 public class DelegationController {
@@ -115,7 +118,7 @@ public class DelegationController {
         delegation.setRoles(this.parseJSONArray(json.getJSONArray("roles")));
         this.delegationDao.save(delegation);
         Account account = accountDao.findByUID(uid);
-        this.roleDao.addUser("ORGADMIN", account, request.getHeader("sec-username"));
+        this.roleDao.addUser("ORGADMIN", account, SecurityHeaders.decode(request.getHeader(SEC_USERNAME)));
 
         return delegation.toJSON().toString();
     }
@@ -136,7 +139,8 @@ public class DelegationController {
 
         // TODO deny if request came from delegated admin
         this.delegationDao.delete(uid);
-        this.roleDao.deleteUser("ORGADMIN", accountDao.findByUID(uid), request.getHeader("sec-username"));
+        this.roleDao.deleteUser("ORGADMIN", accountDao.findByUID(uid),
+                SecurityHeaders.decode(request.getHeader(SEC_USERNAME)));
         return new JSONObject().put("result", "ok").toString();
     }
 

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/orgs/OrgsController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/orgs/OrgsController.java
@@ -19,17 +19,37 @@
 
 package org.georchestra.console.ws.backoffice.orgs;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.dao.AdvancedDelegationDao;
 import org.georchestra.console.dao.DelegationDao;
 import org.georchestra.console.ds.OrgsDao;
 import org.georchestra.console.dto.orgs.Org;
 import org.georchestra.console.dto.orgs.OrgExt;
-import org.georchestra.console.model.DelegationEntry;
 import org.georchestra.console.model.AdminLogType;
+import org.georchestra.console.model.DelegationEntry;
 import org.georchestra.console.ws.backoffice.utils.ResponseUtil;
-import org.georchestra.console.ws.utils.Validation;
 import org.georchestra.console.ws.utils.LogUtils;
+import org.georchestra.console.ws.utils.Validation;
 import org.georchestra.lib.file.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -48,23 +68,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 @Controller
 public class OrgsController {
@@ -243,7 +246,8 @@ public class OrgsController {
         }
 
         // log if pending status change
-        if (request.getHeader("sec-username") != null && defaultPending != org.isPending()) {
+        String username = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
+        if (username != null && defaultPending != org.isPending()) {
             logUtils.createLog(org.getId(), AdminLogType.PENDING_ORG_ACCEPTED, null);
         }
         return org;

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -22,6 +22,7 @@ package org.georchestra.console.ws.backoffice.users;
 import lombok.Setter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.dao.AdvancedDelegationDao;
 import org.georchestra.console.dao.DelegationDao;
 import org.georchestra.console.ds.*;
@@ -56,6 +57,9 @@ import javax.mail.MessagingException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.io.IOException;
 import java.text.Normalizer;
 import java.text.ParseException;
@@ -495,7 +499,7 @@ public class UsersController {
         this.checkAuthorization(uid);
 
         final Account account = accountDao.findByUID(uid);
-        final String requestOriginator = request.getHeader("sec-username");
+        final String requestOriginator = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
         deleteAccount(account, requestOriginator);
         ResponseUtil.writeSuccess(response);
     }

--- a/console/src/main/java/org/georchestra/console/ws/editorgdetails/EditOrgDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/editorgdetails/EditOrgDetailsFormController.java
@@ -18,8 +18,17 @@
  */
 package org.georchestra.console.ws.editorgdetails;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+
+import java.io.IOException;
+import java.util.Base64;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.ds.OrgsDao;
 import org.georchestra.console.dto.orgs.Org;
 import org.georchestra.console.dto.orgs.OrgExt;
@@ -39,11 +48,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
-import java.util.Base64;
 
 @Controller
 @SessionAttributes(types = EditOrgDetailsFormBean.class)
@@ -84,7 +88,7 @@ public class EditOrgDetailsFormController {
     @RequestMapping(value = "/account/orgdetails", method = RequestMethod.GET)
     @PreAuthorize("hasAnyRole('REFERENT', 'SUPERUSER')")
     public String setupForm(HttpServletRequest request, Model model) {
-        Org org = this.orgsDao.findByCommonName(request.getHeader("sec-org"));
+        Org org = this.orgsDao.findByCommonName(SecurityHeaders.decode(request.getHeader(SEC_ORG)));
         OrgExt orgExt = this.orgsDao.findExtById(org.getId());
         org.setOrgExt(orgExt);
 

--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -19,9 +19,31 @@
 
 package org.georchestra.console.ws.newaccount;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.mail.MessagingException;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.validator.routines.EmailValidator;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.bs.ReCaptchaParameters;
 import org.georchestra.console.dao.AdvancedDelegationDao;
 import org.georchestra.console.ds.AccountDao;
@@ -32,9 +54,9 @@ import org.georchestra.console.ds.OrgsDao;
 import org.georchestra.console.ds.RoleDao;
 import org.georchestra.console.dto.Account;
 import org.georchestra.console.dto.AccountFactory;
+import org.georchestra.console.dto.Role;
 import org.georchestra.console.dto.orgs.Org;
 import org.georchestra.console.dto.orgs.OrgExt;
-import org.georchestra.console.dto.Role;
 import org.georchestra.console.mailservice.EmailFactory;
 import org.georchestra.console.model.AdminLogType;
 import org.georchestra.console.model.DelegationEntry;
@@ -54,24 +76,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
-
-import javax.mail.MessagingException;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.time.Clock;
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Manages the UI Account Form.
@@ -278,7 +282,7 @@ public final class NewAccountFormController {
                 account.setPrivacyPolicyAgreementDate(LocalDate.now(clock));
             }
 
-            String requestOriginator = request.getHeader("sec-username");
+            String requestOriginator = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
             accountDao.insert(account, requestOriginator);
             roleDao.addUser(Role.USER, account, requestOriginator);
             orgDao.linkUser(account);

--- a/console/src/main/java/org/georchestra/lib/springutils/GeorchestraUserDetailsService.java
+++ b/console/src/main/java/org/georchestra/lib/springutils/GeorchestraUserDetailsService.java
@@ -1,10 +1,13 @@
 package org.georchestra.lib.springutils;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+
 import java.util.Collection;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.georchestra.commons.security.SecurityHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
@@ -29,7 +32,7 @@ public class GeorchestraUserDetailsService
     protected UserDetails createUserDetails(Authentication token, Collection<? extends GrantedAuthority> authorities) {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
                 .getRequest();
-        String secRoles = request.getHeader("sec-roles");
+        String secRoles = SecurityHeaders.decode(request.getHeader(SEC_ROLES));
         List<GrantedAuthority> auth = StringUtils.isEmpty(secRoles) ? AuthorityUtils.NO_AUTHORITIES
                 : semicolonSeparatedStringToAuthorityList(secRoles);
 

--- a/console/src/test/java/org/georchestra/console/integration/UsersIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/UsersIT.java
@@ -1,8 +1,20 @@
 package org.georchestra.console.integration;
 
-import com.github.database.rider.core.api.configuration.DBUnit;
-import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.spring.api.DBRider;
+import static com.github.database.rider.core.api.dataset.SeedStrategy.CLEAN_INSERT;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.LogFactory;
 import org.georchestra.console.dto.Account;
@@ -11,7 +23,11 @@ import org.georchestra.console.integration.ds.PostgresExtendedDataTypeFactory;
 import org.georchestra.console.integration.instruments.WithMockRandomUidUser;
 import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker;
 import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker.DeletedAccountSummary;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,14 +45,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static com.github.database.rider.core.api.dataset.SeedStrategy.CLEAN_INSERT;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
 
 @RunWith(SpringRunner.class)
 @EnableWebMvc
@@ -99,7 +110,7 @@ public class UsersIT {
                 .getUsername();
         createUser(userName);
 
-        support.perform(get("/account/userdetails").header("sec-username", userName)).andExpect(status().isOk());
+        support.perform(get("/account/userdetails").header(SEC_USERNAME, userName)).andExpect(status().isOk());
     }
 
     @WithMockRandomUidUser
@@ -186,7 +197,7 @@ public class UsersIT {
                 .andExpect(jsonPath("$.geodocs").value(3))//
                 .andExpect(jsonPath("$.ogcStats").value(3));
 
-        this.mockMvc.perform(post("/account/gdpr/delete").header("sec-username", "user1"))//
+        this.mockMvc.perform(post("/account/gdpr/delete").header(SEC_USERNAME, "user1"))//
                 .andExpect(status().isNotFound());
 
     }

--- a/console/src/test/java/org/georchestra/console/ws/HomeControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/HomeControllerTest.java
@@ -1,5 +1,6 @@
 package org.georchestra.console.ws;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
 import static org.junit.Assert.assertTrue;
 
 import javax.servlet.http.HttpServletResponse;
@@ -60,7 +61,7 @@ public class HomeControllerTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        request.addHeader("sec-roles", "ROLE_ADMINISTRATOR");
+        request.addHeader(SEC_ROLES, "ROLE_ADMINISTRATOR");
         ctrl.root(request, response);
 
         assertTrue(response.getRedirectedUrl().endsWith("/account/userdetails"));
@@ -72,7 +73,7 @@ public class HomeControllerTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        request.addHeader("sec-roles", "ROLE_SUPERUSER");
+        request.addHeader(SEC_ROLES, "ROLE_SUPERUSER");
         ctrl.root(request, response);
 
         assertTrue(response.getRedirectedUrl().endsWith("/manager/"));

--- a/console/src/test/java/org/georchestra/console/ws/editorgdetails/EditOrgDetailsFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/editorgdetails/EditOrgDetailsFormControllerTest.java
@@ -1,6 +1,20 @@
 package org.georchestra.console.ws.editorgdetails;
 
-import com.google.common.io.ByteStreams;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+
 import org.georchestra.console.ds.AccountDao;
 import org.georchestra.console.ds.OrgsDao;
 import org.georchestra.console.ds.RoleDao;
@@ -22,17 +36,7 @@ import org.springframework.validation.MapBindingResult;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.google.common.io.ByteStreams;
 
 public class EditOrgDetailsFormControllerTest {
     private EditOrgDetailsFormController ctrl;
@@ -101,9 +105,9 @@ public class EditOrgDetailsFormControllerTest {
 
     @Test
     public void testSetupFormChangeUrl() throws IOException {
-        request.addHeader("sec-org", "georTest");
-        request.addHeader("sec-username", "georTest");
-        request.addHeader("sec-role", "REFERENT,THE_ADMIN");
+        request.addHeader(SEC_ORG, "georTest");
+        request.addHeader(SEC_USERNAME, "georTest");
+        request.addHeader(SEC_ROLES, "REFERENT;THE_ADMIN");
         BindingResult resultErrors = new MapBindingResult(new HashMap<>(), "errors");
         ctrl = new EditOrgDetailsFormController(orgsDao, new Validation(""));
         ctrl.logUtils = mockLogUtils;
@@ -117,9 +121,9 @@ public class EditOrgDetailsFormControllerTest {
 
     @Test
     public void testSetupFormWithImage() throws IOException {
-        request.addHeader("sec-username", "georTest");
-        request.addHeader("sec-org", "georTest");
-        request.addHeader("sec-role", "MOMO,REFERENT");
+        request.addHeader(SEC_USERNAME, "georTest");
+        request.addHeader(SEC_ORG, "georTest");
+        request.addHeader(SEC_ROLES, "MOMO;REFERENT");
         BindingResult resultErrors = new MapBindingResult(new HashMap<>(), "errors");
         ctrl = new EditOrgDetailsFormController(orgsDao, new Validation(""));
         ctrl.logUtils = mockLogUtils;

--- a/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
@@ -1,5 +1,6 @@
 package org.georchestra.console.ws.edituserdetails;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -119,7 +120,7 @@ public class EditUserDetailsFormControllerTest {
 
     @Test
     public void testSetupForm() throws Exception {
-        request.addHeader("sec-username", "mtester");
+        request.addHeader(SEC_USERNAME, "mtester");
         Mockito.when(dao.findByUID(Mockito.anyString())).thenReturn(this.mtesterAccount);
 
         String ret = ctrl.setupForm(request, response, model);
@@ -132,7 +133,7 @@ public class EditUserDetailsFormControllerTest {
     @Test
     public void testEdit() throws Exception {
         String incredibleDesc = "The incredible, marvelous and wonderfull company which tests georchestra";
-        request.addHeader("sec-username", "mtester");
+        request.addHeader(SEC_USERNAME, "mtester");
         Org org = new Org();
         org.setId("georTest");
         org.setName("geOrchestra testing LLC");
@@ -156,7 +157,7 @@ public class EditUserDetailsFormControllerTest {
 
     @Test
     public void testSetupFormNoOrg() throws Exception {
-        request.addHeader("sec-username", "mtesterNoOrg");
+        request.addHeader(SEC_USERNAME, "mtesterNoOrg");
         Mockito.when(dao.findByUID(Mockito.anyString())).thenReturn(this.mtesterAccountNoOrg);
 
         String ret = ctrl.setupForm(request, response, model);
@@ -166,7 +167,7 @@ public class EditUserDetailsFormControllerTest {
 
     @Test
     public void testEditNoOrg() throws Exception {
-        request.addHeader("sec-username", "mtesterNoOrg");
+        request.addHeader(SEC_USERNAME, "mtesterNoOrg");
         Mockito.when(dao.findByUID(Mockito.anyString())).thenReturn(this.mtesterAccountNoOrg);
         String ret = ctrl.edit(request, response, model, formBean, resultErrors, sessionStatus);
 
@@ -199,7 +200,7 @@ public class EditUserDetailsFormControllerTest {
 
     @Test
     public void testEditUserMissingRequiredField() throws IOException {
-        request.addHeader("sec-username", "mtester");
+        request.addHeader(SEC_USERNAME, "mtester");
         EditUserDetailsFormBean formBeanWithMissingField = new EditUserDetailsFormBean();
         BindingResult resultErrors = new MapBindingResult(new HashMap<>(), "errors");
         ctrl = new EditUserDetailsFormController(dao, orgsDao, roleDao,
@@ -214,7 +215,7 @@ public class EditUserDetailsFormControllerTest {
 
     @Test
     public void specialValidators() throws IOException {
-        request.addHeader("sec-username", "mtester");
+        request.addHeader(SEC_USERNAME, "mtester");
         EditUserDetailsFormBean formBeanWithMissingField = new EditUserDetailsFormBean();
         BindingResult resultErrors = new MapBindingResult(new HashMap<>(), "errors");
         ctrl = new EditUserDetailsFormController(dao, orgsDao, roleDao,

--- a/console/src/test/java/org/georchestra/console/ws/emails/EmailControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/emails/EmailControllerTest.java
@@ -1,5 +1,19 @@
 package org.georchestra.console.ws.emails;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_FIRSTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.UnsupportedEncodingException;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
+import javax.servlet.http.HttpServletRequest;
+
 import org.georchestra.console.ds.AccountDao;
 import org.georchestra.console.ds.DataServiceException;
 import org.georchestra.console.dto.Account;
@@ -7,15 +21,6 @@ import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.AddressException;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.eq;
 
 public class EmailControllerTest {
 
@@ -28,10 +33,10 @@ public class EmailControllerTest {
 
         // Mock headers
         this.request = mock(HttpServletRequest.class);
-        when(request.getHeader(eq("sec-roles"))).thenReturn("ROLE_TEST");
-        when(request.getHeader(eq("sec-firstname"))).thenReturn("Test");
-        when(request.getHeader(eq("sec-lastname"))).thenReturn("Admin");
-        when(request.getHeader(eq("sec-email"))).thenReturn("test-admin@georchestra.org");
+        when(request.getHeader(eq(SEC_ROLES))).thenReturn("ROLE_TEST");
+        when(request.getHeader(eq(SEC_FIRSTNAME))).thenReturn("Test");
+        when(request.getHeader(eq(SEC_LASTNAME))).thenReturn("Admin");
+        when(request.getHeader(eq(SEC_EMAIL))).thenReturn("test-admin@georchestra.org");
 
         // Instanciate controller
         this.ctrl = new EmailController();

--- a/console/src/test/java/org/georchestra/console/ws/newaccount/NewAccountFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/newaccount/NewAccountFormControllerTest.java
@@ -1,5 +1,30 @@
 package org.georchestra.console.ws.newaccount;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.net.URL;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.net.ssl.HttpsURLConnection;
+
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.georchestra.console.ReCaptchaV2;
@@ -38,29 +63,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.MapBindingResult;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.support.SessionStatus;
-
-import javax.net.ssl.HttpsURLConnection;
-import java.io.BufferedInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.StringReader;
-import java.net.URL;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({ "javax.net.ssl.*" })
@@ -101,7 +103,7 @@ public class NewAccountFormControllerTest {
         dn.add("uid", "testadmin");
         Account adminAccount = AccountFactory.createBrief("testadmin", "monkey123", "Test", "ADmin",
                 "postmastrer@localhost", "+33123456789", "admin", "");
-        request.addHeader("sec-username", "testadmin"); // Set user connected through http header
+        request.addHeader(SEC_USERNAME, "testadmin"); // Set user connected through http header
         Org mockOrg = new Org();
         mockOrg.setName(orgName);
         try {

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -65,6 +65,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.georchestra</groupId>
+        <artifactId>georchestra-commons</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-rest-openapi-java-client</artifactId>
         <version>${gs-rest-java-client.version}</version>
@@ -178,6 +183,10 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>org.georchestra</groupId>
+      <artifactId>georchestra-commons</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-rest-openapi-java-client</artifactId>

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
@@ -18,6 +18,7 @@
  */
 package org.georchestra.config.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.georchestra.commons.security.SecurityHeaders;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.util.StringUtils;
 
@@ -35,19 +37,19 @@ public class GeorchestraSecurityProxyAuthenticationFilter extends AbstractPreAut
 
     @Override
     protected GeorchestraUserDetails getPreAuthenticatedPrincipal(HttpServletRequest request) {
-        final boolean preAuthenticated = Boolean.parseBoolean(request.getHeader("sec-proxy"));
+        final boolean preAuthenticated = getPreAuthenticatedCredentials(request);
         if (preAuthenticated) {
-            String username = request.getHeader("sec-username");
+            String username = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
             final boolean anonymous = username == null;
             if (anonymous) {
                 username = "anonymousUser";
             }
             List<String> roles = extractRoles(request);
-            String email = request.getHeader("sec-email");
-            String firstName = request.getHeader("sec-firstname");
-            String lastName = request.getHeader("sec-lastname");
-            String organization = request.getHeader("sec-org");
-            String organizationName = request.getHeader("sec-orgname");
+            String email = SecurityHeaders.decode(request.getHeader(SEC_EMAIL));
+            String firstName = SecurityHeaders.decode(request.getHeader(SEC_FIRSTNAME));
+            String lastName = SecurityHeaders.decode(request.getHeader(SEC_LASTNAME));
+            String organization = SecurityHeaders.decode(request.getHeader(SEC_ORG));
+            String organizationName = SecurityHeaders.decode(request.getHeader(SEC_ORGNAME));
             return new GeorchestraUserDetails(username, roles, email, firstName, lastName, organization,
                     organizationName, anonymous);
         }
@@ -59,11 +61,11 @@ public class GeorchestraSecurityProxyAuthenticationFilter extends AbstractPreAut
      */
     @Override
     protected Boolean getPreAuthenticatedCredentials(HttpServletRequest request) {
-        return Boolean.parseBoolean(request.getHeader("sec-proxy"));
+        return Boolean.parseBoolean(request.getHeader(SEC_PROXY));
     }
 
     private List<String> extractRoles(HttpServletRequest request) {
-        String rolesHeader = request.getHeader("sec-roles");
+        String rolesHeader = SecurityHeaders.decode(request.getHeader(SEC_ROLES));
         if (StringUtils.isEmpty(rolesHeader)) {
             return Collections.emptyList();
         }

--- a/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
+++ b/datafeeder/src/main/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilter.java
@@ -61,7 +61,7 @@ public class GeorchestraSecurityProxyAuthenticationFilter extends AbstractPreAut
      */
     @Override
     protected Boolean getPreAuthenticatedCredentials(HttpServletRequest request) {
-        return Boolean.parseBoolean(request.getHeader(SEC_PROXY));
+        return Boolean.parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_PROXY)));
     }
 
     private List<String> extractRoles(HttpServletRequest request) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraDatadirConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraDatadirConfiguration.java
@@ -18,11 +18,26 @@
  */
 package org.georchestra.datafeeder.autoconf;
 
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+
+import lombok.extern.slf4j.Slf4j;
 
 @PropertySource(value = { //
         "file:${georchestra.datadir}/default.properties", //
         "file:${georchestra.datadir}/datafeeder/datafeeder.properties" }, //
         ignoreResourceNotFound = false)
+@Slf4j(topic = "org.georchestra.datafeeder.autoconf")
 public class GeorchestraDatadirConfiguration {
+
+    private @Value("${georchestra.datadir}") String datadir;
+
+    @PostConstruct
+    void log() {
+        log.info(
+                "Contributed application configuration from default.properties and datafeeder/datafeeder.properties in {}",
+                datadir);
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
@@ -18,6 +18,11 @@
  */
 package org.georchestra.datafeeder.service.geonetwork;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -177,10 +182,10 @@ public class GeoNetworkRemoteService {
 //		reqHeaders.set("Origin", "http://localhost:28080");
 //		reqHeaders.set("Referer", "http://localhost:28080");
 
-        reqHeaders.set("sec-proxy", "true");
-        reqHeaders.set("sec-username", "testadmin");
-        reqHeaders.set("sec-roles", "ROLE_GN_ADMIN");
-        reqHeaders.set("sec-org", "Datafeeder Test");
+        reqHeaders.set(SEC_PROXY, "true");
+        reqHeaders.set(SEC_USERNAME, "testadmin");
+        reqHeaders.set(SEC_ROLES, "ROLE_GN_ADMIN");
+        reqHeaders.set(SEC_ORG, "Datafeeder Test");
         // This is odd, apparently any UUID works as XSRF token, and these two need to
         // be set
         reqHeaders.set("X-XSRF-TOKEN", "c9f33266-e242-4198-a18c-b01290dce5f1");

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraPublishingServicesConfiguration.java
@@ -18,6 +18,9 @@
  */
 package org.georchestra.datafeeder.service.publish.impl;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,9 +86,9 @@ public class GeorchestraPublishingServicesConfiguration {
         client.setDebugRequests(config.isLogRequests());
 
         Map<String, String> authHeaders = new HashMap<>();
-        // authHeaders.put("sec-proxy", "true");
-        authHeaders.put("sec-username", "datafeeder-application");
-        authHeaders.put("sec-roles", "ROLE_ADMINISTRATOR");
+        // authHeaders.put(SEC_PROXY, "true");
+        authHeaders.put(SEC_USERNAME, "datafeeder-application");
+        authHeaders.put(SEC_ROLES, "ROLE_ADMINISTRATOR");
 
         client.setRequestHeaderAuth("georchestra", authHeaders);
         return client;

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -135,5 +135,12 @@ datafeeder:
         passwd: georchestra
 
 feign.client.config.default.loggerLevel: full # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
-logging.level.feign: DEBUG
-logging.level.org.geoserver.openapi: DEBUG
+
+logging:
+  level:
+    root: info
+    '[feign]': info
+    '[org.georchestra.datafeeder]': info
+    '[org.georchestra.config.security]': debug
+    '[org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationFilter]': info #mute GeorchestraSecurityProxyAuthenticationFilter superclass a bit
+    '[org.geoserver.openapi]': info

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -18,6 +18,14 @@
  */
 package org.georchestra.config.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_FIRSTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -84,13 +92,13 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
         baseURI = "http://localhost:" + port + contextPath + "/test/security/georchestra";
 
         requestHeaders = new HttpHeaders();
-        requestHeaders.set("sec-proxy", "true");
-        requestHeaders.set("sec-username", "testUserName");
-        requestHeaders.set("sec-email", "test@email.com");
-        requestHeaders.set("sec-firstname", "Test");
-        requestHeaders.set("sec-lastname", "Lastnametest");
-        requestHeaders.set("sec-org", "test-org");
-        requestHeaders.set("sec-orgname", "Test Organization");
+        requestHeaders.set(SEC_PROXY, "true");
+        requestHeaders.set(SEC_USERNAME, "testUserName");
+        requestHeaders.set(SEC_EMAIL, "test@email.com");
+        requestHeaders.set(SEC_FIRSTNAME, "Test");
+        requestHeaders.set(SEC_LASTNAME, "Lastnametest");
+        requestHeaders.set(SEC_ORG, "test-org");
+        requestHeaders.set(SEC_ORGNAME, "Test Organization");
     }
 
     public ResponseEntity<GeorchestraUserDetails> doGet(String relaitvePath) {
@@ -110,7 +118,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     }
 
     public @Test void testAnonymous() {
-        requestHeaders.remove("sec-username");
+        requestHeaders.remove(SEC_USERNAME);
         response = doGet("/anonymous");
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
@@ -126,7 +134,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     }
 
     public @Test void testUserRole() {
-        requestHeaders.set("sec-roles", "ROLE_USER");
+        requestHeaders.set(SEC_ROLES, "ROLE_USER");
 
         response = doGet("/anonymous");
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -144,7 +152,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     }
 
     public @Test void testAdministrator() {
-        requestHeaders.set("sec-roles", "ROLE_ADMINISTRATOR");
+        requestHeaders.set(SEC_ROLES, "ROLE_ADMINISTRATOR");
 
         response = doGet("/anonymous");
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilterTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationFilterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.config.security;
+
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_FIRSTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.georchestra.commons.security.SecurityHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class GeorchestraSecurityProxyAuthenticationFilterTest {
+
+    private GeorchestraSecurityProxyAuthenticationFilter filter;
+    private MockHttpServletRequest request;
+
+    public @Before void before() {
+        request = new MockHttpServletRequest();
+        filter = new GeorchestraSecurityProxyAuthenticationFilter();
+    }
+
+    @Test
+    public void getPreAuthenticatedCredentials_notPreauth() {
+        assertNull(request.getHeader(SEC_PROXY));
+        GeorchestraUserDetails preauth = filter.getPreAuthenticatedPrincipal(request);
+        assertNull(preauth);
+    }
+
+    @Test
+    public void getPreAuthenticatedCredentials_NoUserNameIsAnnonymous() {
+        request.addHeader(SEC_PROXY, "true");
+        GeorchestraUserDetails preauth = filter.getPreAuthenticatedPrincipal(request);
+        assertNotNull(preauth);
+        assertTrue(preauth.isAnonymous());
+        assertEquals("anonymousUser", preauth.getUsername());
+    }
+
+    @Test
+    public void getPreAuthenticatedCredentials() {
+        addEncodedHeader(SEC_PROXY, "true");
+        Map<String, String> headers = new HashMap<>();
+        headers.put(SEC_USERNAME, "test?user");
+        headers.put(SEC_FIRSTNAME, "Gábriel");
+        headers.put(SEC_LASTNAME, "Roldán");
+        headers.put(SEC_ORG, "test'org");
+        headers.put(SEC_ORGNAME, "ジョルケストラコミュニティ");
+        headers.put(SEC_EMAIL, "test@email.com");
+
+        headers.forEach(this::addEncodedHeader);
+
+        GeorchestraUserDetails auth = filter.getPreAuthenticatedPrincipal(request);
+        assertNotNull(auth);
+        assertFalse(auth.isAnonymous());
+
+        assertEquals(headers.get(SEC_USERNAME), auth.getUsername());
+        assertEquals(headers.get(SEC_FIRSTNAME), auth.getFirstName());
+        assertEquals(headers.get(SEC_LASTNAME), auth.getLastName());
+        assertEquals(headers.get(SEC_ORG), auth.getOrganization());
+        assertEquals(headers.get(SEC_ORGNAME), auth.getOrganizationName());
+        assertEquals(headers.get(SEC_EMAIL), auth.getEmail());
+    }
+
+    private void addEncodedHeader(String name, String value) {
+        String encoded = SecurityHeaders.encodeBase64((String) value);
+        addHeader(name, encoded);
+    }
+
+    private void addHeader(String name, String value) {
+        request.addHeader(name, value);
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.datafeeder.it;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -55,7 +57,6 @@ import org.springframework.stereotype.Service;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import net.sf.saxon.functions.ConstantFunction.False;
 
 /**
  * {@link Service @Service} and JUnit {@link Rule @Rule} to aid in integration
@@ -104,7 +105,7 @@ public @Service class IntegrationTestSupport extends ExternalResource {
 
         ResponseEntity<Map> entity;
         try {
-            entity = doGet(uri, Map.class, "sec-username", "datafeeder", "sec-roles", "ROLE_ADMINISTRATOR");
+            entity = doGet(uri, Map.class, SEC_USERNAME, "datafeeder", SEC_ROLES, "ROLE_ADMINISTRATOR");
         } catch (Exception e) {
             throw new IllegalStateException("Unable to connect to GeoServer at " + uri + ". " + e.getMessage(), e);
         }

--- a/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/ExtractorController.java
+++ b/extractorapp/src/main/java/org/georchestra/extractorapp/ws/extractor/ExtractorController.java
@@ -19,6 +19,10 @@
 
 package org.georchestra.extractorapp.ws.extractor;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.beans.PropertyVetoException;
 import java.io.BufferedReader;
 import java.io.File;
@@ -44,6 +48,7 @@ import javax.sql.DataSource;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.extractorapp.ws.AbstractEmailFactory;
 import org.georchestra.extractorapp.ws.Email;
 import org.georchestra.extractorapp.ws.extractor.task.ExecutionMetadata;
@@ -297,9 +302,9 @@ public class ExtractorController implements ServletContextAware {
             String[] recipients = requests.get(0)._emails;
             Email email = emailFactory.createEmail(request, recipients, url.toString());
 
-            String username = request.getHeader("sec-username");
-            String roles = request.getHeader("sec-roles");
-            String org = request.getHeader("sec-orgname");
+            String username = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
+            String roles = SecurityHeaders.decode(request.getHeader(SEC_ROLES));
+            String org = SecurityHeaders.decode(request.getHeader(SEC_ORGNAME));
             RequestConfiguration requestConfig = new RequestConfiguration(requests, requestUuid, email, servletContext,
                     testing, username, roles, org, adminCredentials, secureHost, extractionFolderPrefix,
                     maxCoverageExtractionSize, remoteReproject, useCommandLineGDAL, postData, this.userAgent);

--- a/geowebcache-webapp/src/main/java/org/georchestra/geowebcache/security/PreAuthFilter.java
+++ b/geowebcache-webapp/src/main/java/org/georchestra/geowebcache/security/PreAuthFilter.java
@@ -19,12 +19,15 @@
 
 package org.georchestra.geowebcache.security;
 
-import com.google.common.base.Strings;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -32,11 +35,15 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.google.common.base.Strings;
 
 /**
  * A filter that checks the headers of the request and determines if the user is already logged in,
@@ -46,8 +53,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 public class PreAuthFilter implements Filter {
     private static final Log logger = LogFactory.getLog(PreAuthFilter.class);
-    public static final String SEC_USERNAME = "sec-username";
-    public static final String SEC_ROLES = "sec-roles";
 
     public PreAuthFilter() {
         logger.warn("PreAuthFilter");
@@ -63,7 +68,7 @@ public class PreAuthFilter implements Filter {
             throws IOException, ServletException {
         if (request instanceof HttpServletRequest) {
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-            final String username = httpServletRequest.getHeader(SEC_USERNAME);
+            final String username = SecurityHeaders.decode(httpServletRequest.getHeader(SEC_USERNAME));
             if (username != null) {
                 SecurityContext context = SecurityContextHolder.getContext();
                 Authentication authentication = createAuthentication(httpServletRequest);
@@ -92,8 +97,8 @@ public class PreAuthFilter implements Filter {
     }
 
     private Authentication createAuthentication(HttpServletRequest httpServletRequest) {
-        final String username = httpServletRequest.getHeader(SEC_USERNAME);
-        final String rolesString = httpServletRequest.getHeader(SEC_ROLES);
+        final String username = SecurityHeaders.decode(httpServletRequest.getHeader(SEC_USERNAME));
+        final String rolesString = SecurityHeaders.decode(httpServletRequest.getHeader(SEC_ROLES));
         Set<String> roles =
                 Strings.isNullOrEmpty(rolesString)
                         ? Collections.emptySet()

--- a/geowebcache-webapp/src/test/java/org/georchestra/geowebcache/security/PreAuthFilterIT.java
+++ b/geowebcache-webapp/src/test/java/org/georchestra/geowebcache/security/PreAuthFilterIT.java
@@ -1,5 +1,7 @@
 package org.georchestra.geowebcache.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -7,7 +9,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.servlet.FilterChain;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,11 +50,11 @@ public class PreAuthFilterIT {
         assertNull(SecurityContextHolder.getContext().getAuthentication());
 
         final String username = "username";
-        request.addHeader("sec-username", username);
+        request.addHeader(SEC_USERNAME, username);
         final String roleAdmin = "ROLE_ADMINISTRATOR";
         final String roleOther = "ROLE_OTHER";
 
-        request.addHeader("sec-roles", roleAdmin + ";" + roleOther);
+        request.addHeader(SEC_ROLES, roleAdmin + ";" + roleOther);
 
         chain = Mockito.mock(FilterChain.class);
         preAuthFilter.doFilter(request, response, chain);

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/DocController.java
@@ -19,6 +19,7 @@
 
 package org.georchestra.mapfishapp.ws;
 
+import static org.georchestra.commons.security.SecurityHeaders.*;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,7 @@ import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.georchestra.commons.configuration.GeorchestraConfiguration;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.mapfishapp.ws.classif.ClassifierCommand;
 import org.georchestra.mapfishapp.ws.classif.SLDClassifier;
 import org.geotools.data.wfs.WFSDataStoreFactory;
@@ -455,7 +457,7 @@ public class DocController {
 
             // save SLD content under a file
             SLDDocService service = new SLDDocService(this.docTempDir, this.connectionPool);
-            String fileName = service.saveData(c.getSLD(), request.getHeader("sec-username"));
+            String fileName = service.saveData(c.getSLD(), SecurityHeaders.decode(request.getHeader(SEC_USERNAME)));
 
             PrintWriter out = response.getWriter();
             out.println("{\"success\":true,\"" + FILEPATH_VARNAME + "\":\"" + SLD_URL + fileName + "\"}");
@@ -519,7 +521,7 @@ public class DocController {
 
             // let the specific service handles the storage on the server
             // get back the file name under which it is saved
-            String fileName = docService.saveData(fileContent, request.getHeader("sec-username"));
+            String fileName = docService.saveData(fileContent, SecurityHeaders.decode(request.getHeader(SEC_USERNAME)));
 
             // send back to client the url path to retrieve this file later on
             response.setStatus(HttpServletResponse.SC_CREATED); // 201 created, new resource created
@@ -596,7 +598,7 @@ public class DocController {
         try {
             response.setContentType("application/json; charset=utf-8");
             PrintWriter out = response.getWriter();
-            out.print(docService.listFiles(request.getHeader("sec-username")).toString(4));
+            out.print(docService.listFiles(SecurityHeaders.decode(request.getHeader(SEC_USERNAME))).toString(4));
         } catch (Exception e) {
             sendErrorToClient(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         }
@@ -621,7 +623,7 @@ public class DocController {
         fileName = fileName.replaceAll(A_DocService.DOC_PREFIX, "");
 
         try {
-            docService.deleteFile(fileName, request.getHeader("sec-username"));
+            docService.deleteFile(fileName, SecurityHeaders.decode(request.getHeader(SEC_USERNAME)));
             response.setContentType("application/json; charset=utf-8");
             PrintWriter out = response.getWriter();
             JSONObject res = new JSONObject();

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
@@ -19,21 +19,16 @@
 
 package org.georchestra.security;
 
+import org.georchestra.commons.security.SecurityHeaders;
+
 /**
- * A collection of header names used in the proxy.
+ * A collection of header names used in the proxy, besides the ones defined in
+ * {@link SecurityHeaders}
  *
  * @author Jesse on 5/5/2014.
  */
 public class HeaderNames {
-    // well-known header names
     public static final String PROTECTED_HEADER_PREFIX = "sec-";
-    public static final String SEC_USERNAME = "sec-username";
-    public static final String SEC_ORG = "sec-org";
-    public static final String SEC_ORGNAME = "sec-orgname";
-    public static final String SEC_ROLES = "sec-roles";
-    public static final String REFERER_HEADER_NAME = "Referer";
-    public static final String IMP_ROLES = "imp-roles";
-    public static final String IMP_USERNAME = "imp-username";
     // note: JSESSIONID is strictly speaking not a Header,
     // but usual part of the the Cookie / Set-Cookie header
     public static final String JSESSION_ID = "JSESSIONID";
@@ -42,9 +37,9 @@ public class HeaderNames {
     public static final String CONTENT_LENGTH = "content-length";
     public static final String ACCEPT_ENCODING = "Accept-Encoding";
     public static final String HOST = "host";
-    public static final String SEC_PROXY = "sec-proxy";
     public static final String LOCATION = "location";
     public static final String TRANSFER_ENCODING = "Transfer-Encoding";
     public static final String CHUNKED = "chunked";
     public static final String BASIC_AUTH_HEADER = "Authorization";
+    public static final String REFERER_HEADER_NAME = "Referer";
 }

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
@@ -29,6 +29,7 @@ import org.georchestra.commons.security.SecurityHeaders;
  */
 public class HeaderNames {
     public static final String PROTECTED_HEADER_PREFIX = "sec-";
+    public static final String PRE_AUTH_REQUEST_PROPERTY = "pre-auth";
     // note: JSESSIONID is strictly speaking not a Header,
     // but usual part of the the Cookie / Set-Cookie header
     public static final String JSESSION_ID = "JSESSIONID";

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderNames.java
@@ -25,8 +25,11 @@ package org.georchestra.security;
  * @author Jesse on 5/5/2014.
  */
 public class HeaderNames {
+    // well-known header names
     public static final String PROTECTED_HEADER_PREFIX = "sec-";
     public static final String SEC_USERNAME = "sec-username";
+    public static final String SEC_ORG = "sec-org";
+    public static final String SEC_ORGNAME = "sec-orgname";
     public static final String SEC_ROLES = "sec-roles";
     public static final String REFERER_HEADER_NAME = "Referer";
     public static final String IMP_ROLES = "imp-roles";

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
@@ -34,7 +34,7 @@ public abstract class HeaderProvider {
      * {@link HeadersManagementStrategy#configureRequestHeaders(HttpServletRequest, HttpRequestBase)}
      * to allow extra headers to be added to the copied headers.
      */
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
         return Collections.emptyList();
     }
 
@@ -47,4 +47,7 @@ public abstract class HeaderProvider {
         return Collections.emptyList();
     }
 
+    protected boolean isPreAuthorized(HttpSession session) {
+        return session.getAttribute("pre-auth") != null;
+    }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
@@ -25,10 +25,14 @@ import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
 import org.apache.http.client.methods.HttpRequestBase;
 
 public abstract class HeaderProvider {
+    protected static final Log logger = LogFactory.getLog(HeaderProvider.class.getPackage().getName());
+
     /**
      * Called by
      * {@link HeadersManagementStrategy#configureRequestHeaders(HttpServletRequest, HttpRequestBase)}
@@ -53,7 +57,13 @@ public abstract class HeaderProvider {
         return Collections.emptyList();
     }
 
+    /**
+     * @return {@code true} if the request comes from a trusted proxy and has been
+     *         deemed pre-authorized by setting the {@code pre-auth} session
+     *         attribute to {@code true}
+     * @see ProxyTrustAnotherProxy
+     */
     protected boolean isPreAuthorized(HttpSession session) {
-        return session.getAttribute("pre-auth") != null;
+        return Boolean.TRUE.equals(session.getAttribute("pre-auth"));
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
@@ -33,8 +33,14 @@ public abstract class HeaderProvider {
      * Called by
      * {@link HeadersManagementStrategy#configureRequestHeaders(HttpServletRequest, HttpRequestBase)}
      * to allow extra headers to be added to the copied headers.
+     * 
+     * @param session           current session
+     * @param originalRequest   request being proxified
+     * @param targetServiceName service name as defined in
+     *                          {@code targets-mappings.properties}
      */
-    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
+            String targetServiceName) {
         return Collections.emptyList();
     }
 

--- a/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeaderProvider.java
@@ -19,6 +19,8 @@
 
 package org.georchestra.security;
 
+import static org.georchestra.security.HeaderNames.PRE_AUTH_REQUEST_PROPERTY;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -59,11 +61,11 @@ public abstract class HeaderProvider {
 
     /**
      * @return {@code true} if the request comes from a trusted proxy and has been
-     *         deemed pre-authorized by setting the {@code pre-auth} session
+     *         deemed pre-authorized by setting the {@code pre-auth} request
      *         attribute to {@code true}
      * @see ProxyTrustAnotherProxy
      */
-    protected boolean isPreAuthorized(HttpSession session) {
-        return Boolean.TRUE.equals(session.getAttribute("pre-auth"));
+    public static boolean isPreAuthorized(HttpServletRequest originalRequest) {
+        return Boolean.TRUE.equals(originalRequest.getAttribute(PRE_AUTH_REQUEST_PROPERTY));
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -28,8 +28,8 @@ import static org.georchestra.security.HeaderNames.CONTENT_LENGTH;
 import static org.georchestra.security.HeaderNames.COOKIE_ID;
 import static org.georchestra.security.HeaderNames.HOST;
 import static org.georchestra.security.HeaderNames.PROTECTED_HEADER_PREFIX;
-import static org.georchestra.security.HeaderNames.TRANSFER_ENCODING;
 import static org.georchestra.security.HeaderNames.REFERER_HEADER_NAME;
+import static org.georchestra.security.HeaderNames.TRANSFER_ENCODING;
 
 import java.net.HttpCookie;
 import java.util.ArrayList;
@@ -220,7 +220,7 @@ public class HeadersManagementStrategy {
         addHeaderLog(headersLog, headerName, value);
     }
 
-    private void addHeaderLog(StringBuilder headersLog, String headerName, String value) {
+    private void addHeaderLog(StringBuilder headersLog, String headerName, CharSequence value) {
         if (headersLog != null) {
             headersLog.append("\t" + headerName);
             headersLog.append("=");
@@ -291,12 +291,7 @@ public class HeadersManagementStrategy {
             }
         }
 
-        if (headersLog != null) {
-            headersLog.append("\t" + COOKIE_ID);
-            headersLog.append("=");
-            headersLog.append(cookies);
-            headersLog.append("\n");
-        }
+        addHeaderLog(headersLog, COOKIE_ID, cookies);
 
         proxyRequest.addHeader(new BasicHeader(COOKIE_ID, cookies.toString()));
 

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -40,12 +40,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.apache.http.Header;
-import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.message.BasicHeader;
@@ -71,7 +71,7 @@ public class HeadersManagementStrategy {
     private boolean noAcceptEncoding = false;
     private List<HeaderProvider> headerProviders = Collections.emptyList();
     private List<HeaderFilter> filters = new ArrayList<HeaderFilter>(1);
-    private String referer = null;
+    private String forcedReferer = null;
 
     public HeadersManagementStrategy() {
         filters.add(new SecurityRequestHeaderFilter());
@@ -80,121 +80,151 @@ public class HeadersManagementStrategy {
     /**
      * Copies the request headers from the original request to the proxy request. It
      * may modify the headers slightly
+     * 
+     * @param localProxy true if the request targets a security-proxyfied webapp
+     *                   (e.g. mapfishapp, ...), false otherwise
      */
-    @SuppressWarnings("unchecked")
     public synchronized void configureRequestHeaders(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
             boolean localProxy) {
-        Enumeration<String> headerNames = originalRequest.getHeaderNames();
-        String headerName = null;
 
-        HttpSession session = originalRequest.getSession();
+        final StringBuilder headersLog = logger.isTraceEnabled()
+                ? new StringBuilder("Request Headers:\n==========================================================\n")
+                : null;
 
-        StringBuilder headersLog = new StringBuilder("Request Headers:\n");
-        headersLog.append("==========================================================\n");
-
-        if (!localProxy && referer != null) {
-            addHeaderToRequestAndLog(proxyRequest, headersLog, REFERER_HEADER_NAME, this.referer);
+        // see https://github.com/georchestra/georchestra/issues/509:
+        addHeaderToRequestAndLog(proxyRequest, headersLog, SEC_PROXY, "true");
+        if (!isPreAuthorized(originalRequest)) {
+            addAllowedIncomingHeaders(originalRequest, proxyRequest, localProxy, headersLog);
         }
 
-        if (session.getAttribute("pre-auth") == null) {
-            while (headerNames.hasMoreElements()) {
-                headerName = headerNames.nextElement();
-                if (headerName.compareToIgnoreCase(CONTENT_LENGTH) == 0) {
-                    continue;
-                }
-                if (headerName.equalsIgnoreCase(COOKIE_ID)) {
-                    continue;
-                }
-                if (filter(originalRequest, headerName, proxyRequest)) {
-                    continue;
-                }
-                if (noAcceptEncoding && headerName.equalsIgnoreCase(ACCEPT_ENCODING)) {
-                    continue;
-                }
-                // It is the HttpClient's lib duty to add this header accordingly.
-                if (headerName.equalsIgnoreCase(TRANSFER_ENCODING)) {
-                    continue;
-                }
-                if (headerName.equalsIgnoreCase(HOST)) {
-                    continue;
-                }
-                // Don't forward basic auth
-                if (headerName.equalsIgnoreCase(BASIC_AUTH_HEADER)) {
-                    continue;
-                }
-                // Don't forward 'sec-*' headers, those headers must be managed by
-                // security-proxy
-                if (headerName.toLowerCase().startsWith(PROTECTED_HEADER_PREFIX)) {
-                    continue;
-                }
-                if (!localProxy && referer != null && headerName.equalsIgnoreCase(REFERER_HEADER_NAME)) {
+        if (localProxy) {
+            handleRequestCookies(originalRequest, proxyRequest, headersLog);
+            applyHeaderProviders(originalRequest, proxyRequest, headersLog);
+        } else if (forcedReferer != null) {
+            addHeaderToRequestAndLog(proxyRequest, headersLog, REFERER_HEADER_NAME, this.forcedReferer);
+        }
+
+        if (logger.isTraceEnabled()) {
+            headersLog.append("==========================================================");
+            logger.trace(headersLog.toString());
+        }
+    }
+
+    private void applyHeaderProviders(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
+            StringBuilder headersLog) {
+
+        final boolean preAuthorized = isPreAuthorized(originalRequest);
+        final HttpSession session = originalRequest.getSession();
+        for (HeaderProvider provider : headerProviders) {
+
+            // Don't include headers from security framework for request coming from trusted
+            // proxy
+            if (preAuthorized && !(provider instanceof TrustedProxyRequestHeaderProvider)) {
+                logger.debug("Bypassing header provider : {}", provider.getClass().toString());
+                continue;
+            }
+
+            Collection<Header> providerHeaders = provider.getCustomRequestHeaders(session, originalRequest);
+            for (Header header : providerHeaders) {
+
+                final String providerHeaderName = header.getName();
+                logger.debug("Processing  header  {} from {}", providerHeaderName, provider.getClass().toString());
+                // ignore Host and Content-Length header
+                if (isOneOf(providerHeaderName, HOST, CONTENT_LENGTH)) {
                     continue;
                 }
 
+                if (isOneOf(providerHeaderName, SEC_USERNAME, SEC_ROLES)
+                        && proxyRequest.getFirstHeader(providerHeaderName) != null) {
+                    Header[] originalHeaders = proxyRequest.getHeaders(providerHeaderName);
+                    for (Header originalHeader : originalHeaders) {
+                        addHeaderLog(headersLog, originalHeader.getName(), originalHeader.getValue());
+                    }
+                    continue;
+                }
+
+                logger.debug("Adding header to proxied request: {} = {}", providerHeaderName, header.getValue());
+                proxyRequest.addHeader(header);
+                addHeaderLog(headersLog, providerHeaderName, header.getValue());
+            }
+        }
+    }
+
+    private boolean isOneOf(String header, String... names) {
+        for (String name : names) {
+            if (header.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void addAllowedIncomingHeaders(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
+            boolean localProxy, StringBuilder headersLog) {
+        for (String headerName : Collections.list(originalRequest.getHeaderNames())) {
+            if (!ignoreIncomingHeader(headerName, originalRequest, proxyRequest, localProxy)) {
                 String value = originalRequest.getHeader(headerName);
                 addHeaderToRequestAndLog(proxyRequest, headersLog, headerName, value);
             }
         }
-        // see https://github.com/georchestra/georchestra/issues/509:
-        addHeaderToRequestAndLog(proxyRequest, headersLog, SEC_PROXY, "true");
-
-        if (localProxy) {
-            handleRequestCookies(originalRequest, proxyRequest, headersLog);
-            for (HeaderProvider provider : headerProviders) {
-
-                // Don't include headers from security framework for request coming from trusted
-                // proxy
-                if (session.getAttribute("pre-auth") != null
-                        && (!(provider instanceof TrustedProxyRequestHeaderProvider))) {
-                    logger.debug("Bypassing header provider : {}", provider.getClass().toString());
-                    continue;
-                }
-
-                for (Header header : provider.getCustomRequestHeaders(session, originalRequest)) {
-
-                    logger.debug("Processing  header  {} from {}", header.getName(), provider.getClass().toString());
-
-                    if ((header.getName().equalsIgnoreCase(SEC_USERNAME)
-                            || header.getName().equalsIgnoreCase(SEC_ROLES))
-                            && proxyRequest.getHeaders(header.getName()) != null
-                            && proxyRequest.getHeaders(header.getName()).length > 0) {
-                        Header[] originalHeaders = proxyRequest.getHeaders(header.getName());
-                        for (Header originalHeader : originalHeaders) {
-                            headersLog.append("\t" + originalHeader.getName());
-                            headersLog.append("=");
-                            headersLog.append(originalHeader.getValue());
-                            headersLog.append("\n");
-                        }
-                    } else {
-                        // ignore Host and Content-Length header
-                        if (header.getName().equalsIgnoreCase(HttpHeaders.HOST)
-                                || header.getName().equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH))
-                            continue;
-
-                        logger.debug("Adding header to proxied request: {} = {}", header.getName(), header.getValue());
-                        proxyRequest.addHeader(header);
-                        headersLog.append("\t" + header.getName());
-                        headersLog.append("=");
-                        headersLog.append(header.getValue());
-                        headersLog.append("\n");
-                    }
-                }
-            }
-        }
-
-        headersLog.append("==========================================================");
-
-        logger.trace(headersLog.toString());
     }
 
-    private void addHeaderToRequestAndLog(HttpRequestBase proxyRequest, StringBuilder headersLog, String headerName,
-            String value) {
+    private boolean ignoreIncomingHeader(String headerName, HttpServletRequest originalRequest,
+            HttpRequestBase proxyRequest, boolean localProxy) {
+
+        if (headerName.compareToIgnoreCase(CONTENT_LENGTH) == 0) {
+            return true;
+        }
+        if (headerName.equalsIgnoreCase(COOKIE_ID)) {
+            return true;
+        }
+        if (filter(originalRequest, headerName, proxyRequest)) {
+            return true;
+        }
+        if (noAcceptEncoding && headerName.equalsIgnoreCase(ACCEPT_ENCODING)) {
+            return true;
+        }
+        // It is the HttpClient's lib duty to add this header accordingly.
+        if (headerName.equalsIgnoreCase(TRANSFER_ENCODING)) {
+            return true;
+        }
+        if (headerName.equalsIgnoreCase(HOST)) {
+            return true;
+        }
+        // Don't forward basic auth
+        if (headerName.equalsIgnoreCase(BASIC_AUTH_HEADER)) {
+            return true;
+        }
+        // Don't forward 'sec-*' headers, those headers must be managed by
+        // security-proxy
+        if (headerName.toLowerCase().startsWith(PROTECTED_HEADER_PREFIX)) {
+            return true;
+        }
+        if (!localProxy && forcedReferer != null && headerName.equalsIgnoreCase(REFERER_HEADER_NAME)) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isPreAuthorized(HttpServletRequest originalRequest) {
+        HttpSession session = originalRequest.getSession();
+        return session.getAttribute("pre-auth") != null;
+    }
+
+    private void addHeaderToRequestAndLog(HttpRequestBase proxyRequest, @Nullable StringBuilder headersLog,
+            String headerName, String value) {
         logger.debug("Add Header: {} = {}", headerName, value);
         proxyRequest.addHeader(new BasicHeader(headerName, value));
-        headersLog.append("\t" + headerName);
-        headersLog.append("=");
-        headersLog.append(value);
-        headersLog.append("\n");
+        addHeaderLog(headersLog, headerName, value);
+    }
+
+    private void addHeaderLog(StringBuilder headersLog, String headerName, String value) {
+        if (headersLog != null) {
+            headersLog.append("\t" + headerName);
+            headersLog.append("=");
+            headersLog.append(value);
+            headersLog.append("\n");
+        }
     }
 
     /**
@@ -217,7 +247,7 @@ public class HeadersManagementStrategy {
      */
     @VisibleForTesting
     public void handleRequestCookies(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
-            StringBuilder headersLog) {
+            @Nullable StringBuilder headersLog) {
 
         Enumeration<String> headers = originalRequest.getHeaders(COOKIE_ID);
         StringBuilder cookies = new StringBuilder();
@@ -259,10 +289,12 @@ public class HeadersManagementStrategy {
             }
         }
 
-        headersLog.append("\t" + COOKIE_ID);
-        headersLog.append("=");
-        headersLog.append(cookies);
-        headersLog.append("\n");
+        if (headersLog != null) {
+            headersLog.append("\t" + COOKIE_ID);
+            headersLog.append("=");
+            headersLog.append(cookies);
+            headersLog.append("\n");
+        }
 
         proxyRequest.addHeader(new BasicHeader(COOKIE_ID, cookies.toString()));
 
@@ -443,6 +475,6 @@ public class HeadersManagementStrategy {
     }
 
     public void setReferer(String referer) {
-        this.referer = referer;
+        this.forcedReferer = referer;
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -19,17 +19,17 @@
 
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.georchestra.security.HeaderNames.ACCEPT_ENCODING;
 import static org.georchestra.security.HeaderNames.BASIC_AUTH_HEADER;
 import static org.georchestra.security.HeaderNames.CONTENT_LENGTH;
 import static org.georchestra.security.HeaderNames.COOKIE_ID;
 import static org.georchestra.security.HeaderNames.HOST;
 import static org.georchestra.security.HeaderNames.PROTECTED_HEADER_PREFIX;
-import static org.georchestra.security.HeaderNames.REFERER_HEADER_NAME;
-import static org.georchestra.security.HeaderNames.SEC_PROXY;
-import static org.georchestra.security.HeaderNames.SEC_ROLES;
-import static org.georchestra.security.HeaderNames.SEC_USERNAME;
 import static org.georchestra.security.HeaderNames.TRANSFER_ENCODING;
+import static org.georchestra.security.HeaderNames.REFERER_HEADER_NAME;
 
 import java.net.HttpCookie;
 import java.util.ArrayList;

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -94,7 +94,7 @@ public class HeadersManagementStrategy {
 
         // see https://github.com/georchestra/georchestra/issues/509:
         addHeaderToRequestAndLog(proxyRequest, headersLog, SEC_PROXY, "true");
-        if (!isPreAuthorized(originalRequest)) {
+        if (!HeaderProvider.isPreAuthorized(originalRequest)) {
             addAllowedIncomingHeaders(originalRequest, proxyRequest, localProxy, headersLog);
         }
 
@@ -114,7 +114,7 @@ public class HeadersManagementStrategy {
     private void applyHeaderProviders(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
             StringBuilder headersLog, String targetServiceName) {
 
-        final boolean preAuthorized = isPreAuthorized(originalRequest);
+        final boolean preAuthorized = HeaderProvider.isPreAuthorized(originalRequest);
         final HttpSession session = originalRequest.getSession();
         for (HeaderProvider provider : headerProviders) {
 
@@ -206,11 +206,6 @@ public class HeadersManagementStrategy {
             return true;
         }
         return false;
-    }
-
-    private boolean isPreAuthorized(HttpServletRequest originalRequest) {
-        HttpSession session = originalRequest.getSession();
-        return session.getAttribute("pre-auth") != null;
     }
 
     private void addHeaderToRequestAndLog(HttpRequestBase proxyRequest, @Nullable StringBuilder headersLog,

--- a/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/HeadersManagementStrategy.java
@@ -81,11 +81,12 @@ public class HeadersManagementStrategy {
      * Copies the request headers from the original request to the proxy request. It
      * may modify the headers slightly
      * 
-     * @param localProxy true if the request targets a security-proxyfied webapp
-     *                   (e.g. mapfishapp, ...), false otherwise
+     * @param localProxy        true if the request targets a security-proxyfied
+     *                          webapp (e.g. mapfishapp, ...), false otherwise
+     * @param targetServiceName
      */
     public synchronized void configureRequestHeaders(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
-            boolean localProxy) {
+            boolean localProxy, String targetServiceName) {
 
         final StringBuilder headersLog = logger.isTraceEnabled()
                 ? new StringBuilder("Request Headers:\n==========================================================\n")
@@ -99,7 +100,7 @@ public class HeadersManagementStrategy {
 
         if (localProxy) {
             handleRequestCookies(originalRequest, proxyRequest, headersLog);
-            applyHeaderProviders(originalRequest, proxyRequest, headersLog);
+            applyHeaderProviders(originalRequest, proxyRequest, headersLog, targetServiceName);
         } else if (forcedReferer != null) {
             addHeaderToRequestAndLog(proxyRequest, headersLog, REFERER_HEADER_NAME, this.forcedReferer);
         }
@@ -111,7 +112,7 @@ public class HeadersManagementStrategy {
     }
 
     private void applyHeaderProviders(HttpServletRequest originalRequest, HttpRequestBase proxyRequest,
-            StringBuilder headersLog) {
+            StringBuilder headersLog, String targetServiceName) {
 
         final boolean preAuthorized = isPreAuthorized(originalRequest);
         final HttpSession session = originalRequest.getSession();
@@ -124,7 +125,8 @@ public class HeadersManagementStrategy {
                 continue;
             }
 
-            Collection<Header> providerHeaders = provider.getCustomRequestHeaders(session, originalRequest);
+            Collection<Header> providerHeaders = provider.getCustomRequestHeaders(session, originalRequest,
+                    targetServiceName);
             for (Header header : providerHeaders) {
 
                 final String providerHeaderName = header.getName();

--- a/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -44,6 +45,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 public class ImpersonateUserRequestHeaderProvider extends HeaderProvider {
     private List<String> trustedUsers = new ArrayList<String>();
+
+    @PostConstruct
+    public void init() {
+        logger.info(
+                String.format("User impersonation enabled through request headers %s and %s", IMP_USERNAME, IMP_ROLES));
+    }
 
     @Override
     public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,

--- a/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
@@ -41,7 +41,7 @@ public class ImpersonateUserRequestHeaderProvider extends HeaderProvider {
     private List<String> trustedUsers = new ArrayList<String>();
 
     @Override
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
         if (originalRequest.getHeader(HeaderNames.IMP_USERNAME) != null) {
 
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
@@ -41,7 +41,8 @@ public class ImpersonateUserRequestHeaderProvider extends HeaderProvider {
     private List<String> trustedUsers = new ArrayList<String>();
 
     @Override
-    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
+            String targetServiceName) {
         if (originalRequest.getHeader(HeaderNames.IMP_USERNAME) != null) {
 
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ImpersonateUserRequestHeaderProvider.java
@@ -19,6 +19,11 @@
 
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.IMP_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.IMP_USERNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,16 +48,15 @@ public class ImpersonateUserRequestHeaderProvider extends HeaderProvider {
     @Override
     public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
             String targetServiceName) {
-        if (originalRequest.getHeader(HeaderNames.IMP_USERNAME) != null) {
+        if (originalRequest.getHeader(IMP_USERNAME) != null) {
 
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
             if (authentication != null && trustedUsers != null && trustedUsers.contains(authentication.getName())) {
                 List<Header> headers = new ArrayList<Header>(2);
 
-                headers.add(
-                        new BasicHeader(HeaderNames.SEC_USERNAME, originalRequest.getHeader(HeaderNames.IMP_USERNAME)));
-                headers.add(new BasicHeader(HeaderNames.SEC_ROLES, originalRequest.getHeader(HeaderNames.IMP_ROLES)));
+                headers.add(new BasicHeader(SEC_USERNAME, originalRequest.getHeader(IMP_USERNAME)));
+                headers.add(new BasicHeader(SEC_ROLES, originalRequest.getHeader(IMP_ROLES)));
 
                 return headers;
             }

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -131,7 +131,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
 
     public LdapUserDetailsRequestHeaderProvider(FilterBasedLdapUserSearch userSearch, String orgSearchBaseDN) {
         Assert.notNull(userSearch, "userSearch must not be null");
-        // Q: is it ok for orgSearchBaseDN to be null?
+        Assert.notNull(orgSearchBaseDN, "orgSearchBaseDN must not be null");
         this._userSearch = userSearch;
         this.orgSearchBaseDN = orgSearchBaseDN;
         this.orgSeachMemberOfPattern = Pattern.compile("([^=,]+)=([^=,]+)," + orgSearchBaseDN + ".*");

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -19,8 +19,8 @@
 
 package org.georchestra.security;
 
-import static org.georchestra.security.HeaderNames.SEC_ORG;
-import static org.georchestra.security.HeaderNames.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -23,9 +23,7 @@ import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
 import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,6 +51,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.georchestra.commons.configuration.GeorchestraConfiguration;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.LdapTemplate;
@@ -313,7 +312,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
                 Stream<String> values = Collections.list(all).stream().filter(Predicates.notNull())
                         .map(Object::toString);
                 if (base64) {
-                    values = values.map(this::encodeHeaderValueBase64);
+                    values = values.map(SecurityHeaders::encodeBase64);
                 }
                 return values.collect(Collectors.joining(","));
             } finally {
@@ -321,11 +320,6 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
             }
         }
         return null;
-    }
-
-    private String encodeHeaderValueBase64(String value) {
-        String encoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
-        return "{base64}" + encoded;
     }
 
     private String getCurrentUserName() {

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -19,18 +19,27 @@
 
 package org.georchestra.security;
 
+import static org.georchestra.security.HeaderNames.SEC_ORG;
+import static org.georchestra.security.HeaderNames.SEC_ORGNAME;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -46,24 +55,39 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
-import org.springframework.security.ldap.search.LdapUserSearch;
 import org.springframework.util.Assert;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 /**
  * Reads information from a user node in LDAP and adds the information as
  * headers to the request.
- *
+ * <p>
+ * Adds the remaining standard request headers {@code sec-org} and
+ * {@code sec-orgname} (while {@link SecurityRequestHeaderProvider} adds
+ * {@code sec-username} and {@code sec-roles}), and then any extra request
+ * header that can be extracted from the user's LDAP info and is configured in
+ * the datadirectory's {@code security-proxy/headers-mapping.properties} file.
+ * 
  * @author jeichar
+ * @see SecurityRequestHeaderProvider
  */
 public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
+
+    private static final String CACHED_USERNAME_KEY = "security-proxy-cached-username";
+
+    private static final String CACHED_HEADERS_KEY = "security-proxy-cached-attrs";
 
     protected static final Log logger = LogFactory
             .getLog(LdapUserDetailsRequestHeaderProvider.class.getPackage().getName());
 
-    private LdapUserSearch _userSearch;
-    private Map<String, String> _headerMapping;
-    private Pattern pattern;
-    private String orgSearchBaseDN;
+    private final FilterBasedLdapUserSearch _userSearch;
+    private final Pattern orgSeachMemberOfPattern;
+    private final String orgSearchBaseDN;
+
+    private Map<String, String> _headerMapping = ImmutableMap.of();
 
     @Autowired
     private LdapTemplate ldapTemplate;
@@ -71,131 +95,180 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
     @Autowired
     private GeorchestraConfiguration georchestraConfiguration;
 
-    public LdapUserDetailsRequestHeaderProvider(LdapUserSearch userSearch, String orgSearchBaseDN,
-            Map<String, String> headerMapping) {
+    public LdapUserDetailsRequestHeaderProvider(FilterBasedLdapUserSearch userSearch, String orgSearchBaseDN) {
         Assert.notNull(userSearch, "userSearch must not be null");
-        Assert.notNull(headerMapping, "headerMapping must not be null");
+        // Q: is it ok for orgSearchBaseDN to be null?
         this._userSearch = userSearch;
-        this._headerMapping = headerMapping;
         this.orgSearchBaseDN = orgSearchBaseDN;
-
-        this.pattern = Pattern.compile("([^=,]+)=([^=,]+)," + orgSearchBaseDN + ".*");
+        this.orgSeachMemberOfPattern = Pattern.compile("([^=,]+)=([^=,]+)," + orgSearchBaseDN + ".*");
     }
 
     @PostConstruct
     public void init() throws IOException {
-        if ((georchestraConfiguration != null) && (georchestraConfiguration.activated())) {
+        final boolean loadExternalConfig = (georchestraConfiguration != null) && (georchestraConfiguration.activated());
+        if (loadExternalConfig) {
             Properties pHmap = georchestraConfiguration.loadCustomPropertiesFile("headers-mapping");
-            _headerMapping.clear();
-            for (String key : pHmap.stringPropertyNames()) {
-                _headerMapping.put(key, pHmap.getProperty(key));
+            _headerMapping = Maps.fromProperties(pHmap);
+        }
+    }
+
+    public void setHeadersMapping(Map<String, String> headerNameToLdapPropMappings) {
+        this._headerMapping = headerNameToLdapPropMappings == null ? ImmutableMap.of()
+                : ImmutableMap.copyOf(headerNameToLdapPropMappings);
+    }
+
+    @Override
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+
+        // Don't use this provider for trusted request
+        if (isPreAuthorized(session) || isAnnonymous()) {
+            return Collections.emptyList();
+        }
+
+        synchronized (session) {
+            Optional<Collection<Header>> cached = getCachedHeaders(session);
+            return cached.orElseGet(() -> {
+                Collection<Header> headers = collectHeaders(session);
+                final String username = getCurrentUserName();
+                logger.debug("Storing attributes into session for user :" + username);
+                session.setAttribute(CACHED_USERNAME_KEY, username);
+                session.setAttribute(CACHED_HEADERS_KEY, headers);
+                return headers;
+            });
+        }
+    }
+
+    /**
+     * Actually performs the building of the request headers list
+     */
+    private Collection<Header> collectHeaders(HttpSession session) {
+        final String username = getCurrentUserName();
+
+        List<Header> headers = buildStandardOrganizationHeaders(username);
+        List<Header> userDefinedHeaders = collectHeaderMappings(username, this._headerMapping);
+
+        headers.addAll(userDefinedHeaders);
+
+        return headers;
+    }
+
+    private List<Header> buildStandardOrganizationHeaders(String username) {
+        // Add user organization
+        final String orgCn = loadOrgCn(username);
+
+        List<Header> headers = new ArrayList<>();
+        // add sec-orgname
+        if (orgCn != null) {
+            headers.add(new BasicHeader(SEC_ORG, orgCn));
+            try {
+                DirContextOperations ctx = this.ldapTemplate.lookupContext("cn=" + orgCn + "," + this.orgSearchBaseDN);
+                headers.add(new BasicHeader(SEC_ORGNAME, ctx.getStringAttribute("o")));
+            } catch (RuntimeException ex) {
+                logger.warn("Cannot find associated org with cn " + orgCn);
+            }
+        }
+        return headers;
+    }
+
+    private String loadOrgCn(String username) {
+        try {
+            // Retreive memberOf attributes
+            // WARN! (groldan) looks like _userSearch is a singleton, so we could be mixing
+            // up setReturningAttributes from concurrent requests (we're synchronized on
+            // session here, not on _userSearch)
+            this._userSearch.setReturningAttributes(new String[] { "memberOf" });
+            DirContextOperations orgData = _userSearch.searchForUser(username);
+            Attribute attributes = orgData.getAttributes().get("memberOf");
+            if (attributes != null) {
+                NamingEnumeration<?> all = attributes.getAll();
+                while (all.hasMore()) {
+                    String memberOf = all.next().toString();
+                    Matcher m = this.orgSeachMemberOfPattern.matcher(memberOf);
+                    if (m.matches()) {
+                        String orgCn = m.group(2);
+                        return orgCn;
+                    }
+                }
+            }
+        } catch (javax.naming.NamingException e) {
+            logger.error("problem adding headers for request: organization", e);
+        } finally {
+            // restore standard attribute list
+            this._userSearch.setReturningAttributes(null);
+        }
+        return null;
+    }
+
+    List<Header> collectHeaderMappings(String username, Map<String, String> mappings) {
+        final List<Header> headers = new ArrayList<>();
+        DirContextOperations userData;
+        try {
+            userData = _userSearch.searchForUser(username);
+        } catch (Exception e) {
+            logger.warn("Unable to lookup user:" + username, e);
+            return Collections.emptyList();
+        }
+        try {
+            final Attributes ldapUserAttributes = userData.getAttributes();
+            mappings.forEach((headerName, ldapPropertyName) -> {
+                try {
+                    final @Nullable String headerValue = buildValue(ldapUserAttributes, ldapPropertyName);
+                    headers.add(new BasicHeader(headerName, headerValue));
+                } catch (javax.naming.NamingException e) {
+                    logger.error("problem adding headers for request:" + headerName, e);
+                }
+            });
+            return headers;
+        } finally {
+            try {
+                userData.close();
+            } catch (NamingException e) {
+                logger.warn("error closing ldap context for user :" + username, e);
             }
         }
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
-
-        // Don't use this provider for trusted request
-        if (session.getAttribute("pre-auth") != null) {
-            return Collections.emptyList();
-        }
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication instanceof AnonymousAuthenticationToken) {
-            return Collections.emptyList();
-        }
-        String username = authentication.getName();
-        DirContextOperations userData;
-
-        Collection<Header> headers = Collections.emptyList();
-
-        synchronized (session) {
-
-            if (session.getAttribute("security-proxy-cached-attrs") != null) {
-                try {
-                    headers = (Collection<Header>) session.getAttribute("security-proxy-cached-attrs");
-                    String expectedUsername = (String) session.getAttribute("security-proxy-cached-username");
-
-                    if (username.equals(expectedUsername)) {
-                        return headers;
-                    }
-                } catch (Exception e) {
-                    logger.info("Unable to lookup cached user's attributes for user :" + username, e);
-                }
-            } else {
-                try {
-                    userData = _userSearch.searchForUser(username);
-                } catch (Exception e) {
-                    logger.info("Unable to lookup user:" + username, e);
-                    return Collections.emptyList();
-                }
-                headers = new ArrayList<Header>();
-                for (Map.Entry<String, String> entry : _headerMapping.entrySet()) {
-                    try {
-                        Attribute attributes = userData.getAttributes().get(entry.getValue());
-                        if (attributes != null) {
-                            NamingEnumeration<?> all = attributes.getAll();
-                            StringBuilder value = new StringBuilder();
-                            while (all.hasMore()) {
-                                if (value.length() > 0) {
-                                    value.append(',');
-                                }
-                                value.append(all.next());
-                            }
-                            headers.add(new BasicHeader(entry.getKey(), value.toString()));
-                        }
-                    } catch (javax.naming.NamingException e) {
-                        logger.error("problem adding headers for request:" + entry.getKey(), e);
-                    }
-                }
-
-                // Add user organization
-                String orgCn = null;
-                try {
-                    // Retreive memberOf attributes
-                    String[] attrs = { "memberOf" };
-                    ((FilterBasedLdapUserSearch) this._userSearch).setReturningAttributes(attrs);
-                    userData = _userSearch.searchForUser(username);
-                    Attribute attributes = userData.getAttributes().get("memberOf");
-                    if (attributes != null) {
-                        NamingEnumeration<?> all = attributes.getAll();
-
-                        while (all.hasMore()) {
-                            String memberOf = all.next().toString();
-                            Matcher m = this.pattern.matcher(memberOf);
-                            if (m.matches()) {
-                                orgCn = m.group(2);
-                                headers.add(new BasicHeader("sec-org", orgCn));
-                                break;
-                            }
-                        }
-                    }
-                } catch (javax.naming.NamingException e) {
-                    logger.error("problem adding headers for request: organization", e);
-                } finally {
-                    // restore standard attribute list
-                    ((FilterBasedLdapUserSearch) this._userSearch).setReturningAttributes(null);
-                }
-
-                // add sec-orgname
-                if (orgCn != null) {
-                    try {
-                        DirContextOperations ctx = this.ldapTemplate
-                                .lookupContext("cn=" + orgCn + "," + this.orgSearchBaseDN);
-                        headers.add(new BasicHeader("sec-orgname", ctx.getStringAttribute("o")));
-                    } catch (RuntimeException ex) {
-                        logger.warn("Cannot find associated org with cn " + orgCn);
-                    }
-                }
-
-                logger.info("Storing attributes into session for user :" + username);
-                session.setAttribute("security-proxy-cached-username", username);
-                session.setAttribute("security-proxy-cached-attrs", headers);
+    private String buildValue(Attributes ldapAttributes, String ldapPropertyName) throws NamingException {
+        Attribute attribute = ldapAttributes.get(ldapPropertyName);
+        if (attribute != null) {
+            NamingEnumeration<?> all = attribute.getAll();
+            try {
+                return Collections.list(all).stream().filter(Predicates.notNull()).map(Object::toString)
+                        .collect(Collectors.joining(","));
+            } finally {
+                all.close();
             }
         }
+        return null;
+    }
 
-        return headers;
+    private String getCurrentUserName() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getName();
+    }
+
+    private Optional<Collection<Header>> getCachedHeaders(HttpSession session) {
+        final String username = getCurrentUserName();
+
+        final boolean cached = session.getAttribute(CACHED_HEADERS_KEY) != null;
+        if (cached) {
+            try {
+                @SuppressWarnings("unchecked")
+                Collection<Header> headers = (Collection<Header>) session.getAttribute(CACHED_HEADERS_KEY);
+                String expectedUsername = (String) session.getAttribute(CACHED_USERNAME_KEY);
+
+                if (username.equals(expectedUsername)) {
+                    return Optional.of(headers);
+                }
+            } catch (Exception e) {
+                logger.info("Unable to lookup cached user's attributes for user :" + username, e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean isAnnonymous() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication instanceof AnonymousAuthenticationToken;
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -205,7 +205,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
             String targetServiceName) {
 
         // Don't use this provider for trusted request
-        if (isPreAuthorized(session) || isAnnonymous()) {
+        if (isPreAuthorized(originalRequest) || isAnnonymous()) {
             return Collections.emptyList();
         }
 

--- a/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/LdapUserDetailsRequestHeaderProvider.java
@@ -103,7 +103,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
             .getLog(LdapUserDetailsRequestHeaderProvider.class.getPackage().getName());
 
     private final FilterBasedLdapUserSearch _userSearch;
-    private final Pattern orgSeachMemberOfPattern;
+    private final Pattern orgSearchMemberOfPattern;
     private final String orgSearchBaseDN;
 
     /**
@@ -134,7 +134,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
         Assert.notNull(orgSearchBaseDN, "orgSearchBaseDN must not be null");
         this._userSearch = userSearch;
         this.orgSearchBaseDN = orgSearchBaseDN;
-        this.orgSeachMemberOfPattern = Pattern.compile("([^=,]+)=([^=,]+)," + orgSearchBaseDN + ".*");
+        this.orgSearchMemberOfPattern = Pattern.compile("([^=,]+)=([^=,]+)," + orgSearchBaseDN + ".*");
     }
 
     @PostConstruct
@@ -254,7 +254,7 @@ public class LdapUserDetailsRequestHeaderProvider extends HeaderProvider {
                 NamingEnumeration<?> all = attributes.getAll();
                 while (all.hasMore()) {
                     String memberOf = all.next().toString();
-                    Matcher m = this.orgSeachMemberOfPattern.matcher(memberOf);
+                    Matcher m = this.orgSearchMemberOfPattern.matcher(memberOf);
                     if (m.matches()) {
                         String orgCn = m.group(2);
                         return orgCn;

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -19,7 +19,8 @@
 
 package org.georchestra.security;
 
-import static org.georchestra.security.HeaderNames.*;
+import static org.georchestra.security.HeaderNames.SEC_ORGNAME;
+import static org.georchestra.security.HeaderNames.SEC_ROLES;
 import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
@@ -649,7 +650,8 @@ public class Proxy {
             logger.debug("Final request -- " + sURL);
 
             HttpRequestBase proxyingRequest = makeRequest(request, sURL);
-            headerManagement.configureRequestHeaders(request, proxyingRequest, localProxy);
+            String targetServiceName = findMatchingTarget(request);
+            headerManagement.configureRequestHeaders(request, proxyingRequest, localProxy, targetServiceName);
 
             try {
                 Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -19,8 +19,8 @@
 
 package org.georchestra.security;
 
-import static org.georchestra.security.HeaderNames.SEC_ORGNAME;
-import static org.georchestra.security.HeaderNames.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
 import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.HEAD;

--- a/security-proxy/src/main/java/org/georchestra/security/ProxyTrustAnotherProxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ProxyTrustAnotherProxy.java
@@ -14,7 +14,7 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 
 public class ProxyTrustAnotherProxy extends AbstractPreAuthenticatedProcessingFilter {
 
-    private static String AUTH_HEADER = "sec-username";
+    private static String AUTH_HEADER = HeaderNames.SEC_USERNAME;
     private static final Log logger = LogFactory.getLog(ProxyTrustAnotherProxy.class.getPackage().getName());
 
     /* The default value is an empty list of trusted proxies */

--- a/security-proxy/src/main/java/org/georchestra/security/ProxyTrustAnotherProxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ProxyTrustAnotherProxy.java
@@ -1,5 +1,6 @@
 package org.georchestra.security;
 
+import static org.georchestra.security.HeaderNames.PRE_AUTH_REQUEST_PROPERTY;
 import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 
 import java.net.InetAddress;
@@ -66,7 +67,7 @@ public class ProxyTrustAnotherProxy extends AbstractPreAuthenticatedProcessingFi
                 String username = request.getHeader(AUTH_HEADER);
                 if (username != null) {
                     logger.debug("Request from a trusted proxy, so log in user : " + username);
-                    request.getSession().setAttribute("pre-auth", true);
+                    request.setAttribute(PRE_AUTH_REQUEST_PROPERTY, Boolean.TRUE);
                 } else {
                     logger.debug("Request from a trusted proxy, but no sec-username header found");
                 }

--- a/security-proxy/src/main/java/org/georchestra/security/ProxyTrustAnotherProxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/ProxyTrustAnotherProxy.java
@@ -1,5 +1,7 @@
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashSet;
@@ -14,7 +16,7 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 
 public class ProxyTrustAnotherProxy extends AbstractPreAuthenticatedProcessingFilter {
 
-    private static String AUTH_HEADER = HeaderNames.SEC_USERNAME;
+    private static String AUTH_HEADER = SEC_USERNAME;
     private static final Log logger = LogFactory.getLog(ProxyTrustAnotherProxy.class.getPackage().getName());
 
     /* The default value is an empty list of trusted proxies */

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderFilter.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderFilter.java
@@ -19,11 +19,16 @@
 
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.IMP_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.IMP_USERNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.HttpRequestBase;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Filters out sec-username when not from trusted hosts
@@ -35,9 +40,7 @@ public class SecurityRequestHeaderFilter implements HeaderFilter {
 
     @Override
     public boolean filter(String headerName, HttpServletRequest originalRequest, HttpRequestBase proxyRequest) {
-        return headerName.equalsIgnoreCase(HeaderNames.SEC_USERNAME)
-                || headerName.equalsIgnoreCase(HeaderNames.SEC_ROLES)
-                || headerName.equalsIgnoreCase(HeaderNames.IMP_USERNAME)
-                || headerName.equalsIgnoreCase(HeaderNames.IMP_ROLES);
+        return headerName.equalsIgnoreCase(SEC_USERNAME) || headerName.equalsIgnoreCase(SEC_ROLES)
+                || headerName.equalsIgnoreCase(IMP_USERNAME) || headerName.equalsIgnoreCase(IMP_ROLES);
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
@@ -19,8 +19,8 @@
 
 package org.georchestra.security;
 
-import static org.georchestra.security.HeaderNames.SEC_ROLES;
-import static org.georchestra.security.HeaderNames.SEC_USERNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
@@ -28,9 +28,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.springframework.security.core.Authentication;
@@ -42,6 +45,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * {@link Authentication authenticated user}
  */
 public class SecurityRequestHeaderProvider extends HeaderProvider {
+
+    protected static final Log logger = LogFactory
+            .getLog(LdapUserDetailsRequestHeaderProvider.class.getPackage().getName());
+
+    @PostConstruct
+    public void init() {
+        logger.info(String.format("Will contribute standard header %s", SEC_USERNAME));
+        logger.info(String.format("Will contribute standard header %s", SEC_ROLES));
+    }
 
     @Override
     public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
@@ -44,7 +44,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class SecurityRequestHeaderProvider extends HeaderProvider {
 
     @Override
-    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
+            String targetServiceName) {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         final String authName = authentication.getName();

--- a/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/SecurityRequestHeaderProvider.java
@@ -19,9 +19,14 @@
 
 package org.georchestra.security;
 
+import static org.georchestra.security.HeaderNames.SEC_ROLES;
+import static org.georchestra.security.HeaderNames.SEC_USERNAME;
+
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -32,25 +37,25 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+/**
+ * Generates {@code sec-username} and {@code sec-roles} headers based on the
+ * {@link Authentication authenticated user}
+ */
 public class SecurityRequestHeaderProvider extends HeaderProvider {
 
     @Override
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        List<Header> headers = new ArrayList<Header>();
-        if (authentication.getName().equals("anonymousUser"))
-            return headers;
-        headers.add(new BasicHeader(HeaderNames.SEC_USERNAME, authentication.getName()));
-        StringBuilder roles = new StringBuilder();
-        for (GrantedAuthority grantedAuthority : authorities) {
-            if (roles.length() != 0)
-                roles.append(";");
+        final String authName = authentication.getName();
+        if (authName.equals("anonymousUser"))
+            return Collections.emptyList();
 
-            roles.append(grantedAuthority.getAuthority());
-        }
-        headers.add(new BasicHeader(HeaderNames.SEC_ROLES, roles.toString()));
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(SEC_USERNAME, authName));
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        String roles = authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(";"));
+        headers.add(new BasicHeader(SEC_ROLES, roles.toString()));
 
         return headers;
     }

--- a/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
@@ -18,7 +18,8 @@ public class TrustedProxyRequestHeaderProvider extends HeaderProvider {
     private static final Log logger = LogFactory.getLog(ProxyTrustAnotherProxy.class.getPackage().getName());
 
     @Override
-    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
+            String targetServiceName) {
         if (isPreAuthorized(session)) {
             return Collections.emptyList();
         }

--- a/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
@@ -1,36 +1,35 @@
 package org.georchestra.security;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.http.Header;
-import org.apache.http.message.BasicHeader;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+
 public class TrustedProxyRequestHeaderProvider extends HeaderProvider {
 
     private static final Log logger = LogFactory.getLog(ProxyTrustAnotherProxy.class.getPackage().getName());
 
-    @SuppressWarnings("unchecked")
     @Override
-    protected Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
-        if (session.getAttribute("pre-auth") != null) {
-            Collection<Header> headers = new ArrayList<Header>();
-            Enumeration<String> e = originalRequest.getHeaderNames();
-            while (e.hasMoreElements()) {
-                String headerName = e.nextElement();
-                originalRequest.getHeader(headerName);
-                logger.debug("Adding header: " + headerName + ", value: " + originalRequest.getHeader(headerName));
-                headers.add(new BasicHeader(headerName, originalRequest.getHeader(headerName)));
-            }
-            return headers;
-        } else {
+    public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest) {
+        if (isPreAuthorized(session)) {
             return Collections.emptyList();
         }
+        Collection<Header> headers = new ArrayList<Header>();
+        Enumeration<String> e = originalRequest.getHeaderNames();
+        while (e.hasMoreElements()) {
+            String headerName = e.nextElement();
+            originalRequest.getHeader(headerName);
+            logger.debug("Adding header: " + headerName + ", value: " + originalRequest.getHeader(headerName));
+            headers.add(new BasicHeader(headerName, originalRequest.getHeader(headerName)));
+        }
+        return headers;
     }
 }

--- a/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
@@ -12,6 +12,10 @@ import javax.servlet.http.HttpSession;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 
+/**
+ * 
+ * @see ProxyTrustAnotherProxy
+ */
 public class TrustedProxyRequestHeaderProvider extends HeaderProvider {
 
     @PostConstruct
@@ -22,7 +26,7 @@ public class TrustedProxyRequestHeaderProvider extends HeaderProvider {
     @Override
     public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
             String targetServiceName) {
-        if (!isPreAuthorized(session)) {
+        if (!isPreAuthorized(originalRequest)) {
             return Collections.emptyList();
         }
         Collection<Header> headers = new ArrayList<Header>();

--- a/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
+++ b/security-proxy/src/main/java/org/georchestra/security/TrustedProxyRequestHeaderProvider.java
@@ -5,22 +5,24 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 
+import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 
 public class TrustedProxyRequestHeaderProvider extends HeaderProvider {
 
-    private static final Log logger = LogFactory.getLog(ProxyTrustAnotherProxy.class.getPackage().getName());
+    @PostConstruct
+    public void init() {
+        logger.info("Will forward incoming headers for pre-authorized requests from trusted proxies");
+    }
 
     @Override
     public Collection<Header> getCustomRequestHeaders(HttpSession session, HttpServletRequest originalRequest,
             String targetServiceName) {
-        if (isPreAuthorized(session)) {
+        if (!isPreAuthorized(session)) {
             return Collections.emptyList();
         }
         Collection<Header> headers = new ArrayList<Header>();

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -83,11 +83,6 @@
                 <bean class="org.georchestra.security.LdapUserDetailsRequestHeaderProvider">
                     <constructor-arg index="0" ref="ldapUserSearch"/>
                     <constructor-arg index="1" value="${ldapOrgsRdn}"/>
-                    <constructor-arg index="2">
-                        <map>
-
-                        </map>
-                    </constructor-arg>
                 </bean>
             </list>
         </property>

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -81,8 +81,10 @@
                     <property name="trustedUsers" value="${trustedUsers:geoserver_privileged_user}"/>
                 </bean>
                 <bean class="org.georchestra.security.LdapUserDetailsRequestHeaderProvider">
-                    <constructor-arg index="0" ref="ldapUserSearch"/>
+                    <constructor-arg index="0" ref="contextSource" />
                     <constructor-arg index="1" value="${ldapOrgsRdn}"/>
+                    <constructor-arg index="2" value="${ldapUsersRdn}"/>
+                    <constructor-arg index="3" value="${userSearchFilter:(uid={0})}"/>
                 </bean>
             </list>
         </property>

--- a/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
@@ -1,5 +1,11 @@
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.IMP_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.IMP_USERNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.georchestra.security.HeaderNames.COOKIE_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,14 +48,14 @@ public class HeadersManagementStrategyTest {
 
         headerManagement.configureRequestHeaders(originalRequest, proxyRequest, false, null);
 
-        assertFalse(hasHeader("sec-username", proxyRequest));
-        assertFalse(hasHeader("sec-roles", proxyRequest));
+        assertFalse(hasHeader(SEC_USERNAME, proxyRequest));
+        assertFalse(hasHeader(SEC_ROLES, proxyRequest));
 
         assertFalse(hasHeader("imp-username", proxyRequest));
         assertFalse(hasHeader("imp-roles", proxyRequest));
 
-        assertFalse(hasHeader("sec-org", proxyRequest));
-        assertFalse(hasHeader("sec-email", proxyRequest));
+        assertFalse(hasHeader(SEC_ORG, proxyRequest));
+        assertFalse(hasHeader(SEC_EMAIL, proxyRequest));
         assertFalse(hasHeader("sEc-capitalize", proxyRequest));
         assertFalse(hasHeader("sec-capitalize", proxyRequest));
 
@@ -59,13 +65,13 @@ public class HeadersManagementStrategyTest {
     private MockHttpServletRequest createTestRequest() {
         MockHttpServletRequest originalRequest = new MockHttpServletRequest("get", "http://georchestra.org/geonetwork");
         originalRequest.setRemoteHost("someserver.com");
-        originalRequest.addHeader("sec-username", "jeichar");
-        originalRequest.addHeader("sec-roles", "ROLE_GN_ADMIN");
-        originalRequest.addHeader("imp-username", "imp_user");
-        originalRequest.addHeader("imp-roles", "ROLE_GN_IMP");
+        originalRequest.addHeader(SEC_USERNAME, "jeichar");
+        originalRequest.addHeader(SEC_ROLES, "ROLE_GN_ADMIN");
+        originalRequest.addHeader(IMP_USERNAME, "imp_user");
+        originalRequest.addHeader(IMP_ROLES, "ROLE_GN_IMP");
         originalRequest.addHeader("other_header", "value");
-        originalRequest.addHeader("sec-org", "value");
-        originalRequest.addHeader("sec-email", "value");
+        originalRequest.addHeader(SEC_ORG, "value");
+        originalRequest.addHeader(SEC_EMAIL, "value");
         originalRequest.addHeader("sEc-capitalize", "value");
         return originalRequest;
     }
@@ -85,19 +91,19 @@ public class HeadersManagementStrategyTest {
         Authentication auth = new UsernamePasswordAuthenticationToken("jeichar", "random");
         SecurityContextHolder.getContext().setAuthentication(auth);
         headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true, null);
-        assertTrue(hasHeader("sec-username", proxyRequest));
-        assertEquals(proxyRequest.getHeaders("sec-username")[0].getValue(), "jeichar");
+        assertTrue(hasHeader(SEC_USERNAME, proxyRequest));
+        assertEquals(proxyRequest.getHeaders(SEC_USERNAME)[0].getValue(), "jeichar");
 
         proxyRequest = new HttpGet("http://sdi.georchestra.org/geonetwork");
         originalRequest = createTestRequest();
         headerManagement.configureRequestHeaders(originalRequest, proxyRequest, false, null);
-        assertFalse(hasHeader("sec-username", proxyRequest));
+        assertFalse(hasHeader(SEC_USERNAME, proxyRequest));
 
         proxyRequest = new HttpGet("http://sdi.georchestra.org/geonetwork");
         originalRequest = createTestRequest();
         headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true, null);
-        assertTrue(hasHeader("sec-username", proxyRequest));
-        assertEquals(proxyRequest.getHeaders("sec-username")[0].getValue(), "jeichar");
+        assertTrue(hasHeader(SEC_USERNAME, proxyRequest));
+        assertEquals(proxyRequest.getHeaders(SEC_USERNAME)[0].getValue(), "jeichar");
     }
 
     @Test

--- a/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/HeadersManagementStrategyTest.java
@@ -40,7 +40,7 @@ public class HeadersManagementStrategyTest {
         HttpRequestBase proxyRequest = new HttpGet("http://localhost/geonetwork");
         MockHttpServletRequest originalRequest = createTestRequest();
 
-        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, false);
+        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, false, null);
 
         assertFalse(hasHeader("sec-username", proxyRequest));
         assertFalse(hasHeader("sec-roles", proxyRequest));
@@ -84,18 +84,18 @@ public class HeadersManagementStrategyTest {
         MockHttpServletRequest originalRequest = createTestRequest();
         Authentication auth = new UsernamePasswordAuthenticationToken("jeichar", "random");
         SecurityContextHolder.getContext().setAuthentication(auth);
-        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true);
+        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true, null);
         assertTrue(hasHeader("sec-username", proxyRequest));
         assertEquals(proxyRequest.getHeaders("sec-username")[0].getValue(), "jeichar");
 
         proxyRequest = new HttpGet("http://sdi.georchestra.org/geonetwork");
         originalRequest = createTestRequest();
-        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, false);
+        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, false, null);
         assertFalse(hasHeader("sec-username", proxyRequest));
 
         proxyRequest = new HttpGet("http://sdi.georchestra.org/geonetwork");
         originalRequest = createTestRequest();
-        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true);
+        headerManagement.configureRequestHeaders(originalRequest, proxyRequest, true, null);
         assertTrue(hasHeader("sec-username", proxyRequest));
         assertEquals(proxyRequest.getHeaders("sec-username")[0].getValue(), "jeichar");
     }

--- a/security-proxy/src/test/java/org/georchestra/security/ImpersonateUserRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ImpersonateUserRequestHeaderProviderTest.java
@@ -1,5 +1,15 @@
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.IMP_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.IMP_USERNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.apache.http.Header;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -7,19 +17,13 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-
 public class ImpersonateUserRequestHeaderProviderTest {
 
     @Test
     public void testGetCustomRequestHeadersUntrustedUser() throws Exception {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader(HeaderNames.IMP_USERNAME, "imp-user");
-        request.addHeader(HeaderNames.IMP_ROLES, "ROLE_IMP");
+        request.addHeader(IMP_USERNAME, "imp-user");
+        request.addHeader(IMP_ROLES, "ROLE_IMP");
 
         // Reset auth
         SecurityContextHolder.getContext().setAuthentication(null);
@@ -38,8 +42,8 @@ public class ImpersonateUserRequestHeaderProviderTest {
     @Test
     public void testGetCustomRequestHeadersTrustedUser() throws Exception {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader(HeaderNames.IMP_USERNAME, "imp-user");
-        request.addHeader(HeaderNames.IMP_ROLES, "ROLE_IMP");
+        request.addHeader(IMP_USERNAME, "imp-user");
+        request.addHeader(IMP_ROLES, "ROLE_IMP");
 
         final ImpersonateUserRequestHeaderProvider provider = new ImpersonateUserRequestHeaderProvider();
         List<String> trustedUsers = new ArrayList<String>();
@@ -51,8 +55,8 @@ public class ImpersonateUserRequestHeaderProviderTest {
         SecurityContextHolder.getContext().setAuthentication(auth);
         final Collection<Header> customRequestHeaders = provider.getCustomRequestHeaders(null, request, null);
         assertEquals(2, customRequestHeaders.size());
-        assertContains(customRequestHeaders, HeaderNames.SEC_USERNAME, "imp-user");
-        assertContains(customRequestHeaders, HeaderNames.SEC_ROLES, "ROLE_IMP");
+        assertContains(customRequestHeaders, SEC_USERNAME, "imp-user");
+        assertContains(customRequestHeaders, SEC_ROLES, "ROLE_IMP");
     }
 
     private void assertContains(Collection<Header> customRequestHeaders, String headerName,

--- a/security-proxy/src/test/java/org/georchestra/security/ImpersonateUserRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ImpersonateUserRequestHeaderProviderTest.java
@@ -28,11 +28,11 @@ public class ImpersonateUserRequestHeaderProviderTest {
         List<String> trustedUsers = new ArrayList<String>();
         trustedUsers.add("jeichar");
         provider.setTrustedUsers(trustedUsers);
-        assertEquals(0, provider.getCustomRequestHeaders(null, request).size());
+        assertEquals(0, provider.getCustomRequestHeaders(null, request, null).size());
 
         Authentication auth = new UsernamePasswordAuthenticationToken("randomUser", "random");
         SecurityContextHolder.getContext().setAuthentication(auth);
-        assertEquals(0, provider.getCustomRequestHeaders(null, request).size());
+        assertEquals(0, provider.getCustomRequestHeaders(null, request, null).size());
     }
 
     @Test
@@ -45,11 +45,11 @@ public class ImpersonateUserRequestHeaderProviderTest {
         List<String> trustedUsers = new ArrayList<String>();
         trustedUsers.add("jeichar");
         provider.setTrustedUsers(trustedUsers);
-        assertEquals(0, provider.getCustomRequestHeaders(null, request).size());
+        assertEquals(0, provider.getCustomRequestHeaders(null, request, null).size());
 
         Authentication auth = new UsernamePasswordAuthenticationToken("jeichar", "random");
         SecurityContextHolder.getContext().setAuthentication(auth);
-        final Collection<Header> customRequestHeaders = provider.getCustomRequestHeaders(null, request);
+        final Collection<Header> customRequestHeaders = provider.getCustomRequestHeaders(null, request, null);
         assertEquals(2, customRequestHeaders.size());
         assertContains(customRequestHeaders, HeaderNames.SEC_USERNAME, "imp-user");
         assertContains(customRequestHeaders, HeaderNames.SEC_ROLES, "ROLE_IMP");

--- a/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
@@ -87,7 +87,7 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         username = "testUser";
         userSearch = mock(FilterBasedLdapUserSearch.class);
         ldapTemplate = mock(LdapTemplate.class);
-        ldapProvider = new LdapUserDetailsRequestHeaderProvider(userSearch, orgSearchBaseDN);
+        ldapProvider = new LdapUserDetailsRequestHeaderProvider(() -> userSearch, orgSearchBaseDN);
         ldapProvider.ldapTemplate = ldapTemplate;
         session = new MockHttpSession();
 

--- a/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
@@ -18,8 +18,12 @@
  */
 package org.georchestra.security;
 
-import static org.georchestra.commons.security.SecurityHeaders.*;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_FIRSTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
 import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_TEL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -50,6 +54,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -281,9 +286,8 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         final String encodedLastName = Base64.getEncoder().encodeToString(lastName.getBytes(StandardCharsets.UTF_8));
         final String expectedGivenName = "{base64}" + encodedGivenName;
         final String expectedLastName = "{base64}" + encodedLastName;
-
-        String decodedGivenName = new String(Base64.getDecoder().decode(encodedGivenName), StandardCharsets.UTF_8);
-        assertEquals(givenName, decodedGivenName);
+        assertEquals(expectedGivenName, SecurityHeaders.encodeBase64(givenName));
+        assertEquals(expectedLastName, SecurityHeaders.encodeBase64(lastName));
 
         Map<String, String> ldapContext = ImmutableMap.of(//
                 "givenName", givenName, //

--- a/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
@@ -18,11 +18,10 @@
  */
 package org.georchestra.security;
 
-import static org.georchestra.security.HeaderNames.SEC_ORG;
-import static org.georchestra.security.HeaderNames.SEC_ORGNAME;
+import static org.georchestra.commons.security.SecurityHeaders.*;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORGNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -98,19 +97,18 @@ public class LdapUserDetailsRequestHeaderProviderTest {
     @Test
     public void testLoadConfig_DefaultMappings() {
         Properties props = new Properties();
-        props.setProperty("sec-email", "mail");
-        props.setProperty("sec-firstname", "givenName");
+        props.setProperty(SEC_EMAIL, "mail");
+        props.setProperty(SEC_FIRSTNAME, "givenName");
         ldapProvider.loadConfig(props);
-        assertEquals(ImmutableMap.of("sec-email", "mail", "sec-firstname", "givenName"),
-                ldapProvider.getDefaultMappings());
+        assertEquals(ImmutableMap.of(SEC_EMAIL, "mail", SEC_FIRSTNAME, "givenName"), ldapProvider.getDefaultMappings());
         assertTrue(ldapProvider.perServiceMappings.isEmpty());
     }
 
     @Test
     public void testLoadConfig_ServiceMappings() {
         Properties props = new Properties();
-        props.setProperty("sec-email", "mail");
-        props.setProperty("sec-firstname", "givenName");
+        props.setProperty(SEC_EMAIL, "mail");
+        props.setProperty(SEC_FIRSTNAME, "givenName");
 
         props.setProperty("analytics.sec-lastname", "sn");
         props.setProperty("analytics.sec-tel", "telephoneNumber");
@@ -120,8 +118,7 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         props.setProperty("console.sec-lastname", "sn");
 
         ldapProvider.loadConfig(props);
-        assertEquals(ImmutableMap.of("sec-email", "mail", "sec-firstname", "givenName"),
-                ldapProvider.getDefaultMappings());
+        assertEquals(ImmutableMap.of(SEC_EMAIL, "mail", SEC_FIRSTNAME, "givenName"), ldapProvider.getDefaultMappings());
         assertEquals(2, ldapProvider.perServiceMappings.size());
 
         assertEquals(ldapProvider.getDefaultMappings(), ldapProvider.getServiceMappings("mapfishapp"));
@@ -130,15 +127,15 @@ public class LdapUserDetailsRequestHeaderProviderTest {
 
         Map<String, String> analytics = ldapProvider.getServiceMappings("analytics");
         expected = new HashMap<>(ldapProvider.getDefaultMappings());
-        expected.put("sec-lastname", "sn");
-        expected.put("sec-tel", "telephoneNumber");
+        expected.put(SEC_LASTNAME, "sn");
+        expected.put(SEC_TEL, "telephoneNumber");
         assertEquals(expected, analytics);
 
         Map<String, String> console = ldapProvider.getServiceMappings("console");
         expected = new HashMap<>(ldapProvider.getDefaultMappings());
-        expected.put("sec-email", "mail-override");
-        expected.put("sec-firstname", "givenName-override");
-        expected.put("sec-lastname", "sn");
+        expected.put(SEC_EMAIL, "mail-override");
+        expected.put(SEC_FIRSTNAME, "givenName-override");
+        expected.put(SEC_LASTNAME, "sn");
         assertEquals(expected, console);
     }
 
@@ -206,8 +203,8 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         setupMockLdapContext("test-org", "Test Org Name", ldapContext);
 
         Properties props = new Properties();
-        props.setProperty("sec-email", "mail");
-        props.setProperty("sec-firstname", "givenName");
+        props.setProperty(SEC_EMAIL, "mail");
+        props.setProperty(SEC_FIRSTNAME, "givenName");
 
         props.setProperty("analytics.sec-email", "mail-override");
         props.setProperty("analytics.sec-lastname", "sn");
@@ -224,8 +221,8 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         Map<String, String> expected = new HashMap<>();
         expected.put(SEC_ORG, "test-org");
         expected.put(SEC_ORGNAME, "Test Org Name");
-        expected.put("sec-email", ldapContext.get("mail"));
-        expected.put("sec-firstname", ldapContext.get("givenName"));
+        expected.put(SEC_EMAIL, ldapContext.get("mail"));
+        expected.put(SEC_FIRSTNAME, ldapContext.get("givenName"));
 
         assertEquals(expected.keySet(), actual.keySet());
         assertEquals("expected default headers on non service-name match", expected, actual);
@@ -239,8 +236,8 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         setupMockLdapContext("test-org", "Test Org Name", ldapContext);
 
         Properties props = new Properties();
-        props.setProperty("sec-email", "mail");
-        props.setProperty("sec-firstname", "givenName");
+        props.setProperty(SEC_EMAIL, "mail");
+        props.setProperty(SEC_FIRSTNAME, "givenName");
 
         props.setProperty("analytics.sec-email", "mail-override");
         props.setProperty("analytics.sec-lastname", "sn");
@@ -257,12 +254,12 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         Map<String, String> expected = new HashMap<>();
         expected.put(SEC_ORG, "test-org");
         expected.put(SEC_ORGNAME, "Test Org Name");
-        expected.put("sec-firstname", ldapContext.get("givenName"));
+        expected.put(SEC_FIRSTNAME, ldapContext.get("givenName"));
         // overridden per-service header
-        expected.put("sec-email", ldapContext.get("mail-override"));
+        expected.put(SEC_EMAIL, ldapContext.get("mail-override"));
         // per-service headers not present in default headers
-        expected.put("sec-lastname", ldapContext.get("sn"));
-        expected.put("sec-tel", ldapContext.get("telephoneNumber"));
+        expected.put(SEC_LASTNAME, ldapContext.get("sn"));
+        expected.put(SEC_TEL, ldapContext.get("telephoneNumber"));
 
         assertEquals(expected.keySet(), actual.keySet());
         assertEquals(expected, actual);
@@ -296,9 +293,9 @@ public class LdapUserDetailsRequestHeaderProviderTest {
         setupMockLdapContext("test-org", "Test Org Name", ldapContext);
 
         Properties props = new Properties();
-        props.setProperty("sec-firstname", "base64:givenName");
-        props.setProperty("sec-lastname", "base64:sn");
-        props.setProperty("sec-email", "mail");
+        props.setProperty(SEC_FIRSTNAME, "base64:givenName");
+        props.setProperty(SEC_LASTNAME, "base64:sn");
+        props.setProperty(SEC_EMAIL, "mail");
 
         this.ldapProvider.loadConfig(props);
 
@@ -308,9 +305,9 @@ public class LdapUserDetailsRequestHeaderProviderTest {
                 h -> assertEquals("header shall have just one value: " + h.toString(), 1, h.getElements().length));
 
         Map<String, String> actual = headers.stream().collect(Collectors.toMap(Header::getName, Header::getValue));
-        assertEquals(expectedGivenName, actual.get("sec-firstname"));
-        assertEquals(expectedLastName, actual.get("sec-lastname"));
-        assertEquals("test@mock.com", actual.get("sec-email"));
+        assertEquals(expectedGivenName, actual.get(SEC_FIRSTNAME));
+        assertEquals(expectedLastName, actual.get(SEC_LASTNAME));
+        assertEquals("test@mock.com", actual.get(SEC_EMAIL));
     }
 
     private void setupMockLdapContext(String org, String orgName, Map<String, String> ldapContext) throws Exception {

--- a/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/LdapUserDetailsRequestHeaderProviderTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.security;
+
+import static org.georchestra.security.HeaderNames.SEC_ORG;
+import static org.georchestra.security.HeaderNames.SEC_ORGNAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
+
+import com.google.common.collect.ImmutableMap;
+
+public class LdapUserDetailsRequestHeaderProviderTest {
+
+    private LdapUserDetailsRequestHeaderProvider ldapProvider;
+
+    private FilterBasedLdapUserSearch userSearch;
+    private LdapTemplate ldapTemplate;
+
+    private final String orgSearchBaseDN = "ou=orgs";
+
+    private String username;
+
+    private HttpSession session;
+    private final HttpServletRequest request = new MockHttpServletRequest();
+
+    public @Before void before() {
+        username = "testUser";
+        userSearch = mock(FilterBasedLdapUserSearch.class);
+        ldapTemplate = mock(LdapTemplate.class);
+        ldapProvider = new LdapUserDetailsRequestHeaderProvider(userSearch, orgSearchBaseDN);
+        ldapProvider.ldapTemplate = ldapTemplate;
+        session = new MockHttpSession();
+
+        Authentication auth = new TestingAuthenticationToken(username, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    public @After void after() {
+
+    }
+
+    @Test
+    public void testLoadConfig_DefaultMappings() {
+        Properties props = new Properties();
+        props.setProperty("sec-email", "mail");
+        props.setProperty("sec-firstname", "givenName");
+        ldapProvider.loadConfig(props);
+        assertEquals(ImmutableMap.of("sec-email", "mail", "sec-firstname", "givenName"),
+                ldapProvider.getDefaultMappings());
+        assertTrue(ldapProvider.perServiceMappings.isEmpty());
+    }
+
+    @Test
+    public void testLoadConfig_ServiceMappings() {
+        Properties props = new Properties();
+        props.setProperty("sec-email", "mail");
+        props.setProperty("sec-firstname", "givenName");
+
+        props.setProperty("analytics.sec-lastname", "sn");
+        props.setProperty("analytics.sec-tel", "telephoneNumber");
+
+        props.setProperty("console.sec-email", "mail-override");
+        props.setProperty("console.sec-firstname", "givenName-override");
+        props.setProperty("console.sec-lastname", "sn");
+
+        ldapProvider.loadConfig(props);
+        assertEquals(ImmutableMap.of("sec-email", "mail", "sec-firstname", "givenName"),
+                ldapProvider.getDefaultMappings());
+        assertEquals(2, ldapProvider.perServiceMappings.size());
+
+        assertEquals(ldapProvider.getDefaultMappings(), ldapProvider.getServiceMappings("mapfishapp"));
+
+        Map<String, String> expected;
+
+        Map<String, String> analytics = ldapProvider.getServiceMappings("analytics");
+        expected = new HashMap<>(ldapProvider.getDefaultMappings());
+        expected.put("sec-lastname", "sn");
+        expected.put("sec-tel", "telephoneNumber");
+        assertEquals(expected, analytics);
+
+        Map<String, String> console = ldapProvider.getServiceMappings("console");
+        expected = new HashMap<>(ldapProvider.getDefaultMappings());
+        expected.put("sec-email", "mail-override");
+        expected.put("sec-firstname", "givenName-override");
+        expected.put("sec-lastname", "sn");
+        assertEquals(expected, console);
+    }
+
+    @Test
+    public void testCachedHeaders_NoServiceName() {
+        String service = null;
+        Optional<Collection<Header>> cached = this.ldapProvider.getCachedHeaders(session, service);
+        assertFalse(cached.isPresent());
+        Collection<Header> headers = Collections.singletonList(new BasicHeader("test", "value"));
+        this.ldapProvider.setCachedHeaders(session, headers, service);
+        cached = this.ldapProvider.getCachedHeaders(session, service);
+        assertTrue(cached.isPresent());
+        assertNotSame(headers, cached.get());
+        assertEquals(headers, cached.get());
+    }
+
+    @Test
+    public void testCachedHeaders_ServiceName() {
+
+        final String service1 = "analytics";
+        final String service2 = "console";
+        Collection<Header> headers1 = Collections.singletonList(new BasicHeader("test", "analytics-value"));
+        Collection<Header> headers2 = Collections.singletonList(new BasicHeader("test", "console-value"));
+
+        Optional<Collection<Header>> cached1 = this.ldapProvider.getCachedHeaders(session, service1);
+        Optional<Collection<Header>> cached2 = this.ldapProvider.getCachedHeaders(session, service2);
+
+        assertFalse(cached1.isPresent());
+        assertFalse(cached2.isPresent());
+
+        this.ldapProvider.setCachedHeaders(session, headers1, service1);
+        this.ldapProvider.setCachedHeaders(session, headers2, service2);
+
+        cached1 = this.ldapProvider.getCachedHeaders(session, service1);
+        cached2 = this.ldapProvider.getCachedHeaders(session, service2);
+
+        assertTrue(cached1.isPresent());
+        assertTrue(cached2.isPresent());
+
+        assertNotSame(headers1, cached1.get());
+        assertNotSame(headers2, cached2.get());
+
+        assertEquals(headers1, cached1.get());
+        assertEquals(headers2, cached2.get());
+    }
+
+    @Test
+    public void testGetCustomRequestHeaders_SetsOrgAndOrgNameStandardHeaders() throws Exception {
+        setupMockLdapContext("test-org", "Test Org Name", null);
+
+        String targetServiceName = null;
+        Collection<Header> headers = ldapProvider.getCustomRequestHeaders(session, request, targetServiceName);
+        headers.forEach(
+                h -> assertEquals("header has more than one value: " + h.toString(), 1, h.getElements().length));
+
+        Map<String, String> actual = headers.stream().collect(Collectors.toMap(Header::getName, Header::getValue));
+        assertEquals(ImmutableMap.of(SEC_ORG, "test-org", SEC_ORGNAME, "Test Org Name"), actual);
+    }
+
+    @Test
+    public void testGetCustomRequestHeaders_defaultHeaders() throws Exception {
+        Map<String, String> ldapContext = ImmutableMap.of("mail", "test@mock.com", "givenName", "Mockfirsname",
+                "mail-override", "test@mock.override.com", "sn", "Mocklastname", "telephoneNumber", "123456");
+
+        setupMockLdapContext("test-org", "Test Org Name", ldapContext);
+
+        Properties props = new Properties();
+        props.setProperty("sec-email", "mail");
+        props.setProperty("sec-firstname", "givenName");
+
+        props.setProperty("analytics.sec-email", "mail-override");
+        props.setProperty("analytics.sec-lastname", "sn");
+        props.setProperty("analytics.sec-tel", "telephoneNumber");
+        this.ldapProvider.loadConfig(props);
+
+        String targetServiceName = null;
+        Collection<Header> headers = ldapProvider.getCustomRequestHeaders(session, request, targetServiceName);
+        headers.forEach(
+                h -> assertEquals("header shall have just one value: " + h.toString(), 1, h.getElements().length));
+
+        Map<String, String> actual = headers.stream().collect(Collectors.toMap(Header::getName, Header::getValue));
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put(SEC_ORG, "test-org");
+        expected.put(SEC_ORGNAME, "Test Org Name");
+        expected.put("sec-email", ldapContext.get("mail"));
+        expected.put("sec-firstname", ldapContext.get("givenName"));
+
+        assertEquals(expected.keySet(), actual.keySet());
+        assertEquals("expected default headers on non service-name match", expected, actual);
+    }
+
+    @Test
+    public void testGetCustomRequestHeaders_ServiceSpecificHeaders() throws Exception {
+        Map<String, String> ldapContext = ImmutableMap.of("mail", "test@mock.com", "givenName", "Mockfirsname",
+                "mail-override", "test@mock.override.com", "sn", "Mocklastname", "telephoneNumber", "123456");
+
+        setupMockLdapContext("test-org", "Test Org Name", ldapContext);
+
+        Properties props = new Properties();
+        props.setProperty("sec-email", "mail");
+        props.setProperty("sec-firstname", "givenName");
+
+        props.setProperty("analytics.sec-email", "mail-override");
+        props.setProperty("analytics.sec-lastname", "sn");
+        props.setProperty("analytics.sec-tel", "telephoneNumber");
+        this.ldapProvider.loadConfig(props);
+
+        String targetServiceName = "analytics";
+        Collection<Header> headers = ldapProvider.getCustomRequestHeaders(session, request, targetServiceName);
+        headers.forEach(
+                h -> assertEquals("header shall have just one value: " + h.toString(), 1, h.getElements().length));
+
+        Map<String, String> actual = headers.stream().collect(Collectors.toMap(Header::getName, Header::getValue));
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put(SEC_ORG, "test-org");
+        expected.put(SEC_ORGNAME, "Test Org Name");
+        expected.put("sec-firstname", ldapContext.get("givenName"));
+        // overridden per-service header
+        expected.put("sec-email", ldapContext.get("mail-override"));
+        // per-service headers not present in default headers
+        expected.put("sec-lastname", ldapContext.get("sn"));
+        expected.put("sec-tel", ldapContext.get("telephoneNumber"));
+
+        assertEquals(expected.keySet(), actual.keySet());
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Headers mappings can be defined with an encoding scheme, like {@code base64},
+     * for example: {@code sec-firstname=base64:givenName}, the resulting value will
+     * be the encoding-prefixed encoded value, for example: {@code "{base64}<encoded
+     * string>"}
+     * <p>
+     */
+    @Test
+    public void testGetCustomRequestHeaders_HeaderValueEncoding_Base64() throws Exception {
+        final String givenName = "ガブリエル";
+        final String lastName = "ロルダン";
+
+        final String encodedGivenName = Base64.getEncoder().encodeToString(givenName.getBytes(StandardCharsets.UTF_8));
+        final String encodedLastName = Base64.getEncoder().encodeToString(lastName.getBytes(StandardCharsets.UTF_8));
+        final String expectedGivenName = "{base64}" + encodedGivenName;
+        final String expectedLastName = "{base64}" + encodedLastName;
+
+        String decodedGivenName = new String(Base64.getDecoder().decode(encodedGivenName), StandardCharsets.UTF_8);
+        assertEquals(givenName, decodedGivenName);
+
+        Map<String, String> ldapContext = ImmutableMap.of(//
+                "givenName", givenName, //
+                "sn", lastName, //
+                "mail", "test@mock.com", "mail-override", "test@mock.override.com", "telephoneNumber", "123456");
+
+        setupMockLdapContext("test-org", "Test Org Name", ldapContext);
+
+        Properties props = new Properties();
+        props.setProperty("sec-firstname", "base64:givenName");
+        props.setProperty("sec-lastname", "base64:sn");
+        props.setProperty("sec-email", "mail");
+
+        this.ldapProvider.loadConfig(props);
+
+        String targetServiceName = "analytics";
+        Collection<Header> headers = ldapProvider.getCustomRequestHeaders(session, request, targetServiceName);
+        headers.forEach(
+                h -> assertEquals("header shall have just one value: " + h.toString(), 1, h.getElements().length));
+
+        Map<String, String> actual = headers.stream().collect(Collectors.toMap(Header::getName, Header::getValue));
+        assertEquals(expectedGivenName, actual.get("sec-firstname"));
+        assertEquals(expectedLastName, actual.get("sec-lastname"));
+        assertEquals("test@mock.com", actual.get("sec-email"));
+    }
+
+    private void setupMockLdapContext(String org, String orgName, Map<String, String> ldapContext) throws Exception {
+
+        Attribute memberOf = mock(Attribute.class);
+        NamingEnumeration<Object> orgs = namingEnumeration("cn=test-org,ou=orgs");// ([^=,]+)=([^=,]+),ou=orgs.*
+        doReturn(orgs).when(memberOf).getAll();
+        DirContextOperations ctx = mock(DirContextOperations.class);
+        when(ctx.getStringAttribute(eq("o"))).thenReturn(orgName);
+        when(ldapTemplate.lookupContext(eq("cn=" + org + ",ou=orgs"))).thenReturn(ctx);
+
+        Attributes userAttributes = mock(Attributes.class);
+        when(userAttributes.get(eq("memberOf"))).thenReturn(memberOf);
+
+        DirContextOperations userProperties = mock(DirContextOperations.class);
+        when(userProperties.getAttributes()).thenReturn(userAttributes);
+
+        when(userSearch.searchForUser(eq(username))).thenReturn(userProperties);
+
+        if (ldapContext != null) {
+            for (Map.Entry<String, String> e : ldapContext.entrySet()) {
+                String name = e.getKey();
+                String value = e.getValue();
+
+                NamingEnumeration<?> propEnum = namingEnumeration(value);
+                Attribute propAttribute = mock(Attribute.class);
+                doReturn(propEnum).when(propAttribute).getAll();
+                when(userAttributes.get(eq(name))).thenReturn(propAttribute);
+            }
+        }
+    }
+
+    private NamingEnumeration<Object> namingEnumeration(Object... values) {
+        return new NamingEnumeration<Object>() {
+            final Iterator<Object> it = Arrays.asList(values).iterator();
+
+            public @Override boolean hasMoreElements() {
+                return it.hasNext();
+            }
+
+            public @Override Object nextElement() {
+                return it.next();
+            }
+
+            public @Override Object next() throws NamingException {
+                return it.next();
+            }
+
+            public @Override boolean hasMore() throws NamingException {
+                return hasMoreElements();
+            }
+
+            public @Override void close() throws NamingException {
+            }
+        };
+    }
+}

--- a/security-proxy/src/test/java/org/georchestra/security/PermissionsTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/PermissionsTest.java
@@ -9,9 +9,11 @@ import java.io.InputStream;
 import java.net.URL;
 
 import org.georchestra.security.permissions.Permissions;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
 
+@Ignore("java.net.UnknownHostException: sdi.georchestra.org")
 public class PermissionsTest {
 
     private Permissions load(String permissionsFile) throws IOException {

--- a/security-proxy/src/test/java/org/georchestra/security/SecurityRequestHeaderFilterTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/SecurityRequestHeaderFilterTest.java
@@ -1,12 +1,16 @@
 package org.georchestra.security;
 
+import static org.georchestra.commons.security.SecurityHeaders.IMP_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.IMP_USERNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Jesse on 4/24/2014.
@@ -25,10 +29,10 @@ public class SecurityRequestHeaderFilterTest {
     private void assertUntrustworthyServerFiltering(SecurityRequestHeaderFilter filter,
             MockHttpServletRequest untrustWorthyServer, HttpRequestBase proxyRequest) {
         assertFalse(filter.filter("some-random-header", untrustWorthyServer, proxyRequest));
-        assertTrue(filter.filter("sec-username", untrustWorthyServer, proxyRequest));
-        assertTrue(filter.filter("sec-roles", untrustWorthyServer, proxyRequest));
-        assertTrue(filter.filter("imp-username", untrustWorthyServer, proxyRequest));
-        assertTrue(filter.filter("imp-roles", untrustWorthyServer, proxyRequest));
+        assertTrue(filter.filter(SEC_USERNAME, untrustWorthyServer, proxyRequest));
+        assertTrue(filter.filter(SEC_ROLES, untrustWorthyServer, proxyRequest));
+        assertTrue(filter.filter(IMP_USERNAME, untrustWorthyServer, proxyRequest));
+        assertTrue(filter.filter(IMP_ROLES, untrustWorthyServer, proxyRequest));
     }
 
 }


### PR DESCRIPTION
## Add support for per-service header mappings

Enhancement to allow configuring request headers on a per-target service (proxified app) fashion.
`headers-mapping.properties` can now have, besides default header mappings, service-specific mappings.

For example, the following `headers-mapping.properties` file would set up `sec-email` for all services, and `sec-lastname` only for the `analytics` proxified application:

```
    sec-email=mail
    analytics.sec-lastname=sn
```    

## Add support to base64-encode header values
    
Allow header values to be defined as base64-encoded in header-mappings.properties, by appending the `base64:` prefix to  the LDAP property name.
    
For example, a mapping of:
    
    sec-firstname=base64:givenName
    
Will result in a value of:
    
    {base64}<base64 encoded string>

## Move security header names to commons' SecurityHeaders
    
Introduce commons' `org.georchestra.commons.security.SecurityHeaders`
holding the common request header names used in security-proxy.
    
Introduce a `SecurityHeaders.decode(String):String` utility method and
change all calls to `HttpServletRequest.getHeader(String)` to
`SecurityHeaders.decode(request.getHeader(...))`, to account for the
 fact that headers could come encoded to preserve non ISO-8869-1
 characters, as defined in security-proxy's `headers-mapping.properties`
 (for example, `sec-username=base64:givenName` instead of just
`sec-username=givenName`).
