### PR TITLE
Fix gs-importer profile

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -418,7 +418,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>importer</id>
+      <id>gs-importer</id>
       <dependencies>
         <dependency>
           <groupId>org.geoserver.importer</groupId>


### PR DESCRIPTION
importer extension has been removed from standard GeoServer build. The
profile was kept, but did not build anymore, because the name changed.