### PR TITLE
[datafeeder] parameterize geoserver base namespace URI

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -44,7 +44,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j(topic = "org.georchestra.datafeeder.config")
 public @Data class DataFeederConfigurationProperties {
-
     private URI frontEndConfigFile;
     private FileUploadConfig fileUpload = new FileUploadConfig();
     private PublishingConfiguration publishing = new PublishingConfiguration();
@@ -79,8 +78,7 @@ public @Data class DataFeederConfigurationProperties {
     }
 
     public static @Data class PublishingConfiguration {
-
-        private ExternalApiConfiguration geoserver = new ExternalApiConfiguration();
+        private GeoServerPublishingConfiguration geoserver = new GeoServerPublishingConfiguration();
         private GeonetworkPublishingConfiguration geonetwork = new GeonetworkPublishingConfiguration();
         private BackendConfiguration backend = new BackendConfiguration();
     }
@@ -91,6 +89,12 @@ public @Data class DataFeederConfigurationProperties {
         private String templateRecordId;
         private URI templateRecord;
         private URI templateTransform;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class GeoServerPublishingConfiguration extends ExternalApiConfiguration {
+        private String baseNamespaceURI;
     }
 
     public static @Data class ExternalApiConfiguration {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -249,8 +249,9 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
     private String resolveWorkspace(@NonNull UserInfo user) {
         final @NonNull String orgName = user.getOrganization().getId();
         final String workspaceName = nameResolver.resolveWorkspaceName(orgName);
-
-        WorkspaceInfo ws = geoserver.getOrCreateWorkspace(workspaceName);
+        String baseNamespaceURI = this.configProperties.getPublishing().getGeoserver().getBaseNamespaceURI();
+        String namespaceURI = URI.create(baseNamespaceURI + "/" + workspaceName).normalize().toString();
+        WorkspaceInfo ws = geoserver.getOrCreateWorkspace(workspaceName, namespaceURI);
 
         return ws.getName();
     }

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -56,6 +56,9 @@ datafeeder:
     temporary-location: ${file-upload.temporary-location:${java.io.tmpdir}/datafeeder/tmp}
     # directory location where files will be stored.
     persistent-location: ${file-upload.persistent-location:${java.io.tmpdir}/datafeeder/uploads}
+  publishing:
+    geoserver:
+      baseNamespaceURI: ${publicUrl}/import
 
 feign:
   okhttp.enabled: true
@@ -130,6 +133,7 @@ datafeeder:
       api-url: http://localhost:18080/geoserver/rest
       public-url: https://georchestra.mydomain.org/geoserver
       log-requests: true
+      baseNamespaceURI: ${publicUrl}/import
     geonetwork:
       api-url: http://localhost:28080/geonetwork
       public-url: https://georchestra.mydomain.org/geonetwork


### PR DESCRIPTION
When creating a geoserver workspace/namespace pair, the namespace URI
was hardcoded as `https://georchestra.org/datafeeder/ <workspace_name>`.

Added a new configuration property,
`datafeeder.publishing.geoserver.baseNamespaceURI`, which defaults to
the `${publicUrl}/import`, for an end result of
`${publicUrl}/import/workspacename`.