### PR TITLE
[datafeeder] Properly handle upload files with spaces

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DatasetsService.java
@@ -326,7 +326,11 @@ public class DatasetsService {
         if (isShapefile(path)) {
             URL url;
             try {
-                url = path.toUri().toURL();
+                // white space handling. We don't want "file name.shp" to be "file%20name.shp",
+                // or the "native type name" will also be "file%20name"
+                Path parent = path.getParent();
+                Path fileName = path.getFileName();
+                url = new URL(String.format("file://%s/%s", parent.toAbsolutePath(), fileName.toString()));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/test/MultipartTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/test/MultipartTestSupport.java
@@ -27,12 +27,15 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.geotools.TestData;
 import org.junit.rules.ExternalResource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.google.common.io.ByteStreams;
+import com.sun.mail.handlers.multipart_mixed;
 
 import lombok.NonNull;
 
@@ -61,6 +64,16 @@ public class MultipartTestSupport extends ExternalResource {
     public List<MultipartFile> chinesePolyShapefile() {
         return loadGeoToolsTestFiles("shapes/chinese_poly.shp", "shapes/chinese_poly.dbf", "shapes/chinese_poly.prj",
                 "shapes/chinese_poly.shx");
+    }
+
+    public List<MultipartFile> renameDataset(String newName, List<MultipartFile> datasetFiles) throws IOException {
+        List<MultipartFile> renamed = new ArrayList<>();
+        for (MultipartFile f : datasetFiles) {
+            String extension = FilenameUtils.getExtension(f.getOriginalFilename());
+            String name = String.format("%s.%s", newName, extension);
+            renamed.add(createMultipartFile(name, f.getBytes()));
+        }
+        return renamed;
     }
 
     private List<MultipartFile> loadGeoToolsTestFiles(String... names) {


### PR DESCRIPTION
Using `java.nio.Path.toUri().toURL()` to create the URL argument for
GeoTools Shapefile DataStore produced URL encoded file names (e.g.
`file%20name.shp` instead of `file name.shp`, which afterwards results
in the Shapefile DataStore.getTypeNames() to return `file%20name` as the
native type name.