### PR TITLE
[datafeeder] Add progress reporting to publish job

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -299,6 +299,9 @@ components:
     PublishStatusEnum:
       type: string
       enum: [PENDING, RUNNING, DONE, ERROR]
+    PublishStepEnum:
+      type: string
+      enum: [SKIPPED, SCHEDULED, DATA_IMPORT_STARTED, DATA_IMPORT_FINISHED, OWS_PUBLISHING_STARTED, OWS_PUBLISHING_FINISHED, METADATA_PUBLISHING_STARTED, METADATA_PUBLISHING_FINISHED, OWS_METADATA_UPDATE_STARTED, OWS_METADATA_UPDATE_FINISHED, COMPLETED]
 
     UploadJobStatus:
       type: object
@@ -505,3 +508,16 @@ components:
         error:
           type: string
           description: short description of the error that prevents the dataset to be published
+        publish:
+          type: boolean
+          description: true if this dataset is scheduled to be published (as requested through a PublishRequest)
+        progress:
+          description: Estimated completion progress, from 0 to 1.
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          default: 0.0
+        progressStep:
+          $ref: '#/components/schemas/PublishStepEnum'
+          

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/mapper/DataPublishingResponseMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/mapper/DataPublishingResponseMapper.java
@@ -18,18 +18,32 @@
  */
 package org.georchestra.datafeeder.api.mapper;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 import org.georchestra.datafeeder.api.DatasetPublishingStatus;
 import org.georchestra.datafeeder.api.PublishJobStatus;
+import org.georchestra.datafeeder.api.PublishStepEnum;
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker;
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 
-@Mapper(componentModel = "spring", uses = CRSMapper.class)
-public interface DataPublishingResponseMapper {
+@Mapper(componentModel = "spring", uses = CRSMapper.class, unmappedSourcePolicy = ReportingPolicy.WARN, unmappedTargetPolicy = ReportingPolicy.ERROR)
+public abstract class DataPublishingResponseMapper {
+
+    private @Autowired PublishJobProgressTracker progressTracker;
 
     @Mapping(target = "status", source = "publishStatus")
-    PublishJobStatus toApi(DataUploadJob upload);
+    @Mapping(target = "progress", ignore = true) // set by setJobProgress() @Aftermapping
+    public abstract PublishJobStatus toApi(DataUploadJob upload);
 
     @Mapping(target = "status", source = "publishStatus")
     @Mapping(target = "nativeName", source = "name")
@@ -37,5 +51,34 @@ public interface DataPublishingResponseMapper {
     @Mapping(target = "publishedWorkspace", source = "publishing.publishedWorkspace")
     @Mapping(target = "metadataRecordId", source = "publishing.metadataRecordId")
     @Mapping(target = "title", source = "publishing.title")
-    DatasetPublishingStatus toApi(DatasetUploadState upload);
+    @Mapping(target = "publish", source = "publishing.publish")
+    @Mapping(target = "progress", ignore = true) // set by setDatasetProgress() @Aftermapping
+    @Mapping(target = "progressStep", ignore = true) // set by setDatasetProgress() @Aftermapping
+    public abstract DatasetPublishingStatus toApi(DatasetUploadState upload);
+
+    public @AfterMapping void setJobProgress(DataUploadJob source, @MappingTarget PublishJobStatus target) {
+        double progress = progressTracker.getProgress(source);
+        target.setProgress(progress);
+
+        List<DatasetPublishingStatus> datasets = target.getDatasets();
+        Collections.sort(datasets, (d1, d2) -> {
+            int c = Comparator.comparing(DatasetPublishingStatus::getProgressStep).reversed().compare(d1, d2);
+            if (c != 0) {
+                return c;
+            }
+            String pn1 = d1.getPublishedName() == null ? d1.getNativeName() : d1.getPublishedName();
+            String pn2 = d2.getPublishedName() == null ? d2.getNativeName() : d2.getPublishedName();
+            return pn1.compareTo(pn2);
+        });
+    }
+
+    abstract PublishStepEnum toApi(DatasetPublishingStep publishStep);
+
+    public @AfterMapping void setDatasetProgress(DatasetUploadState source,
+            @MappingTarget DatasetPublishingStatus target) {
+        double progress = progressTracker.getProgress(source);
+        DatasetPublishingStep currentStep = progressTracker.getCurrentStep(source);
+        target.setProgress(progress);
+        target.setProgressStep(toApi(currentStep));
+    }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/analysis/DatasetUploadStateUpdateListener.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/analysis/DatasetUploadStateUpdateListener.java
@@ -18,11 +18,8 @@
  */
 package org.georchestra.datafeeder.batch.analysis;
 
-import java.util.UUID;
-
 import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.model.JobStatus;
-import org.georchestra.datafeeder.repository.DataUploadJobRepository;
 import org.georchestra.datafeeder.repository.DatasetUploadStateRepository;
 import org.springframework.batch.core.ItemProcessListener;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +33,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class DatasetUploadStateUpdateListener implements ItemProcessListener<DatasetUploadState, DatasetUploadState> {
 
-    private @Autowired DataUploadJobRepository jobRepository;
     private @Autowired DatasetUploadStateRepository datasetRepository;
 
     @Override
@@ -47,13 +43,9 @@ public class DatasetUploadStateUpdateListener implements ItemProcessListener<Dat
 
     @Override
     public void afterProcess(DatasetUploadState item, DatasetUploadState result) {
-        UUID uploadId = item.getJob().getJobId();
-        jobRepository.incrementProgress(uploadId);
     }
 
     @Override
     public void onProcessError(DatasetUploadState item, Exception e) {
-        UUID uploadId = item.getJob().getJobId();
-        jobRepository.incrementProgress(uploadId);
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/DataImportTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/DataImportTasklet.java
@@ -54,7 +54,7 @@ public class DataImportTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        service.importDatasetsToTargetDatastore(uploadId, user);
+        service.step1_importDatasetsToTargetDatastore(uploadId, user);
         return RepeatStatus.FINISHED;
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/DataPublishingJobConfiguration.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/DataPublishingJobConfiguration.java
@@ -48,6 +48,10 @@ public class DataPublishingJobConfiguration {
     private @Autowired JobBuilderFactory jobBuilderFactory;
     private @Autowired StepBuilderFactory stepBuilderFactory;
 
+    public @Bean PublishJobProgressTracker publishJobProgressTracker() {
+        return new PublishJobProgressTracker();
+    }
+
     public @Bean PublishingBatchService publishingBatchService() {
         return new PublishingBatchService();
     }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/GeoNetworkTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/GeoNetworkTasklet.java
@@ -49,7 +49,7 @@ public class GeoNetworkTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        service.publishDatasetsMetadataToGeoNetwork(uploadId, user);
+        service.step3_publishDatasetsMetadataToGeoNetwork(uploadId, user);
         return RepeatStatus.FINISHED;
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/GeoServerGeoNetworkUpdateTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/GeoServerGeoNetworkUpdateTasklet.java
@@ -35,7 +35,7 @@ public class GeoServerGeoNetworkUpdateTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        service.addMetadataLinksToGeoServerDatasets(uploadId);
+        service.step4_addMetadataLinksToGeoServerDatasets(uploadId);
         return RepeatStatus.FINISHED;
     }
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/GeoServerTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/GeoServerTasklet.java
@@ -50,7 +50,7 @@ public class GeoServerTasklet implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         try {
-            service.publishDatasetsToGeoServer(uploadId, user);
+            service.step2_publishDatasetsToGeoServer(uploadId, user);
         } catch (Exception e) {
             e.printStackTrace();
             throw e;

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/PrepareTargetDataStoreTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/PrepareTargetDataStoreTasklet.java
@@ -64,7 +64,7 @@ public class PrepareTargetDataStoreTasklet implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         try {
-            service.prepareTargetStoreForJobDatasets(uploadId, user);
+            service.step0_prepareTargetStoreForJobDatasets(uploadId, user);
         } catch (RuntimeException e) {
             log.error("Error preparing target store", e);
             String message = e.getMessage();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/PublishJobProgressTracker.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/PublishJobProgressTracker.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.batch.publish;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.georchestra.datafeeder.model.JobStatus;
+import org.hibernate.internal.util.collections.BoundedConcurrentHashMap;
+import org.springframework.util.Assert;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+public class PublishJobProgressTracker {
+
+    final ConcurrentMap<UUID, JobProgress> progress = new BoundedConcurrentHashMap<>();
+
+    public JobProgress initialize(@NonNull DataUploadJob job) {
+        UUID jobId = job.getJobId();
+        JobProgress jobProgress = buildJobProgress(job);
+        progress.put(jobId, jobProgress);
+        return jobProgress;
+    }
+
+    public JobProgress dispose(@NonNull UUID jobId) {
+        return progress.remove(jobId);
+    }
+
+    public Optional<JobProgress> find(@NonNull UUID jobId) {
+        return Optional.ofNullable(progress.get(jobId));
+    }
+
+    public JobProgress get(@NonNull UUID jobId) {
+        return find(jobId)
+                .orElseThrow(() -> new IllegalArgumentException("Progress for job " + jobId + " is not being tracked"));
+    }
+
+    public double getProgress(DataUploadJob job) {
+        return find(job.getJobId()).map(JobProgress::getProgress)
+                .orElseGet(() -> progressFromStatus(job.getPublishStatus()));
+    }
+
+    private double progressFromStatus(JobStatus status) {
+        switch (status) {
+        case DONE:
+        case ERROR:
+            return 1.0;
+        default:
+            return 0.0;
+        }
+    }
+
+    public double getProgress(DatasetUploadState source) {
+        Optional<JobProgress> job = find(source.getJob().getJobId());
+        Optional<DatasetProgress> dataset = job.flatMap(j -> j.find(source.getId()));
+        return dataset.map(DatasetProgress::getProgress).orElseGet(() -> progressFromStatus(source.getPublishStatus()));
+    }
+
+    public DatasetPublishingStep getCurrentStep(DatasetUploadState source) {
+        Optional<JobProgress> job = find(source.getJob().getJobId());
+        Optional<DatasetProgress> dataset = job.flatMap(j -> j.find(source.getId()));
+        return dataset.map(DatasetProgress::getStep).orElseGet(() -> {
+            JobStatus publishStatus = source.getPublishStatus();
+            if (source.getPublishing().getPublish()
+                    && (publishStatus == JobStatus.DONE || publishStatus == JobStatus.ERROR)) {
+                return DatasetPublishingStep.COMPLETED;
+            }
+            return DatasetPublishingStep.SKIPPED;
+        });
+    }
+
+    private JobProgress buildJobProgress(@NonNull DataUploadJob job) {
+        List<DatasetUploadState> publishableDatasets = job.getPublishableDatasets();
+
+        final long totalFeatures = publishableDatasets.stream().map(DatasetUploadState::getFeatureCount)
+                .filter(Objects::nonNull).mapToLong(Integer::longValue).sum();
+
+        JobProgress progress = new JobProgress();
+
+        for (DatasetUploadState dataset : publishableDatasets) {
+            int featureCount = dataset.getFeatureCount() == null ? 0 : dataset.getFeatureCount().intValue();
+            DatasetProgress datasetProgress = DatasetProgress.valueOf(totalFeatures, featureCount);
+            progress.add(dataset.getId(), datasetProgress);
+        }
+        return progress;
+    }
+
+    public static class JobProgress {
+        private Map<Long, DatasetProgress> datasets = new ConcurrentHashMap<>();
+
+        long totalEffort;
+
+        void add(Long datasetId, DatasetProgress datasetProgress) {
+            this.datasets.put(datasetId, datasetProgress);
+            totalEffort = this.datasets.values().stream().map(DatasetProgress::getTotalEffort)
+                    .mapToLong(Long::longValue).sum();
+
+        }
+
+        public double getProgress() {
+            double sum = datasets.values().stream().mapToDouble(this::coalesceProgress).sum();
+            if (sum < 0d || sum > 1d)
+                throw new IllegalStateException("Coalesced progress out of bounds [0..1]: " + sum);
+            return sum;
+        }
+
+        public Optional<DatasetProgress> find(@NonNull Long datasetId) {
+            return Optional.ofNullable(datasets.get(datasetId));
+        }
+
+        public DatasetProgress getProgress(@NonNull Long datasetId) {
+            return find(datasetId).orElseThrow(() -> new IllegalArgumentException("Progress for dataset " + datasetId
+                    + " is not being tracked. Make sure it was a publishable dataset"));
+        }
+
+        private double coalesceProgress(DatasetProgress dataset) {
+            double factor = (double) dataset.getTotalEffort() / (double) this.totalEffort;
+            double progress = dataset.getProgress();
+            return progress * factor;
+        }
+    }
+
+    public static enum DatasetPublishingStep {
+        SKIPPED, SCHEDULED, //
+        DATA_IMPORT_STARTED, DATA_IMPORT_FINISHED, //
+        OWS_PUBLISHING_STARTED, OWS_PUBLISHING_FINISHED, //
+        METADATA_PUBLISHING_STARTED, METADATA_PUBLISHING_FINISHED, //
+        OWS_METADATA_UPDATE_STARTED, OWS_METADATA_UPDATE_FINISHED, //
+        COMPLETED
+    }
+
+    public static class DatasetProgress {
+        private static final int OWS_PUBLISH_RELATIVE_IMPACT = 100;
+        private static final int METADATA_PUBLISH_RELATIVE_IMPACT = 100;
+        private static final int OWS_MD_UPDATE_RELATIVE_IMPACT = 100;
+
+        private @Getter DatasetPublishingStep step = DatasetPublishingStep.SCHEDULED;
+        private final double featureImportImpact, owsPublishImpact, mdPublishImpact, owsMdUpdateImpact;
+        private final @Getter long totalEffort;
+
+        private double dataImportProgress;
+        private double nonDataImportProgress;
+
+        public DatasetProgress(long totalEffort, double featureImportImpact, double owsPublishImpact,
+                double mdPublishImpact, double owsMdUpdateImpact) {
+            this.totalEffort = totalEffort;
+            this.featureImportImpact = featureImportImpact;
+            this.owsPublishImpact = owsPublishImpact;
+            this.mdPublishImpact = mdPublishImpact;
+            this.owsMdUpdateImpact = owsMdUpdateImpact;
+        }
+
+        public void setStep(@NonNull DatasetPublishingStep step) {
+            this.step = step;
+            switch (step) {
+            case SCHEDULED:
+                nonDataImportProgress = 0d;
+                break;
+            case DATA_IMPORT_STARTED:
+                // no-upate, wait for setImportProgress() calls
+                break;
+            case DATA_IMPORT_FINISHED:
+                dataImportProgress = 1.0;
+                break;
+            case OWS_PUBLISHING_STARTED:
+                break;
+            case OWS_PUBLISHING_FINISHED:
+                nonDataImportProgress += owsMdUpdateImpact;
+                break;
+            case METADATA_PUBLISHING_STARTED:
+                break;
+            case METADATA_PUBLISHING_FINISHED:
+                nonDataImportProgress += mdPublishImpact;
+                break;
+            case OWS_METADATA_UPDATE_STARTED:
+                break;
+            case OWS_METADATA_UPDATE_FINISHED:
+                nonDataImportProgress += owsPublishImpact;
+                break;
+            case COMPLETED:
+                nonDataImportProgress = owsPublishImpact + owsMdUpdateImpact + mdPublishImpact;
+                break;
+            default:
+                throw new IllegalArgumentException();
+            }
+        }
+
+        public void setImportProgress(double progress) {
+            Assert.isTrue(progress >= 0d && progress <= 1d,
+                    () -> "import progress must be between 0.0 and 1.0, got " + progress);
+            if (step != DatasetPublishingStep.DATA_IMPORT_STARTED) {
+                throw new IllegalStateException("Current step should be DATA_IMPORT_STARTED, but it's " + step);
+            }
+            this.dataImportProgress = progress;
+        }
+
+        public double getProgress() {
+            double relativeDataImportProgress = this.dataImportProgress * this.featureImportImpact;
+            return nonDataImportProgress + relativeDataImportProgress;
+        }
+
+        public static DatasetProgress valueOf(long totalFeatures, int featureCount) {
+            final int nonImportStepsFeatureRelativeImpact = OWS_PUBLISH_RELATIVE_IMPACT
+                    + METADATA_PUBLISH_RELATIVE_IMPACT + OWS_MD_UPDATE_RELATIVE_IMPACT;
+            final long totalEffort = featureCount + nonImportStepsFeatureRelativeImpact;
+
+            double featureImportImpact = featureCount / (double) totalEffort;
+            double owsPublishImpact = OWS_PUBLISH_RELATIVE_IMPACT / (double) totalEffort;
+            double mdPublishImpact = METADATA_PUBLISH_RELATIVE_IMPACT / (double) totalEffort;
+            double owsMdUpdateImpact = OWS_MD_UPDATE_RELATIVE_IMPACT / (double) totalEffort;
+            return new DatasetProgress(totalEffort, featureImportImpact, owsPublishImpact, mdPublishImpact,
+                    owsMdUpdateImpact);
+        }
+    }
+
+}

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/DataUploadAnalysisService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/service/DataUploadAnalysisService.java
@@ -132,7 +132,6 @@ public class DataUploadAnalysisService {
             throw new IllegalStateException(e);
         }
 
-        int errored = 0;
         for (String fileRelativePath : datasetFiles) {
             Path path = uploadPack.resolve(fileRelativePath);
             List<String> typeNames;
@@ -142,15 +141,11 @@ public class DataUploadAnalysisService {
                 fileDatasets.forEach(d -> d.setJob(job));
                 job.getDatasets().addAll(fileDatasets);
             } catch (Exception e) {
-                errored++;
                 DatasetUploadState dataset = createFailedDataset(fileRelativePath, path, e);
                 dataset.setJob(job);
                 job.getDatasets().add(dataset);
             }
         }
-        int totalSteps = job.getDatasets().size() - errored;
-        job.setTotalSteps(totalSteps);
-        job.setFinishedSteps(0);
         jobRepository.save(job);
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadJob.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DataUploadJob.java
@@ -85,12 +85,10 @@ public class DataUploadJob {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<DatasetUploadState> datasets = new ArrayList<>();
 
+    @Deprecated
     private int totalSteps;
+    @Deprecated
     private int finishedSteps;
-
-    public double getProgress() {
-        return totalSteps == 0 ? 0d : (double) finishedSteps / totalSteps;
-    }
 
     /**
      * @return all uploaded datasets

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
@@ -99,5 +99,5 @@ public class DatasetUploadState {
     private List<SampleProperty> sampleProperties = new ArrayList<>();
 
     @Embedded
-    private PublishSettings publishing;
+    private PublishSettings publishing = new PublishSettings();
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/repository/DataUploadJobRepository.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/repository/DataUploadJobRepository.java
@@ -54,7 +54,4 @@ public interface DataUploadJobRepository extends JpaRepository<DataUploadJob, UU
     int setPublishingStatus(@Param("jobId") UUID jobId, @Param("status") JobStatus status,
             @Param("error") String errorMessage);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update DataUploadJob set finishedSteps = finishedSteps + 1 where jobId = :jobId")
-    int incrementProgress(@Param("jobId") UUID jobId);
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/DataBackendService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/DataBackendService.java
@@ -21,6 +21,7 @@ package org.georchestra.datafeeder.service.publish;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.model.UserInfo;
+import org.opengis.util.ProgressListener;
 
 import lombok.NonNull;
 
@@ -28,6 +29,6 @@ public interface DataBackendService {
 
     void prepareBackend(DataUploadJob job, @NonNull UserInfo user);
 
-    void importDataset(DatasetUploadState dataset, @NonNull UserInfo user);
+    void importDataset(DatasetUploadState dataset, @NonNull UserInfo user, @NonNull ProgressListener progressListener);
 
 }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
@@ -43,6 +43,7 @@ import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.postgis.PostgisNGDataStoreFactory;
 import org.geotools.jdbc.JDBCDataStore;
+import org.opengis.util.ProgressListener;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -128,7 +129,8 @@ public class GeorchestraDataBackendService implements DataBackendService {
     }
 
     @Override
-    public void importDataset(@NonNull DatasetUploadState dataset, @NonNull UserInfo user) {
+    public void importDataset(@NonNull DatasetUploadState dataset, @NonNull UserInfo user,
+            @NonNull ProgressListener progressListener) {
         requireNonNull(dataset.getName(), "Dataset name is null");
         requireNonNull(user.getOrganization(), "Organization is null");
         requireNonNull(user.getOrganization().getId(), "Organization is null");
@@ -146,7 +148,7 @@ public class GeorchestraDataBackendService implements DataBackendService {
         try {
             dataset.getPublishing().setImportedName(uniqueTargetName);
             log.info("Importing dataset {} into PostGIS as {}.{}", dataset.getName(), postgresSchema, uniqueTargetName);
-            datasetsService.importDataset(dataset, connectionParams);
+            datasetsService.importDataset(dataset, connectionParams, progressListener);
         } catch (IOException e) {
             log.error("Error importing dataset {} into PostGIS as {}.{}", dataset.getName(), postgresSchema,
                     uniqueTargetName, e);

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -79,6 +79,7 @@ spring:
   profiles: georchestra
   jpa.database-platform: org.hibernate.dialect.PostgreSQL10Dialect
   jpa.hibernate.ddl-auto: update
+  jackson.default-property-inclusion: non-null
   batch:
     job.enabled: false #disable automatically running configured jobs at startup time
     initialize-schema: always

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraSecurityProxyAuthenticationConfigurationTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 
 import org.georchestra.datafeeder.api.AuthorizationService;
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker;
 import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.DatasetsService;
@@ -76,6 +77,7 @@ public class GeorchestraSecurityProxyAuthenticationConfigurationTest {
     private @MockBean DataPublishingService mockDataPublishingService;
     private @MockBean MetadataPublicationService mockMetadataPublicationService;
     private @MockBean DatasetsService mockDatasetsService;
+    private @MockBean PublishJobProgressTracker mockPublishJobProgressTracker;
 
     private @LocalServerPort int port;
     private @Value("${server.servlet.context-path}") String contextPath;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/ApiTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/ApiTestSupport.java
@@ -116,7 +116,6 @@ public class ApiTestSupport {
         Optional<DataUploadJob> state = uploadService.findJob(id);
         assertTrue(state.isPresent());
         assertNull(state.get().getError());
-        assertEquals(1d, state.get().getProgress(), 0d);
         List<DatasetUploadState> datasets = state.get().getDatasets();
 
         assertEquals(expectedDatasetNames.length, datasets.size());

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/DataPublishingApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/DataPublishingApiControllerTest.java
@@ -77,7 +77,7 @@ public class DataPublishingApiControllerTest {
         DatasetUploadState dset = upload.getDatasets().get(0);
         DatasetPublishRequest dsetReq = buildRequest(dset);
 
-        PublishRequest publishRequest = new PublishRequest().datasets(Arrays.asList(dsetReq));
+        PublishRequest publishRequest = new PublishRequest().addDatasetsItem(dsetReq);
 
         ResponseEntity<PublishJobStatus> response = controller.publish(upload.getJobId(), publishRequest);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
@@ -160,7 +160,7 @@ public class DataPublishingApiControllerTest {
         DatasetPublishRequest dsetReq = buildRequest(dset);
         dsetReq.setSrs(null);
 
-        PublishRequest publishRequest = new PublishRequest().datasets(Arrays.asList(dsetReq));
+        PublishRequest publishRequest = new PublishRequest().addDatasetsItem(dsetReq);
 
         ResponseEntity<PublishJobStatus> response = controller.publish(upload.getJobId(), publishRequest);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerSecurityTest.java
@@ -21,6 +21,7 @@ package org.georchestra.datafeeder.api;
 import java.util.Collections;
 
 import org.georchestra.datafeeder.api.mapper.FileUploadResponseMapper;
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker;
 import org.georchestra.datafeeder.service.DataPublishingService;
 import org.georchestra.datafeeder.service.DataUploadService;
 import org.georchestra.datafeeder.service.FileStorageService;
@@ -46,6 +47,7 @@ public class FileUploadApiControllerSecurityTest {
     private @MockBean FileUploadResponseMapper mapper;
     private @MockBean AuthorizationService mockDataUploadValidityService;
     private @MockBean DataPublishingService mockDataPublishingService;
+    private @MockBean PublishJobProgressTracker mockPublishJobProgressTracker;
 
     private @Autowired FileUploadApi controller;
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
@@ -143,7 +143,6 @@ public class FileUploadApiControllerTest {
         DataUploadJob job = testSupport.awaitUntilJobIsOneOf(id, 3, ERROR);
         job = uploadService.findJob(job.getJobId()).orElse(null);
         assertEquals(1, job.getDatasets().size());
-        assertEquals("failed job should report full progress", 1d, job.getProgress(), 0d);
         assertNotNull(job.getError());
 
         testSupport.assertDataset(job.getDatasets(), "test", ERROR);
@@ -180,7 +179,6 @@ public class FileUploadApiControllerTest {
         DataUploadJob job = testSupport.awaitUntilJobIsOneOf(id, 3, ERROR);
         job = this.uploadService.findJob(job.getJobId()).orElse(null);
         assertEquals(3, job.getDatasets().size());
-        assertEquals("failed job should report full progress", 1d, job.getProgress(), 0d);
         assertNotNull(job.getError());
 
         testSupport.assertDataset(job.getDatasets(), "archsites", DONE);

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraIntegrationAutoConfigurationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.georchestra.datafeeder.api.AuthorizationService;
 import org.georchestra.datafeeder.api.DataFeederApiConfiguration;
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.FileUploadConfig;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.PublishingConfiguration;
@@ -65,6 +66,7 @@ public class GeorchestraIntegrationAutoConfigurationTest {
     private @MockBean DataPublishingService mockDataPublishingService;
     private @MockBean MetadataPublicationService mockMetadataPublicationService;
     private @MockBean DatasetsService mockDatasetsService;
+    private @MockBean PublishJobProgressTracker mockPublishJobProgressTracker;
 
     private @Autowired ApplicationContext context;
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/batch/analysis/UploadAnalysisJobConfigurationTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/batch/analysis/UploadAnalysisJobConfigurationTest.java
@@ -156,7 +156,6 @@ public class UploadAnalysisJobConfigurationTest {
         assertEquals(uploadId, state.getJobId());
         assertEquals(JobStatus.DONE, state.getAnalyzeStatus());
         assertEquals(1, state.getDatasets().size());
-        assertEquals(1.0, state.getProgress(), 0d);
 
         DatasetUploadState dset = state.getDatasets().get(0);
         assertEquals(JobStatus.DONE, dset.getAnalyzeStatus());
@@ -196,9 +195,6 @@ public class UploadAnalysisJobConfigurationTest {
         assertEquals(uploadId, state.getJobId());
         assertEquals(JobStatus.DONE, state.getAnalyzeStatus());
         assertEquals(3, state.getDatasets().size());
-        assertEquals(3, state.getTotalSteps());
-        assertEquals(3, state.getFinishedSteps());
-        assertEquals(1.0, state.getProgress(), 0d);
 
         List<DatasetUploadState> dsets = datasetRepository.findAllByJobId(uploadId);
         assertEquals(3, dsets.size());

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/batch/publish/PublishJobProgressTrackerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/batch/publish/PublishJobProgressTrackerTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.batch.publish;
+
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.COMPLETED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.DATA_IMPORT_FINISHED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.DATA_IMPORT_STARTED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.METADATA_PUBLISHING_FINISHED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.METADATA_PUBLISHING_STARTED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.OWS_METADATA_UPDATE_FINISHED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.OWS_METADATA_UPDATE_STARTED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.OWS_PUBLISHING_FINISHED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.OWS_PUBLISHING_STARTED;
+import static org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetPublishingStep.SCHEDULED;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.UUID;
+
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.DatasetProgress;
+import org.georchestra.datafeeder.batch.publish.PublishJobProgressTracker.JobProgress;
+import org.georchestra.datafeeder.model.DataUploadJob;
+import org.georchestra.datafeeder.model.DatasetUploadState;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PublishJobProgressTrackerTest {
+
+    private PublishJobProgressTracker tracker;
+
+    DataUploadJob job;
+
+    private DatasetUploadState dataset1;
+
+    private DatasetUploadState dataset2;
+
+    public @Before void before() {
+        tracker = new PublishJobProgressTracker();
+        job = new DataUploadJob();
+        job.setJobId(UUID.randomUUID());
+        dataset1 = new DatasetUploadState();
+        dataset2 = new DatasetUploadState();
+        dataset1.setId(1L);
+        dataset2.setId(2L);
+        job.getDatasets().add(dataset1);
+        job.getDatasets().add(dataset2);
+    }
+
+    @Test
+    public void testInitialize_NoPublishableDatasets() {
+        dataset1.getPublishing().setPublish(false);
+        dataset2.getPublishing().setPublish(false);
+
+        JobProgress progress = tracker.initialize(job);
+        assertEquals(0d, progress.getProgress(), 1e-9);
+        try {
+            progress.getProgress(dataset1.getId());
+            fail("expected IAE");
+        } catch (IllegalArgumentException expected) {
+            assertEquals("Progress for dataset 1 is not being tracked. Make sure it was a publishable dataset",
+                    expected.getMessage());
+        }
+        try {
+            progress.getProgress(dataset2.getId());
+            fail("expected IAE");
+        } catch (IllegalArgumentException expected) {
+            assertEquals("Progress for dataset 2 is not being tracked. Make sure it was a publishable dataset",
+                    expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testInitialize() {
+        JobProgress progress;
+
+        dataset1.getPublishing().setPublish(true);
+        dataset1.setFeatureCount(0);
+        progress = tracker.initialize(job);
+        assertEquals(300L, progress.totalEffort);
+        assertEquals(300L, progress.getProgress(dataset1.getId()).getTotalEffort());
+
+        dataset1.setFeatureCount(100);
+        progress = tracker.initialize(job);
+        assertEquals(400L, progress.totalEffort);
+        assertEquals(400L, progress.getProgress(dataset1.getId()).getTotalEffort());
+
+        dataset2.getPublishing().setPublish(true);
+        dataset2.setFeatureCount(0);
+        progress = tracker.initialize(job);
+        assertEquals(700L, progress.totalEffort);
+        assertEquals(300L, progress.getProgress(dataset2.getId()).getTotalEffort());
+
+        dataset2.setFeatureCount(1_000);
+        progress = tracker.initialize(job);
+        assertEquals(1700L, progress.totalEffort);
+        assertEquals(1300L, progress.getProgress(dataset2.getId()).getTotalEffort());
+    }
+
+    @Test
+    public void testDispose() {
+        tracker.initialize(job);
+        assertNotNull(tracker.get(job.getJobId()));
+        tracker.dispose(job.getJobId());
+        try {
+            tracker.get(job.getJobId());
+            fail("expected IAE");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getMessage(), containsString("Progress for job"));
+            assertThat(expected.getMessage(), containsString("is not being tracked"));
+        }
+    }
+
+    @Test
+    public void testGetProgress_singleDataset_zeroFeatures() {
+        JobProgress progress;
+
+        dataset1.getPublishing().setPublish(true);
+        dataset1.setFeatureCount(0);
+        progress = tracker.initialize(job);
+
+        DatasetProgress dp = progress.getProgress(dataset1.getId());
+        assertEquals(300, dp.getTotalEffort());
+        assertEquals(SCHEDULED, dp.getStep());
+
+        assertEquals(0d, dp.getProgress(), 1e-9);
+
+        dp.setStep(DATA_IMPORT_STARTED);
+        assertEquals(0d, dp.getProgress(), 1e-9);
+        dp.setStep(DATA_IMPORT_FINISHED);
+
+        dp.setStep(OWS_PUBLISHING_STARTED);
+        assertEquals("no change expected upon started event", 0d, dp.getProgress(), 1e-9);
+        dp.setStep(OWS_PUBLISHING_FINISHED);
+        assertEquals(1 / 3d, dp.getProgress(), 1e-9);
+
+        dp.setStep(METADATA_PUBLISHING_STARTED);
+        assertEquals("no change expected upon started event", 1 / 3d, dp.getProgress(), 1e-9);
+        dp.setStep(METADATA_PUBLISHING_FINISHED);
+        assertEquals(2 / 3d, dp.getProgress(), 1e-9);
+
+        dp.setStep(OWS_METADATA_UPDATE_STARTED);
+        assertEquals("no change expected upon started event", 2 / 3d, dp.getProgress(), 1e-9);
+        dp.setStep(OWS_METADATA_UPDATE_FINISHED);
+        assertEquals(3 / 3d, dp.getProgress(), 1e-9);
+
+        dp.setStep(COMPLETED);
+        assertEquals(1.0, dp.getProgress(), 1e-9);
+    }
+
+    @Test
+    public void testGetProgress_singleDataset() {
+        JobProgress jobProgress;
+
+        final int featureCount = 100;
+
+        dataset1.getPublishing().setPublish(true);
+        dataset1.setFeatureCount(featureCount);
+        jobProgress = tracker.initialize(job);
+
+        DatasetProgress dp = jobProgress.getProgress(dataset1.getId());
+        assertEquals(400, dp.getTotalEffort());
+        assertEquals(SCHEDULED, dp.getStep());
+
+        assertEquals(0d, dp.getProgress(), 1e-9);
+
+        dp.setStep(DATA_IMPORT_STARTED);
+        assertEquals(0d, dp.getProgress(), 1e-9);
+
+        dp.setImportProgress(0);
+        assertEquals(0, dp.getProgress(), 1e-9);
+
+        dp.setImportProgress(0.5);
+        assertEquals(0.125, dp.getProgress(), 1e-9);
+        assertEquals(0.125, jobProgress.getProgress(), 1e-9);
+
+        dp.setImportProgress(1.0);
+        dp.setStep(DATA_IMPORT_FINISHED);
+        assertEquals(0.25, dp.getProgress(), 1e-9);
+        assertEquals(0.25, jobProgress.getProgress(), 1e-9);
+
+        dp.setStep(OWS_PUBLISHING_STARTED);
+        assertEquals("no change expected upon started evend", 0.25, dp.getProgress(), 1e-9);
+        dp.setStep(OWS_PUBLISHING_FINISHED);
+        assertEquals(0.5, dp.getProgress(), 1e-9);
+        assertEquals(0.5, jobProgress.getProgress(), 1e-9);
+
+        dp.setStep(METADATA_PUBLISHING_STARTED);
+        assertEquals("no change expected upon started evend", 0.5, dp.getProgress(), 1e-9);
+        dp.setStep(METADATA_PUBLISHING_FINISHED);
+        assertEquals(0.75, dp.getProgress(), 1e-9);
+        assertEquals(0.75, jobProgress.getProgress(), 1e-9);
+
+        dp.setStep(OWS_METADATA_UPDATE_STARTED);
+        assertEquals("no change expected upon started evend", 0.75, dp.getProgress(), 1e-9);
+        dp.setStep(OWS_METADATA_UPDATE_FINISHED);
+        assertEquals(1.0, dp.getProgress(), 1e-9);
+        assertEquals(1.0, jobProgress.getProgress(), 1e-9);
+
+        dp.setStep(COMPLETED);
+        assertEquals(1.0, dp.getProgress(), 1e-9);
+        assertEquals(1.0, jobProgress.getProgress(), 1e-9);
+    }
+
+    @Test
+    public void testGetProgress_multipleDatasets() {
+        dataset1.getPublishing().setPublish(true);
+        dataset2.getPublishing().setPublish(true);
+
+        dataset1.setFeatureCount(100);
+        dataset2.setFeatureCount(100);
+
+        JobProgress jobProgress = tracker.initialize(job);
+        DatasetProgress dp1 = jobProgress.getProgress(dataset1.getId());
+        DatasetProgress dp2 = jobProgress.getProgress(dataset2.getId());
+        assertEquals(SCHEDULED, dp1.getStep());
+        assertEquals(SCHEDULED, dp2.getStep());
+
+        final double totalEffort = 800;
+        assertEquals(totalEffort, jobProgress.totalEffort, 1e-9);
+
+        assertEquals(0d, jobProgress.getProgress(), 1e-9);
+
+        /////
+        dp1.setStep(OWS_PUBLISHING_STARTED);
+        assertEquals("no change expected", 0d, dp1.getProgress(), 1e-9);
+
+        dp2.setStep(OWS_PUBLISHING_STARTED);
+        assertEquals("no change expected", 0d, dp2.getProgress(), 1e-9);
+
+        dp1.setStep(OWS_PUBLISHING_FINISHED);
+        assertEquals(0.25, dp1.getProgress(), 1e-9);
+        assertEquals(0.125, jobProgress.getProgress(), 1e-9);
+
+        dp2.setStep(OWS_PUBLISHING_FINISHED);
+        assertEquals(0.25, dp2.getProgress(), 1e-9);
+        assertEquals(0.25, jobProgress.getProgress(), 1e-9);
+
+        /////
+
+        dp1.setStep(METADATA_PUBLISHING_STARTED);
+        assertEquals("no change expected", 0.25, dp1.getProgress(), 1e-9);
+
+        dp2.setStep(METADATA_PUBLISHING_STARTED);
+        assertEquals("no change expected", 0.25, dp2.getProgress(), 1e-9);
+
+        dp1.setStep(METADATA_PUBLISHING_FINISHED);
+        assertEquals(0.5, dp1.getProgress(), 1e-9);
+        assertEquals(0.375, jobProgress.getProgress(), 1e-9);
+
+        dp2.setStep(METADATA_PUBLISHING_FINISHED);
+        assertEquals(0.5, dp2.getProgress(), 1e-9);
+        assertEquals(0.5, jobProgress.getProgress(), 1e-9);
+
+        /////
+
+        dp1.setStep(OWS_METADATA_UPDATE_STARTED);
+        assertEquals("no change expected", 0.5, dp1.getProgress(), 1e-9);
+
+        dp2.setStep(OWS_METADATA_UPDATE_STARTED);
+        assertEquals("no change expected", 0.5, dp2.getProgress(), 1e-9);
+
+        dp1.setStep(OWS_METADATA_UPDATE_FINISHED);
+        assertEquals(0.75, dp1.getProgress(), 1e-9);
+        assertEquals(0.625, jobProgress.getProgress(), 1e-9);
+
+        dp2.setStep(OWS_METADATA_UPDATE_FINISHED);
+        assertEquals(0.75, dp2.getProgress(), 1e-9);
+        assertEquals(0.75, jobProgress.getProgress(), 1e-9);
+
+        ///////////
+
+        dp1.setStep(DATA_IMPORT_STARTED);
+        dp2.setStep(DATA_IMPORT_STARTED);
+        assertEquals("no change expected", 0.75, jobProgress.getProgress(), 1e-9);
+
+        dp1.setImportProgress(0.5);
+        assertEquals(0.875, dp1.getProgress(), 1e-9);
+        assertEquals(0.75 + 0.125 / 2, jobProgress.getProgress(), 1e-9);
+
+        dp2.setImportProgress(0.5);
+        assertEquals(0.875, dp2.getProgress(), 1e-9);
+        assertEquals(0.875, jobProgress.getProgress(), 1e-9);
+
+        dp1.setImportProgress(1.0);
+        assertEquals(1, dp1.getProgress(), 1e-9);
+        assertEquals(1 - 0.125 / 2, jobProgress.getProgress(), 1e-9);
+
+        dp2.setImportProgress(1.0);
+        assertEquals(1, dp2.getProgress(), 1e-9);
+        assertEquals(1, jobProgress.getProgress(), 1e-9);
+
+        dp1.setStep(DATA_IMPORT_FINISHED);
+        dp2.setStep(DATA_IMPORT_FINISHED);
+        assertEquals(1, dp1.getProgress(), 1e-9);
+        assertEquals(1, dp2.getProgress(), 1e-9);
+        assertEquals(1, jobProgress.getProgress(), 1e-9);
+    }
+}

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/mock/MockDataBackendService.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/mock/MockDataBackendService.java
@@ -32,6 +32,7 @@ import org.georchestra.datafeeder.model.UserInfo;
 import org.georchestra.datafeeder.service.DatasetsService;
 import org.georchestra.datafeeder.service.publish.DataBackendService;
 import org.geotools.data.shapefile.ShapefileDirectoryFactory;
+import org.opengis.util.ProgressListener;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.FileSystemUtils;
@@ -69,12 +70,13 @@ public class MockDataBackendService implements DataBackendService, DisposableBea
     }
 
     @Override
-    public void importDataset(@NonNull DatasetUploadState dataset, @NonNull UserInfo user) {
+    public void importDataset(@NonNull DatasetUploadState dataset, @NonNull UserInfo user,
+            @NonNull ProgressListener progressListener) {
         Map<String, String> connectionParams = resolveConnectionParams(dataset.getJob(), user);
         try {
             // use the same native featuretype name for the imported dataset featuretype
             dataset.getPublishing().setImportedName(dataset.getName());
-            datasetsService.importDataset(dataset, connectionParams);
+            datasetsService.importDataset(dataset, connectionParams, progressListener);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
A new service bean `PublishJobProgressTracker` takes care of tracking
progress of dataset publish jobs.

The progress indicators have been removed from the internal job object
model, being considered a "presentation" concern, and not a business
one.

The API object property `PublishJobStatus.progress` is an aggregate
progress of the publishing progress of all the datasets being published
on a single job (given the API supports uploading and publishing several
datasets for a single job).

This aggregate is computed taking into account the relative impact of
each dataset, based on their number of features.

Each `DatasetPublishingStatus` in `PublishJobStatus.datasets[]` has the
following new properties:

- `publish:boolean`: whether the dataset has been requested for being
  published or not.
- `progress:double`: the dataset specific progress.
- `progressStep:PublishStepEnum`: enum indicating the current step being
  being running. Allows the UI to create a more indicative progress
message.

The `PublishStepEnum` has the following values:

* SKIPPED: the dataset is not being published
* SCHEDULED: the dataset will be published but hasn't started yet
* DATA_IMPORT_STARTED: the data is being imported into PostGIS
* DATA_IMPORT_FINISHED: the data has been imported
* OWS_PUBLISHING_STARTED: dataset is being published to GeoServer
* OWS_PUBLISHING_FINISHED: GeoServer publication finished
* METADATA_PUBLISHING_STARTED: metadata is being published to GeoNetwork
* METADATA_PUBLISHING_FINISHED: GeoNetwork publication finished
* OWS_METADATA_UPDATE_STARTED: GeoServer metadata links are being added
* OWS_METADATA_UPDATE_FINISHED: GeoServer metadata links added.
* COMPLETED: publish job completed for the dataset