### PR TITLE
[datafeeder] Fix single line multiple variables resolution on email templates

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraEmailFactory.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraEmailFactory.java
@@ -358,9 +358,9 @@ public class GeorchestraEmailFactory implements DatafeederEmailFactory {
         return propertyName;
     }
 
-    private Set<String> extractVariableNames(String messageTemplate) {
-        Matcher matcher = Pattern.compile("\\$\\{.*\\}").matcher(messageTemplate);
+    static Set<String> extractVariableNames(String messageTemplate) {
         Set<String> varNames = new TreeSet<>();
+        Matcher matcher = Pattern.compile("\\$(\\{(\\w+\\.)*\\w+\\})").matcher(messageTemplate);
         while (matcher.find()) {
             String varName = matcher.group(0);
             varNames.add(varName);

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -159,6 +159,6 @@ logging:
     root: info
     '[feign]': info
     '[org.georchestra.datafeeder]': info
-    '[org.georchestra.config.security]': debug
+    '[org.georchestra.config.security]': info
     '[org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationFilter]': info #mute GeorchestraSecurityProxyAuthenticationFilter superclass a bit
     '[org.geoserver.openapi]': info

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraEmailFactoryTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/autoconf/GeorchestraEmailFactoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.datafeeder.autoconf;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+public class GeorchestraEmailFactoryTest {
+
+    private static final String TEMPLATE = "to: ${user.email}\n"//
+            + "cc: ${administratorEmail}\n"//
+            + "bcc:\n"//
+            + "sender: ${administratorEmail}\n"//
+            + "from: Georchestra Importer Application\n"//
+            + "subject: Your ${dataset.name} dataset has been published\n"//
+            + "body:\n"//
+            + "\n" + "Dear ${user.name}, \n"//
+            + "\n"//
+            + "We're pleased to inform you that your ${dataset.name} dataset\n"//
+            + "submitted on ${job.createdAt} has been correctly processed and published.\n"//
+            + "\n"//
+            + "Browse to the following URL to access a map preview of the published layer:\n"//
+            + "\n"//
+            + "${publicUrl}/geoserver/${publish.workspace}/wms/reflect?format=application/openlayers&LAYERS=${publish.layerName}\n"//
+            + "\n"//
+            + "And to this URL to access its published metadata:\n"//
+            + "\n"//
+            + "${publicUrl}/geonetwork/srv/eng/catalog.search#/metadata/${metadata.id}\n"//
+            + "";
+
+    @Test
+    public void testExtractVariableNames() {
+        Set<String> expected = new TreeSet<>(Arrays.asList("${user.email}", "${administratorEmail}", "${dataset.name}",
+                "${user.name}", "${job.createdAt}", "${publicUrl}", "${publish.workspace}", "${publish.layerName}",
+                "${metadata.id}"));
+
+        Set<String> actual = GeorchestraEmailFactory.extractVariableNames(TEMPLATE);
+        assertEquals(expected, actual);
+    }
+
+}

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -24,6 +24,7 @@
 #  Datafeeder specific properties  #
 ####################################
 
+publicUrl=http://localhost:8080
 # pgsqlSchema=datafeeder
 
 # maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)
@@ -90,11 +91,11 @@ datafeeder.publishing.backend.geoserver.preparedStatements=true
 datafeeder.publishing.backend.geoserver.schema=<schema>
 datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
 #if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
-#datafeeder.publishing.backend.geoserver.host=localhost
-#datafeeder.publishing.backend.geoserver.port=5432
-#datafeeder.publishing.backend.geoserver.database=datafeeder
-#datafeeder.publishing.backend.geoserver.user=postgres
-#datafeeder.publishing.backend.geoserver.passwd=postgres
+datafeeder.publishing.backend.geoserver.host=localhost
+datafeeder.publishing.backend.geoserver.port=5432
+datafeeder.publishing.backend.geoserver.database=datafeeder
+datafeeder.publishing.backend.geoserver.user=postgres
+datafeeder.publishing.backend.geoserver.passwd=postgres
 
 # note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false

--- a/datafeeder/src/test/resources/datadir/datafeeder/templates/analysis-failed-email-template.txt
+++ b/datafeeder/src/test/resources/datadir/datafeeder/templates/analysis-failed-email-template.txt
@@ -9,9 +9,20 @@ body:
 Dear ${user.name}, 
 
 We're sorry to inform you that a problem occurred during the
-analysis phase for the ${dataset.name} you've uploaded.
+analysis phase for the ${dataset.name} dataset you have provided
+on ${job.createdAt}.
 
-Here's the full information:
+The platform administrator has been notified too.
+
+Job identifier: ${job.id}
+Reported error: ${job.error}
+
+You can access the job page at this location: ${publicUrl}/import/${job.id}
+
+---
+Sent by ${instanceName}
+
+--- For debugging purposes, full list of available job properties: ---
 
 user.name: ${user.name}
 user.lastName: ${user.lastName}
@@ -38,6 +49,3 @@ metadata.lineage: ${metadata.lineage}
 metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
 metadata.keywords: ${metadata.keywords}
 metadata.scale: ${metadata.scale}
-
----
-Sent by ${instanceName}

--- a/datafeeder/src/test/resources/datadir/datafeeder/templates/analysis-started-email-template.txt
+++ b/datafeeder/src/test/resources/datadir/datafeeder/templates/analysis-started-email-template.txt
@@ -6,10 +6,16 @@ from: Georchestra Importer Application
 subject: Analysis process started for your ${dataset.name} dataset
 body:
 
-Dear ${user.name}, 
+Dear ${user.name},
 
 Your ${dataset.name} dataset was received correctly and is currently being analyzed.
 
+You can access the job page at this location: ${publicUrl}/import/${job.id}
+
+---
+Sent by ${instanceName}
+
+--- For debugging purposes, full list of available job properties: ---
 user.name: ${user.name}
 user.lastName: ${user.lastName}
 user.email: ${user.email}
@@ -35,6 +41,3 @@ metadata.lineage: ${metadata.lineage}
 metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
 metadata.keywords: ${metadata.keywords}
 metadata.scale: ${metadata.scale}
-
----
-Sent by ${instanceName}

--- a/datafeeder/src/test/resources/datadir/datafeeder/templates/data-publishing-failed-email-template.txt
+++ b/datafeeder/src/test/resources/datadir/datafeeder/templates/data-publishing-failed-email-template.txt
@@ -8,10 +8,21 @@ body:
 
 Dear ${user.name}, 
 
-We're sorry to inform you that the publcation process for your
-${dataset.name} dataset failed.
+We're sorry to inform you that the publication process for your
+${dataset.name} dataset failed submitted on ${job.createdAt}
+has encountered an error and could not finish correctly. 
 
-Here's the full information:
+The platform administrator has been notified too.
+
+Job identifier: ${job.id}
+Reported error: ${job.error}
+
+You can access the job page at this location: ${publicUrl}/import/${job.id}
+
+---
+Sent by ${instanceName}
+
+--- For debugging purposes, full list of available job properties: ---
 
 user.name: ${user.name}
 user.lastName: ${user.lastName}
@@ -38,6 +49,3 @@ metadata.lineage: ${metadata.lineage}
 metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
 metadata.keywords: ${metadata.keywords}
 metadata.scale: ${metadata.scale}
-
----
-Sent by ${instanceName}

--- a/datafeeder/src/test/resources/datadir/datafeeder/templates/data-publishing-succeeded-email-template.txt
+++ b/datafeeder/src/test/resources/datadir/datafeeder/templates/data-publishing-succeeded-email-template.txt
@@ -9,7 +9,20 @@ body:
 Dear ${user.name}, 
 
 We're pleased to inform you that your ${dataset.name} dataset
-has been published.
+submitted on ${job.createdAt} has been correctly processed and published.
+
+Browse to the following URL to access a map preview of the published layer:
+
+${publicUrl}/geoserver/${publish.workspace}/wms/reflect?format=application/openlayers&LAYERS=${publish.layerName}
+
+And to this URL to access its published metadata:
+
+${publicUrl}/geonetwork/srv/eng/catalog.search#/metadata/${metadata.id}
+
+---
+Sent by ${instanceName}
+
+--- For debugging purposes, full list of available job properties: ---
 
 user.name: ${user.name}
 user.lastName: ${user.lastName}
@@ -36,6 +49,3 @@ metadata.lineage: ${metadata.lineage}
 metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
 metadata.keywords: ${metadata.keywords}
 metadata.scale: ${metadata.scale}
-
----
-Sent by ${instanceName}


### PR DESCRIPTION
Fix variable names resolution when there is more than one variable on
the same line of email templates.

Change templates to be closer to what the real ones shall be.

Better handle job failures.  We need to leave the spring-batch job complete normally or the
publishStatus/error won't be persisted, as spring-batch and our JPA
repositories share the same entity manager. If a publishing process failed and
the exception was re-thrown, spring-batch would abort the current
transaction.