### PR TITLE
[datafeeder] Externalize auth config of geoserver and geonetwork REST clients

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -96,9 +96,23 @@ public @Data class DataFeederConfigurationProperties {
     public static @Data class ExternalApiConfiguration {
         private URL apiUrl;
         private URL publicUrl;
+        private boolean logRequests;
+        private Auth auth = new Auth();
+    }
+
+    public static @Data class Auth {
+        public static enum AuthType {
+            none, basic, headers
+        }
+
+        private AuthType type = AuthType.none;
+        private BasicAuth basic;
+        private Map<String, String> headers = new HashMap<>();
+    }
+
+    public static @Data class BasicAuth {
         private String username;
         private String password;
-        private boolean logRequests;
     }
 
     public static @Data class BackendConfiguration {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
@@ -19,19 +19,23 @@
 package org.georchestra.datafeeder.service.geonetwork;
 
 import java.io.IOException;
-
-import org.springframework.http.HttpHeaders;
+import java.net.URL;
+import java.util.Map;
 
 import lombok.NonNull;
 
 public interface GeoNetworkClient {
 
-    void checkServiceAvailable(String url, HttpHeaders reqHeaders) throws IOException;
+    void setApiUrl(URL apiUrl);
 
-    GeoNetworkResponse putXmlRecord(String url, HttpHeaders additionalRequestHeaders, String metadataId,
-            String xmlRecord);
+    void setBasicAuth(String username, String password);
 
-    String getXmlRecord(@NonNull String baseUrl, @NonNull HttpHeaders additionalRequestHeaders,
-            @NonNull String recordId);
+    void setHeadersAuth(Map<String, String> authHeaders);
+
+    void checkServiceAvailable() throws IOException;
+
+    GeoNetworkResponse putXmlRecord(String metadataId, String xmlRecord);
+
+    String getXmlRecord(@NonNull String recordId);
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
@@ -18,11 +18,6 @@
  */
 package org.georchestra.datafeeder.service.geonetwork;
 
-import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
-import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
-import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
-import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,7 +26,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.ExternalApiConfiguration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -125,14 +119,9 @@ public class GeoNetworkRemoteService {
      * @return
      */
     public GeoNetworkResponse publish(@NonNull String metadataId, @NonNull Supplier<String> xmlRecordAsString) {
-
-        final URL apiBaseURL = this.config.getApiUrl();
-        final String url = apiBaseURL.toString();
         final String xmlRecord = xmlRecordAsString.get();
 
-        HttpHeaders reqHeaders = createAdditionalRequestHeaders();
-
-        GeoNetworkResponse response = client.putXmlRecord(url, reqHeaders, metadataId, xmlRecord);
+        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord);
 
         HttpStatus statusCode = response.getStatus();
         String statusText = response.getStatusText();
@@ -149,40 +138,11 @@ public class GeoNetworkRemoteService {
     }
 
     public void checkServiceAvailable() throws IOException {
-        final URL apiBaseURL = this.config.getApiUrl();
-        final String url = apiBaseURL.toString();
-
-        HttpHeaders reqHeaders = createAdditionalRequestHeaders();
-
-        client.checkServiceAvailable(url, reqHeaders);
+        client.checkServiceAvailable();
     }
 
     public String getRecordById(@NonNull String metadataId) {
-
-        final URL apiBaseURL = this.config.getApiUrl();
-        final String url = apiBaseURL.toString();
-
-        HttpHeaders reqHeaders = createAdditionalRequestHeaders();
-
-        String response = client.getXmlRecord(url, reqHeaders, metadataId);
-
-        return response;
-    }
-
-    private HttpHeaders createAdditionalRequestHeaders() {
-        // Allow passing restricted headers
-        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
-
-        HttpHeaders reqHeaders = new HttpHeaders();
-        reqHeaders.set(SEC_PROXY, "true");
-        reqHeaders.set(SEC_USERNAME, "testadmin");
-        reqHeaders.set(SEC_ROLES, "ROLE_GN_ADMIN");
-        reqHeaders.set(SEC_ORG, "Datafeeder Test");
-        // This is odd, apparently any UUID works as XSRF token, and these two need to
-        // be set
-        reqHeaders.set("X-XSRF-TOKEN", "c9f33266-e242-4198-a18c-b01290dce5f1");
-        reqHeaders.set("Cookie", "XSRF-TOKEN=c9f33266-e242-4198-a18c-b01290dce5f1");
-        return reqHeaders;
+        return client.getXmlRecord(metadataId);
     }
 
     public URI buildMetadataRecordIdentifier(@NonNull String recordId) {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
@@ -21,7 +21,6 @@ package org.georchestra.datafeeder.service.geonetwork;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -33,7 +32,6 @@ import java.net.URL;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.ExternalApiConfiguration;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
 public class GeoNetworkRemoteServiceTest {
@@ -80,11 +78,10 @@ public class GeoNetworkRemoteServiceTest {
                         + "<gmd:MD_Metadata>\n",
                 id);//
 
-        String expectedURL = "http://geonetwork:8080/geonetwork";
         GeoNetworkResponse response = new GeoNetworkResponse();
         response.setStatus(HttpStatus.CREATED);
 
-        when(mockClient.putXmlRecord(eq(expectedURL), any(HttpHeaders.class), eq(id), eq(record))).thenReturn(response);
+        when(mockClient.putXmlRecord(eq(id), eq(record))).thenReturn(response);
 
         GeoNetworkResponse ret = service.publish(id, () -> record);
         assertSame(response, ret);

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -41,9 +41,32 @@ front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
 datafeeder.publishing.geoserver.api-url=http://localhost:8080/geoserver/rest
 datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
+# Use this for HTTP basic authentication to geoserver api url:
+#datafeeder.publishing.geoserver.auth.type=basic
+#datafeeder.publishing.geoserver.auth.basic.username=geoserver_privileged_user
+#datafeeder.publishing.geoserver.auth.basic.password=gerlsSnFd6SmM
+# Use this for HTTP-headers based authentication to GeoServer's api url:
+datafeeder.publishing.geoserver.auth.type=headers
+datafeeder.publishing.geoserver.auth.headers.[sec-proxy]=true
+datafeeder.publishing.geoserver.auth.headers.[sec-username]=datafeeder-application
+datafeeder.publishing.geoserver.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR
 
 datafeeder.publishing.geonetwork.api-url=http://localhost:8081/geonetwork
 datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
+# Use this for HTTP basic authentication to Geonetwork's api url:
+#datafeeder.publishing.geonetwork.auth.type=basic
+#datafeeder.publishing.geonetwork.auth.basic.username=
+#datafeeder.publishing.geonetwork.auth.basic.password=
+# Use this for HTTP-headers based authentication to Geonetwork's api url:
+datafeeder.publishing.geonetwork.auth.type=headers
+datafeeder.publishing.geonetwork.auth.headers.[sec-proxy]=true
+datafeeder.publishing.geonetwork.auth.headers.[sec-username]=testadmin
+datafeeder.publishing.geonetwork.auth.headers.[sec-org]=Datafeeder Test
+datafeeder.publishing.geonetwork.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR;ROLE_GN_ADMIN
+# This is odd, apparently any UUID works as XSRF token, and these two need to be set
+datafeeder.publishing.geonetwork.auth.headers.[X-XSRF-TOKEN]=c9f33266-e242-4198-a18c-b01290dce5f1
+datafeeder.publishing.geonetwork.auth.headers.[Cookie]=XSRF-TOKEN=c9f33266-e242-4198-a18c-b01290dce5f1
+
 #template-record-id, an existing geonetwork record id to use as template. If provided, takes precedence over template-record 
 datafeeder.publishing.geonetwork.template-record-id:
 #let's use the default template and transform for testing


### PR DESCRIPTION
Externalize auth config of geoserver and geonetwork REST clients
    
Add basic and headers auth config properties.
    
Use externalized configuration to set up authentication for both the
GeoServer and GeoNetwork REST clients, using the following configuration
in `datafeeder.properties`:
    
```
datafeeder.publishing.geoserver.auth.type=basic|headers
datafeeder.publishing.geoserver.auth.basic.username=<username>
datafeeder.publishing.geoserver.auth.basic.password=<pwd>
datafeeder.publishing.geoserver.auth.headers.[<header-name>]=<header-value>

datafeeder.publishing.geonetwork.auth.type=basic|headers
datafeeder.publishing.geonetwork.auth.basic.username=<username>
datafeeder.publishing.geonetwork.auth.basic.password=<pwd>
datafeeder.publishing.geonetwork.auth.headers.[<header-name>]=<header-value>
```
