### PR TITLE
datafeeder-ui - serves the index.html file on dynamic endpoints

### DIFF
--- a/datafeeder-ui/pom.xml
+++ b/datafeeder-ui/pom.xml
@@ -12,10 +12,42 @@
   <artifactId>datafeeder-ui</artifactId>
   <packaging>war</packaging>
   <name>Data-Feeder (web ui)</name>
-
+  <dependencies>
+      <dependency>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-webmvc</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>2.8.0</version>
+      </dependency>
+      <dependency>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+          <version>3.0.1</version>
+          <scope>provided</scope>
+      </dependency>
+  </dependencies>
   <build>
       <finalName>import</finalName>
       <plugins>
+          <plugin>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-maven-plugin</artifactId>
+              <version>9.4.40.v20210413</version>
+              <configuration>
+                  <scanIntervalSeconds>10</scanIntervalSeconds>
+                  <webAppSourceDirectory>${project.build.directory}/import</webAppSourceDirectory>
+                  <webApp>
+                      <contextPath>/import</contextPath>
+                  </webApp>
+              </configuration>
+          </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-scm-plugin</artifactId>

--- a/datafeeder-ui/src/main/java/org/georchestra/datafeeder/ui/CatchAllDatasetsController.java
+++ b/datafeeder-ui/src/main/java/org/georchestra/datafeeder/ui/CatchAllDatasetsController.java
@@ -15,6 +15,8 @@ import java.io.OutputStream;
 public class CatchAllDatasetsController {
 
     private void serveIndexHtml(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setHeader("Content-Type", "text/html;charset=UTF-8");
+
         OutputStream os = response.getOutputStream();
         InputStream is = request.getServletContext().getResourceAsStream("/index.html");
         IOUtils.copy(is, os);

--- a/datafeeder-ui/src/main/java/org/georchestra/datafeeder/ui/CatchAllDatasetsController.java
+++ b/datafeeder-ui/src/main/java/org/georchestra/datafeeder/ui/CatchAllDatasetsController.java
@@ -10,7 +10,25 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-
+/**
+ * Controller which catch requests and returns the index.html file from the UI.
+ * Regardless of the URL which is queried, we need to return the index.html file,
+ * as the path will be interpreted client-side by the Javascript code.
+ * <p>
+ * This is mainly the reason why we need a webapp here, in the Docker image which derives from Nginx, the same
+ * feature is implemented using the following configuration:
+ * <p>
+ * ```
+ * location ~ "^/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}.*$" {
+ * alias /usr/share/nginx/html/index.html;
+ * add_header "content-type" "text/html";
+ * }
+ * ```
+ *
+ * Using spring may sound a bit overkill, and we could probably implement the same using a simpler webapp
+ * (e.g. using urlrewrite).
+ *
+ */
 @Controller
 public class CatchAllDatasetsController {
 
@@ -22,36 +40,78 @@ public class CatchAllDatasetsController {
         IOUtils.copy(is, os);
     }
 
+    /**
+     * Returns the index.html whenever a url with the `/[uuid]` format is requested.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}")
     public void singleUuid(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);
     }
 
+    /**
+     * Returns the index.html whenever a url with the `/[uuid]/validation` format is requested.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/validation")
     public void singleUuidValidation(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);
     }
 
+    /**
+     * Returns the index.html whenever a url with the `/[uuid]/step/[stepid]` format is requested.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/step/{stepid}")
     public void uuidStep(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);
     }
 
+    /**
+     * Returns the index.html whenever a url with the `/[uuid]/confirm` format is requested.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/confirm")
     public void uuidConfirm(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);
     }
 
+    /**
+     * Returns the index.html whenever a url with the `/[uuid]/publish` format is requested.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/publish")
     public void uuidPublish(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);
     }
 
+    /**
+     * Returns the index.html whenever a url with the `/[uuid]/publishok` format is requested.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/publishok")
     public void uuidPublishOk(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);
     }
 
+    /**
+     * Default entrypoint.
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @RequestMapping("/")
     public void defaultRoot(HttpServletRequest request, HttpServletResponse response) throws IOException {
         serveIndexHtml(request, response);

--- a/datafeeder-ui/src/main/java/org/georchestra/datafeeder/ui/CatchAllDatasetsController.java
+++ b/datafeeder-ui/src/main/java/org/georchestra/datafeeder/ui/CatchAllDatasetsController.java
@@ -1,0 +1,59 @@
+package org.georchestra.datafeeder.ui;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+
+@Controller
+public class CatchAllDatasetsController {
+
+    private void serveIndexHtml(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        OutputStream os = response.getOutputStream();
+        InputStream is = request.getServletContext().getResourceAsStream("/index.html");
+        IOUtils.copy(is, os);
+    }
+
+    @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}")
+    public void singleUuid(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+    @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/validation")
+    public void singleUuidValidation(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+    @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/step/{stepid}")
+    public void uuidStep(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+    @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/confirm")
+    public void uuidConfirm(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+    @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/publish")
+    public void uuidPublish(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+    @RequestMapping("/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}/publishok")
+    public void uuidPublishOk(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+    @RequestMapping("/")
+    public void defaultRoot(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        serveIndexHtml(request, response);
+    }
+
+
+}

--- a/datafeeder-ui/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/datafeeder-ui/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -1,0 +1,25 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+
+
+    <context:component-scan base-package="org.georchestra.datafeeder.ui" />
+    <mvc:annotation-driven />
+    <mvc:resources mapping="/*.svg" location="/" />
+    <mvc:resources mapping="/*.ttf" location="/" />
+    <mvc:resources mapping="/*.woff" location="/" />
+    <mvc:resources mapping="/*.ico" location="/" />
+    <mvc:resources mapping="/*.html" location="/" />
+    <mvc:resources mapping="/*.js" location="/" />
+    <mvc:resources mapping="/*.map" location="/" />
+    <mvc:resources mapping="/assets/**" location="/assets/" />
+
+</beans>

--- a/datafeeder-ui/src/main/webapp/WEB-INF/web.xml
+++ b/datafeeder-ui/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    metadata-complete="true">
  <display-name>import (datafeeder UI)</display-name>
+ <servlet>
+  <servlet-name>dispatcher</servlet-name>
+  <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+  <load-on-startup>1</load-on-startup>
+ </servlet>
+
+ <servlet-mapping>
+  <servlet-name>default</servlet-name>
+  <url-pattern>/index.html</url-pattern>
+ </servlet-mapping>
+
+ <servlet-mapping>
+   <servlet-name>dispatcher</servlet-name>
+   <url-pattern>/*</url-pattern>
+  </servlet-mapping>
+
+ <welcome-file-list>
+    <welcome-file>index.hml</welcome-file>
+ </welcome-file-list>
+
 </web-app>


### PR DESCRIPTION
the JS app will manage the actual requested path in some cases, e.g.  if
`/import/<uuid>/validation` is requested, then we have to return the
index.html content to the client, which will parse JS-side the url
fragment and display the according page.

The behaviour should be slightly the same as the suggested nginx
configuration from the geonetwork-ui repository, see:

https://github.com/georchestra/geonetwork-ui/blob/georchestra/nginx-default.conf

Note: I first tried to do it in a more "bare-metal servlet" approach,
thinking that the servlet-mapping's url-pattern parameters in the
web.xml would suffice, but it actually does not support regexps and is
more of a simple globbing. Then the "fastest" way to figure out how I
could send whatever I wanted to the client was to do spring-mvc, and
introducing spring as a dependency. Maybe a urlrewrite would have been
lighter.

Note2: I could have converted the project into a spring-boot one, but
the idea is still to finish with a webapp war that could be easily
deployed into an existing servlet container for non-dockerized approach.

Tests: mainly runtime-tested via `mvn clean package jetty:run` with
loads of curl.

Also tested in a simple jetty docker image, dropping the webapp into
`/var/lib/jetty/webapps`, replacing the import container by this new one, and I
was able to publish a dataset.
