### PR TITLE
[datafeeder] Fix mismatch between PostGIS table name and requested GeoServer native layer name

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -88,7 +88,10 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
 
         PublishSettings publishing = dataset.getPublishing();
         requireNonNull(publishing);
-        requireNonNull(publishing.getPublishedName());
+        requireNonNull(publishing.getPublishedName(),
+                "publishedName is required to assign a layer name to the geoserver feature type");
+        requireNonNull(publishing.getImportedName(),
+                "importedName is required to resolve the native feature type name");
 
         final String workspaceName = resolveWorkspace(user);
         final String dataStoreName = resolveDataStoreName(dataset);
@@ -191,7 +194,7 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         PublishSettings publishing = dataset.getPublishing();
         FeatureTypeInfo ft = new FeatureTypeInfo();
 
-        ft.setNativeName(dataset.getName());
+        ft.setNativeName(publishing.getImportedName());
         ft.setName(layerName);
         ft.setNamespace(new NamespaceInfo().prefix(workspace));
 


### PR DESCRIPTION
Fixes #3393 

Datasets with mixed case were failing to be published to GeoServer with
an error "Trying to create new feature type inside the store, but no
attributes were specified".

Though a bit cryptic, it means that it couldn't find the requested table
name in PostGIS when processing the POST request for a `FeatureTypeInfo`,
from its `nativeName` property, and was trying to create such table, but
the `FeatureTypeInfo` provided no `AttributeTypeInfo`'s.

The root of the issue was that Datafeeder was using the "dataset native
name" instead of the "publishing imported name" to set the
`FeatureTypeInfo.nativeName` property (i.e., it was passing the type name
of the uploaded dataset - shapefile name -, instead of the name of the
table imported into postgis).