### PR TITLE
[geoserver] enable sldservice extension

### DIFF
--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -1,7 +1,7 @@
 ---
 env:
   # The following variable should be set to the same value as in the Makefile at the root of the repository
-  GEOSERVER_EXTENSION_PROFILES: colormap,mbtiles,wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2,mbstyle,ogcapi,web-resource,flatgeobuf
+  GEOSERVER_EXTENSION_PROFILES: colormap,mbtiles,wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2,mbstyle,ogcapi,web-resource,flatgeobuf,sldservice
 
 name: "geoserver"
 on:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Docker related targets
 
-GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2,mbstyle,ogcapi,web-resource,flatgeobuf
+GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2,mbstyle,ogcapi,web-resource,flatgeobuf,sldservice
 BTAG=latest
 
 docker-pull-jetty:


### PR DESCRIPTION
should fix #3395 and georchestra/mapstore2-georchestra#366 - to be backported to 20.1.x and 20.0.x.