### PR TITLE
[datafeeder] publish metadata records to the users org GN group

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
@@ -34,7 +34,7 @@ public interface GeoNetworkClient {
 
     void checkServiceAvailable() throws IOException;
 
-    GeoNetworkResponse putXmlRecord(String metadataId, String xmlRecord);
+    GeoNetworkResponse putXmlRecord(@NonNull String metadataId, @NonNull String xmlRecord, String groupName);
 
     String getXmlRecord(@NonNull String recordId);
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
@@ -111,17 +111,13 @@ public class GeoNetworkRemoteService {
      * </code>
      * </pre>
      * 
-     * @param metadataId
-     * 
-     * @param metadataId
-     * 
-     * @param xmlRecordAsString
      * @return
      */
-    public GeoNetworkResponse publish(@NonNull String metadataId, @NonNull Supplier<String> xmlRecordAsString) {
+    public GeoNetworkResponse publish(@NonNull String metadataId, @NonNull Supplier<String> xmlRecordAsString,
+            String group) {
         final String xmlRecord = xmlRecordAsString.get();
 
-        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord);
+        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord, group);
 
         HttpStatus statusCode = response.getStatus();
         String statusText = response.getStatusText();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -75,7 +75,12 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
         String metadataId = mdProps.getMetadataId();
 
         Supplier<String> record = templateMapper.apply(mdProps);
-        GeoNetworkResponse response = geonetwork.publish(metadataId, record);
+        Organization organization = user.getOrganization();
+        // The metadata is inserted into the group which already exists due to
+        // GeoNetwork's LDAP sync (which currently garantees that a geonetwork group
+        // exists for the publishing organization)
+        String mdGroupId = organization.getId();
+        GeoNetworkResponse response = geonetwork.publish(metadataId, record, mdGroupId);
         dataset.getPublishing().setMetadataRecordId(metadataId);
     }
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceIT.java
@@ -70,7 +70,9 @@ public class GeoNetworkRemoteServiceIT {
         final String id = UUID.randomUUID().toString();
         final String record = loadSampleRecord(id);
 
-        GeoNetworkResponse response = service.publish(id, () -> record);
+        // we don't have gn groups in the it compose?
+        String group = null;
+        GeoNetworkResponse response = service.publish(id, () -> record, group);
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatus());
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
@@ -81,9 +81,10 @@ public class GeoNetworkRemoteServiceTest {
         GeoNetworkResponse response = new GeoNetworkResponse();
         response.setStatus(HttpStatus.CREATED);
 
-        when(mockClient.putXmlRecord(eq(id), eq(record))).thenReturn(response);
+        String group = "psc";
+        when(mockClient.putXmlRecord(eq(id), eq(record), eq(group))).thenReturn(response);
 
-        GeoNetworkResponse ret = service.publish(id, () -> record);
+        GeoNetworkResponse ret = service.publish(id, () -> record, group);
         assertSame(response, ret);
     }
 


### PR DESCRIPTION
Remaining task : "The metadata is inserted into the group which
already exists due to GeoNetwork's LDAP sync (which currently
guarantees that a geonetwork group exists for the publishing organization)"