### PR TITLE
[datafeeder] Publish only the requested dataset when several where uploaded

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
@@ -36,6 +36,7 @@ import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.UserInfo;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.FileStorageService;
+import org.georchestra.datafeeder.service.UploadPackage;
 import org.geotools.geojson.feature.FeatureJSON;
 import org.opengis.feature.simple.SimpleFeature;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,7 +71,8 @@ public class FileUploadApiController implements FileUploadApi {
         }
         try {
             String username = validityService.getUserName();
-            uploadId = storageService.saveUploads(files);
+            UploadPackage uploadPack = storageService.createPackageFromUpload(files);
+            uploadId = uploadPack.getId();
             state = uploadService.createJob(uploadId, username);
             UserInfo user = validityService.getUserInfo();
             uploadService.analyze(uploadId, user);

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraEmailFactory.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraEmailFactory.java
@@ -399,11 +399,22 @@ public class GeorchestraEmailFactory implements DatafeederEmailFactory {
             .build();
 
     private static Optional<PublishSettings> publishing(MessageData d) {
-        return d.getJob().firstDataset().map(DatasetUploadState::getPublishing);
+        return dataset(d).map(DatasetUploadState::getPublishing);
     }
 
     private static Optional<DatasetUploadState> dataset(MessageData d) {
-        return d.getJob().firstDataset();
+        DataUploadJob job = d.getJob();
+        // REVISIT: we'll be returning the first published dataset if at least one has
+        // been published, or the first uploaded one at all otherwise.
+        // this could only be an issue if the user uploaded several shapefiles in a zip
+        // file, which btw is out of scope for the current app, so although we do
+        // support uploading and publishing multiple shapefiles, the UI doesn't. but
+        // this would need to be revisited in the event it does.
+        List<DatasetUploadState> publishableDatasets = job.getPublishableDatasets();
+        if (!publishableDatasets.isEmpty()) {
+            return Optional.of(publishableDatasets.get(0));
+        }
+        return job.firstDataset();
     }
 
     private static String str(Optional<?> o) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/DataUploadAnalysisService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/DataUploadAnalysisService.java
@@ -79,8 +79,8 @@ public class DataUploadAnalysisService {
      *                                  {@link FileStorageService}
      */
     public DataUploadJob createJob(@NonNull UUID jobId, @NonNull String username) {
-        log.info("Creating DataUploadState from UploadPackage {}", jobId);
-        getUploadPack(jobId);
+        log.info("Creating PENDING DataUploadJob for upload package {}", jobId);
+        UploadPackage uploadPack = getUploadPack(jobId);
         DataUploadJob state = new DataUploadJob();
         state.setJobId(jobId);
         state.setAnalyzeStatus(JobStatus.PENDING);
@@ -244,9 +244,7 @@ public class DataUploadAnalysisService {
 
     private UploadPackage getUploadPack(UUID jobId) {
         try {
-            UploadPackage uploadPack = fileStore.find(jobId);
-            log.info("Creating PENDING DataUploadJob for upload package {}", uploadPack.getId());
-            return uploadPack;
+            return fileStore.find(jobId);
         } catch (FileNotFoundException e) {
             throw new IllegalArgumentException("Upload pack " + jobId + " does not exist");
         } catch (IOException e) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/PublishingBatchService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/PublishingBatchService.java
@@ -127,7 +127,7 @@ public class PublishingBatchService {
 
         backendService.prepareBackend(job, user);
 
-        job.getDatasets().forEach(dset -> {
+        job.getPublishableDatasets().forEach(dset -> {
             dset.setPublishStatus(JobStatus.RUNNING);
             if (dset.getPublishing() == null) {
                 dset.setPublishing(new PublishSettings());
@@ -175,7 +175,7 @@ public class PublishingBatchService {
     }
 
     private void doOnEachRunningDataset(DataUploadJob job, Consumer<DatasetUploadState> consumer) {
-        for (DatasetUploadState dataset : job.getDatasets()) {
+        for (DatasetUploadState dataset : job.getPublishableDatasets()) {
             if (JobStatus.RUNNING == dataset.getPublishStatus()) {
                 try {
                     consumer.accept(dataset);
@@ -193,10 +193,10 @@ public class PublishingBatchService {
         log.info("Publish {}: summarize status", jobId);
         DataUploadJob job = this.findJob(jobId);
         if (job.getPublishStatus() != JobStatus.ERROR) {
-            JobStatus status = determineJobStatus(job.getDatasets());
+            JobStatus status = determineJobStatus(job.getPublishableDatasets());
             job.setPublishStatus(status);
             if (JobStatus.ERROR == status) {
-                String errorMessage = buildErrorMessage(job.getDatasets());
+                String errorMessage = buildErrorMessage(job.getPublishableDatasets());
                 log.info("Publish {}: summarized status is ERROR '{}'", jobId, errorMessage);
                 job.setError(errorMessage);
             }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadJob.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadJob.java
@@ -56,9 +56,6 @@ public class DataUploadJob {
     @Column(name = "created_by", nullable = false)
     private String username;
 
-//    @Transient
-//    private UserInfo user = new UserInfo();
-
     @CreatedDate
     @Column(name = "created_date", nullable = false)
     private Date createdDate;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadJob.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadJob.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
@@ -89,6 +90,23 @@ public class DataUploadJob {
 
     public double getProgress() {
         return totalSteps == 0 ? 0d : (double) finishedSteps / totalSteps;
+    }
+
+    /**
+     * @return all uploaded datasets
+     */
+    public List<DatasetUploadState> getDatasets() {
+        return this.datasets;
+    }
+
+    /**
+     * @return all uploaded datasets that have been marked as
+     *         {@link PublishSettings#isPublish() intended to be published} by
+     *         inspecting {@code DatasetUploadState.getPublishing().isPublish()}
+     */
+    public List<DatasetUploadState> getPublishableDatasets() {
+        return getDatasets().stream().filter(d -> d.getPublishing() != null && d.getPublishing().getPublish())
+                .collect(Collectors.toList());
     }
 
     public Optional<DatasetUploadState> getDataset(@NonNull String nativeName) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/PublishSettings.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/PublishSettings.java
@@ -35,6 +35,9 @@ import lombok.Data;
 @Data
 @Embeddable
 public class PublishSettings {
+    @Column(name = "publish")
+    private Boolean publish = false;
+
     @Column(name = "imported_name")
     private String importedName;
 
@@ -82,4 +85,8 @@ public class PublishSettings {
             @AttributeOverride(name = "miny", column = @Column(name = "md_geog_miny")), //
             @AttributeOverride(name = "maxy", column = @Column(name = "md_geog_maxy")) })
     private Envelope geographicBoundingBox;
+
+    public boolean getPublish() {
+        return this.publish == null ? false : this.publish.booleanValue();
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
@@ -377,14 +377,14 @@ public class DatasetsService {
 
     public void importDataset(@NonNull DatasetUploadState d, @NonNull Map<String, String> connectionParams)
             throws IOException {
-        requireNonNull(d.getPublishing());
-        requireNonNull(d.getPublishing().getImportedName(), "imported type name not provided");
-
+        final PublishSettings publishing = d.getPublishing();
+        requireNonNull(publishing);
+        requireNonNull(publishing.getImportedName(), "imported type name not provided");
         DataStore sourceDs = resolveSourceDataStore(d);
         try {
             SimpleFeatureSource source = resolveFeatureSource(sourceDs, d);
             SimpleFeatureType sourceType = source.getSchema();
-            String targetTypeName = d.getPublishing().getImportedName();
+            String targetTypeName = publishing.getImportedName();
             SimpleFeatureType targetType;
             {
                 SimpleFeatureTypeBuilder ftb = new SimpleFeatureTypeBuilder();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/FileStorageService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/FileStorageService.java
@@ -46,8 +46,8 @@ public class FileStorageService {
 
     /**
      */
-    public UUID saveUploads(@NonNull List<MultipartFile> received) throws IOException {
-        UploadPackage pack = initializePackage();
+    public UploadPackage createPackageFromUpload(@NonNull List<MultipartFile> received) throws IOException {
+        UploadPackage pack = createEmptyPackage();
         try {
             for (MultipartFile mpf : received) {
                 addFileToPackage(pack, mpf);
@@ -56,7 +56,7 @@ public class FileStorageService {
             deletePackage(pack.getId());
             throw e;
         }
-        return pack.getId();
+        return pack;
     }
 
     public void addFileToPackage(@NonNull UploadPackage pack, @NonNull MultipartFile mpf) throws IOException {
@@ -68,7 +68,7 @@ public class FileStorageService {
         }
     }
 
-    public UploadPackage initializePackage() throws IOException {
+    public UploadPackage createEmptyPackage() throws IOException {
         UUID packageId = UUID.randomUUID();
         Path root = resolve(packageId);
         Files.createDirectory(root);

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/UploadPackage.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/UploadPackage.java
@@ -39,7 +39,9 @@ import com.google.common.annotations.VisibleForTesting;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class UploadPackage {
 
     private FileStorageService service;
@@ -81,6 +83,7 @@ public class UploadPackage {
     }
 
     public void unpack(@NonNull String archiveRelativeFileName) throws IOException {
+        log.info("Unpacking {}", archiveRelativeFileName);
         Path archive = resolve(archiveRelativeFileName);
         if (!Files.exists(archive)) {
             throw new FileNotFoundException(archiveRelativeFileName + " not found under " + id);

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -78,6 +78,7 @@ logging:
 spring:
   profiles: georchestra
   jpa.database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+  jpa.hibernate.ddl-auto: update
   batch:
     job.enabled: false #disable automatically running configured jobs at startup time
     initialize-schema: always

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/ApiTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/ApiTestSupport.java
@@ -35,6 +35,7 @@ import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -90,6 +91,10 @@ public class ApiTestSupport {
         Set<UUID> expected = Arrays.stream(expectedUserJobs).map(UploadJobStatus::getJobId).collect(Collectors.toSet());
         Set<UUID> actual = jobs.stream().map(UploadJobStatus::getJobId).collect(Collectors.toSet());
         assertEquals(expected, actual);
+    }
+
+    public DataUploadJob uploadAndWaitForSuccess(MultipartFile uploadedFile, String... expectedDatasetNames) {
+        return uploadAndWaitForSuccess(Collections.singletonList(uploadedFile), expectedDatasetNames);
     }
 
     public DataUploadJob uploadAndWaitForSuccess(List<MultipartFile> uploadedFiles, String... expectedDatasetNames) {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/batch/analysis/UploadAnalysisJobConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/batch/analysis/UploadAnalysisJobConfigurationTest.java
@@ -107,7 +107,7 @@ public class UploadAnalysisJobConfigurationTest {
     @Test
     public void step1_ReadUploadPack_single_shapefile() throws IOException {
         List<MultipartFile> received = multipartSupport.roadsShapefile();
-        UUID uploadId = storageService.saveUploads(received);
+        UUID uploadId = storageService.createPackageFromUpload(received).getId();
         DataUploadJob initial = uploadService.createJob(uploadId, "testuser");
         assertEquals(JobStatus.PENDING, initial.getAnalyzeStatus());
 
@@ -141,7 +141,7 @@ public class UploadAnalysisJobConfigurationTest {
     @Test
     public void analyze_single_shapefile() throws Exception {
         List<MultipartFile> received = multipartSupport.roadsShapefile();
-        UUID uploadId = storageService.saveUploads(received);
+        UUID uploadId = storageService.createPackageFromUpload(received).getId();
         DataUploadJob initial = uploadService.createJob(uploadId, "testuser");
         assertEquals(JobStatus.PENDING, initial.getAnalyzeStatus());
 
@@ -181,7 +181,7 @@ public class UploadAnalysisJobConfigurationTest {
 
         MultipartFile received = multipartSupport.createZipFile("test upload.zip", roads, states, chinesePoly);
 
-        UUID uploadId = storageService.saveUploads(Collections.singletonList(received));
+        UUID uploadId = storageService.createPackageFromUpload(Collections.singletonList(received)).getId();
         DataUploadJob initial = uploadService.createJob(uploadId, "testuser");
         assertEquals(JobStatus.PENDING, initial.getAnalyzeStatus());
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/FileStorageServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/FileStorageServiceTest.java
@@ -66,8 +66,8 @@ public class FileStorageServiceTest {
     }
 
     public @Test void testInitializePackage() throws IOException {
-        UploadPackage p1 = service.initializePackage();
-        UploadPackage p2 = service.initializePackage();
+        UploadPackage p1 = service.createEmptyPackage();
+        UploadPackage p2 = service.createEmptyPackage();
         assertNotNull(p1);
         assertNotNull(p2);
         assertNotNull(p1.getId());
@@ -84,8 +84,8 @@ public class FileStorageServiceTest {
 
     @Test(expected = NullPointerException.class)
     public void testFind() throws IOException {
-        UploadPackage p1 = service.initializePackage();
-        UploadPackage p2 = service.initializePackage();
+        UploadPackage p1 = service.createEmptyPackage();
+        UploadPackage p2 = service.createEmptyPackage();
 
         UploadPackage found1 = service.find(p1.getId());
         UploadPackage found2 = service.find(p2.getId());
@@ -99,8 +99,8 @@ public class FileStorageServiceTest {
 
     @Test(expected = NullPointerException.class)
     public void testDeletePackage() throws IOException {
-        UploadPackage p1 = service.initializePackage();
-        UploadPackage p2 = service.initializePackage();
+        UploadPackage p1 = service.createEmptyPackage();
+        UploadPackage p2 = service.createEmptyPackage();
 
         Path root1 = root.resolve(p1.getId().toString());
         Path root2 = root.resolve(p2.getId().toString());
@@ -126,9 +126,9 @@ public class FileStorageServiceTest {
         assertEquals(root.resolve(id.toString()), service.resolve(id));
     }
 
-    public @Test void testSaveUploadsNoFiles() throws IOException {
+    public @Test void createPackageFromUpload_NoFiles() throws IOException {
         List<MultipartFile> received = Collections.emptyList();
-        UUID id = service.saveUploads(received);
+        UUID id = service.createPackageFromUpload(received).getId();
         assertNotNull(id);
         UploadPackage pack = service.find(id);
         assertNotNull(pack);
@@ -137,24 +137,24 @@ public class FileStorageServiceTest {
         assertTrue(pack.findAll().isEmpty());
     }
 
-    public @Test void testSaveUploadsSingleFile() throws IOException {
+    public @Test void createPackageFromUpload_SingleFile() throws IOException {
         List<MultipartFile> received = Arrays.asList(multipartSupport.createFakeFile("test.geojson", 1024));
-        UUID id = service.saveUploads(received);
+        UUID id = service.createPackageFromUpload(received).getId();
         verifyUploads(id, received);
     }
 
-    public @Test void testSaveUploadsMultipleFiles() throws IOException {
+    public @Test void createPackageFromUpload_MultipleFiles() throws IOException {
         List<MultipartFile> received = Arrays.asList(//
                 multipartSupport.createFakeFile("test.shp", 4096), //
                 multipartSupport.createFakeFile("test.shx", 1024), //
                 multipartSupport.createFakeFile("test.prj", 128), //
                 multipartSupport.createFakeFile("test.dbf", 1024 * 1024)//
         );
-        UUID id = service.saveUploads(received);
+        UUID id = service.createPackageFromUpload(received).getId();
         verifyUploads(id, received);
     }
 
-    public @Test void testSaveUploadsZipFileIsExtractedAutomatically() throws IOException {
+    public @Test void createPackageFromUpload_ZipFileIsExtractedAutomatically() throws IOException {
         List<MultipartFile> zipped = Arrays.asList(//
                 multipartSupport.createFakeFile("test.shp", 4096), //
                 multipartSupport.createFakeFile("test.shx", 1024), //
@@ -169,7 +169,7 @@ public class FileStorageServiceTest {
                 multipartSupport.createFakeFile("test3.geojson", 1024)//
         );
         MultipartFile zipFile = multipartSupport.createZipFile("test.zip", zipped);
-        final UUID id = service.saveUploads(Collections.singletonList(zipFile));
+        final UUID id = service.createPackageFromUpload(Collections.singletonList(zipFile)).getId();
 
         List<MultipartFile> expected = new ArrayList<>(zipped);
         expected.add(zipFile);


### PR DESCRIPTION
If the user uploaded a zipfile with several datasets (e.g. shapefiles), then the publish request is executed, it contains the list of datasets to publish among their metadata.
    
Currently the datafeeder-ui expects an uploaded zip file to contain a single shapefile, but nothing prevents the user from providing a zip file with several shapefiles. This backend application is prepared to handle multiple datasets publications in a single call though.
