### PR TITLE
[WIP][datafeeder] Add TopicCategory from INSPIRE thesaurus to published md records

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapper.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  * {@link TemplateMapper} specific to geOrchestra, uses properties in
  * geOrchestra data directory's {@code datafeeder/datafeeder.properties} to
  * provide the location of the {@link #loadTemplateRecord() template record} and
- * {@link #loadTransform() XSL transform}.
+ * {@link #resolveTransformURI() XSL transform}.
  */
 @Slf4j
 public class GeorchestraTemplateMapper extends TemplateMapper {
@@ -46,18 +46,18 @@ public class GeorchestraTemplateMapper extends TemplateMapper {
      * Overrides to load the template transformation XSL file from the URI provided
      * in {@code datafeeder/datafeeder.properties} geOrchestra datadir file, under
      * the {@code datafeeder.publishing.geonetwork.template-transform} key. Defers
-     * to the default template at {@link TemplateMapper#loadTransform()} if no URI
-     * is configured.
+     * to the default template at {@link TemplateMapper#resolveTransformURI()} if no
+     * URI is configured.
      */
     @Override
-    protected String loadTransform() {
+    protected URI resolveTransformURI() {
         GeonetworkPublishingConfiguration gn = config.getPublishing().getGeonetwork();
         URI transformURI = gn.getTemplateTransform();
         if (transformURI != null) {
-            return config.loadResourceAsString(transformURI, "datafeeder.publishing.geonetwork.template-transform");
+            return transformURI;
         }
         log.info("No metadata template provided in georchstra datadir, using default XSL transform");
-        return super.loadTransform();
+        return super.resolveTransformURI();
     }
 
     /**

--- a/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
+++ b/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
@@ -1,15 +1,25 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:exsl="http://exslt.org/common" extension-element-prefixes="exsl" xmlns:gmd="http://www.isotc211.org/2005/gmd"
-  xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:srv="http://www.isotc211.org/2005/srv"
-  xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts"
-  xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi"
-  xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd"
-  exclude-result-prefixes="gmd srv gco">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common" 
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                version="2.0" 
+                exclude-result-prefixes="#all">
+
 <!-- 
 Default template to apply MetadataRecordProperties.java properties to a record template adhering to http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd
  -->
+
+  <xsl:import href="inspire-themes-and-topiccategory.xsl"/>
+
   <xsl:strip-space elements="*" xmlns="http://www.isotc211.org/2005/gmd" />
   <xsl:output indent="yes" standalone="yes" />
 

--- a/datafeeder/src/main/resources/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf
+++ b/datafeeder/src/main/resources/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme">
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">GEMET - INSPIRE themes, version 1.0</dc:title>
+    <dcterms:issued xmlns:dcterms="http://purl.org/dc/terms/">2018-05-23T10:25:56</dcterms:issued>
+    <dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/">2018-05-23T10:25:56</dcterms:modified>
+  </skos:ConceptScheme>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ad">
+    <skos:prefLabel xml:lang="en">Addresses</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Adressen</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Location of properties based on address identifiers, usually by road name, house number, postal code.</skos:scopeNote>
+    <skos:altLabel>ad</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/au">
+    <skos:prefLabel xml:lang="en">Administrative units</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Units of administration, dividing areas where Member States have and/or exercise jurisdictional rights, for local, regional and national governance, separated by administrative boundaries.</skos:scopeNote>
+    <skos:altLabel>au</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/rs">
+    <skos:prefLabel xml:lang="en">Coordinate reference systems</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Systems for uniquely referencing spatial information in space as a set of coordinates (x, y, z) and/or latitude and longitude and height, based on a geodetic horizontal and vertical datum.</skos:scopeNote>
+    <skos:altLabel>rs</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/gg">
+    <skos:prefLabel xml:lang="en">Geographical grid systems</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Harmonised multi-resolution grid with a common point of origin and standardised location and size of grid cells.</skos:scopeNote>
+    <skos:altLabel>gg</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/cp">
+    <skos:prefLabel xml:lang="en">Cadastral parcels</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Areas defined by cadastral registers or equivalent.</skos:scopeNote>
+    <skos:altLabel>cp</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/gn">
+    <skos:prefLabel xml:lang="en">Geographical names</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Names of areas, regions, localities, cities, suburbs, towns or settlements, or any geographical or topographical feature of public or historical interest.</skos:scopeNote>
+    <skos:altLabel>gn</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/hy">
+    <skos:prefLabel xml:lang="en">Hydrography</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Hydrographic elements, including marine areas and all other water bodies and items related to them, including river basins and sub-basins. Where appropriate, according to the definitions set out in Directive 2000/60/EC of the European Parliament and of the Council of 23 October 2000 establishing a framework for Community action in the field of water policy (2) and in the form of networks.</skos:scopeNote>
+    <skos:altLabel>hy</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ps">
+    <skos:prefLabel xml:lang="en">Protected sites</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Area designated or managed within a framework of international, Community and Member States' legislation to achieve specific conservation objectives.</skos:scopeNote>
+    <skos:altLabel>ps</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/tn">
+    <skos:prefLabel xml:lang="en">Transport networks</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Road, rail, air and water transport networks and related infrastructure. Includes links between different networks. Also includes the trans-European transport network as defined in Decision No 1692/96/EC of the European Parliament and of the Council of 23 July 1996 on Community Guidelines for the development of the trans-European transport network (1) and future revisions of that Decision.</skos:scopeNote>
+    <skos:altLabel>tn</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/el">
+    <skos:prefLabel xml:lang="en">Elevation</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Digital elevation models for land, ice and ocean surface. Includes terrestrial elevation, bathymetry and shoreline.</skos:scopeNote>
+    <skos:altLabel>el</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ge">
+    <skos:prefLabel xml:lang="en">Geology</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geology characterised according to composition and structure. Includes bedrock, aquifers and geomorphology.</skos:scopeNote>
+    <skos:altLabel>ge</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/lc">
+    <skos:prefLabel xml:lang="en">Land cover</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical and biological cover of the earth's surface including artificial surfaces, agricultural areas, forests, (semi-)natural areas, wetlands, water bodies.</skos:scopeNote>
+    <skos:altLabel>lc</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/oi">
+    <skos:prefLabel xml:lang="en">Orthoimagery</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geo-referenced image data of the Earth's surface, from either satellite or airborne sensors.</skos:scopeNote>
+    <skos:altLabel>oi</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/af">
+    <skos:prefLabel xml:lang="en">Agricultural and aquaculture facilities</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Farming equipment and production facilities (including irrigation systems, greenhouses and stables).</skos:scopeNote>
+    <skos:altLabel>af</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/am">
+    <skos:prefLabel xml:lang="en">Area management/restriction/regulation zones and reporting units</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Areas managed, regulated or used for reporting at international, European, national, regional and local levels. Includes dumping sites, restricted areas around drinking water sources, nitrate-vulnerable zones, regulated fairways at sea or large inland waters, areas for the dumping of waste, noise restriction zones, prospecting and mining permit areas, river basin districts, relevant reporting units and coastal zone management areas.</skos:scopeNote>
+    <skos:altLabel>am</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ac">
+    <skos:prefLabel xml:lang="en">Atmospheric conditions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical conditions in the atmosphere. Includes spatial data based on measurements, on models or on a combination thereof and includes measurement locations.</skos:scopeNote>
+    <skos:altLabel>ac</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/br">
+    <skos:prefLabel xml:lang="en">Bio-geographical regions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Areas of relatively homogeneous ecological conditions with common characteristics.</skos:scopeNote>
+    <skos:altLabel>br</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/bu">
+    <skos:prefLabel xml:lang="en">Buildings</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical location of buildings.</skos:scopeNote>
+    <skos:altLabel>bu</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/er">
+    <skos:prefLabel xml:lang="en">Energy resources</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Energy resources including hydrocarbons, hydropower, bio-energy, solar, wind, etc., where relevant including depth/height information on the extent of the resource.</skos:scopeNote>
+    <skos:altLabel>er</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ef">
+    <skos:prefLabel xml:lang="en">Environmental monitoring facilities</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Location and operation of environmental monitoring facilities includes observation and measurement of emissions, of the state of environmental media and of other ecosystem parameters (biodiversity, ecological conditions of vegetation, etc.) by or on behalf of public authorities.</skos:scopeNote>
+    <skos:altLabel>ef</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/hb">
+    <skos:prefLabel xml:lang="en">Habitats and biotopes</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical areas characterised by specific ecological conditions, processes, structure, and (life support) functions that physically support the organisms that live there. Includes terrestrial and aquatic areas distinguished by geographical, abiotic and biotic features, whether entirely natural or semi-natural.</skos:scopeNote>
+    <skos:altLabel>hb</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/hh">
+    <skos:prefLabel xml:lang="en">Human health and safety</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical distribution of dominance of pathologies (allergies, cancers, respiratory diseases, etc.), information indicating the effect on health (biomarkers, decline of fertility, epidemics) or well-being of humans (fatigue, stress, etc.) linked directly (air pollution, chemicals, depletion of the ozone layer, noise, etc.) or indirectly (food, genetically modified organisms, etc.) to the quality of the environment.</skos:scopeNote>
+    <skos:altLabel>hh</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/lu">
+    <skos:prefLabel xml:lang="en">Land use</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Territory characterised according to its current and future planned functional dimension or socio-economic purpose (e.g. residential, industrial, commercial, agricultural, forestry, recreational).</skos:scopeNote>
+    <skos:altLabel>lu</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/mr">
+    <skos:prefLabel xml:lang="en">Mineral resources</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Mineral resources including metal ores, industrial minerals, etc., where relevant including depth/height information on the extent of the resource.</skos:scopeNote>
+    <skos:altLabel>mr</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/nz">
+    <skos:prefLabel xml:lang="en">Natural risk zones</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Vulnerable areas characterised according to natural hazards (all atmospheric, hydrologic, seismic, volcanic and wildfire phenomena that, because of their location, severity, and frequency, have the potential to seriously affect society), e.g. floods, landslides and subsidence, avalanches, forest fires, earthquakes, volcanic eruptions.</skos:scopeNote>
+    <skos:altLabel>nz</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/of">
+    <skos:prefLabel xml:lang="en">Oceanographic geographical features</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical conditions of oceans (currents, salinity, wave heights, etc.).</skos:scopeNote>
+    <skos:altLabel>of</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/pd">
+    <skos:prefLabel xml:lang="en">Population distribution - demography</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical distribution of people, including population characteristics and activity levels, aggregated by grid, region, administrative unit or other analytical unit.</skos:scopeNote>
+    <skos:altLabel>pd</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/pf">
+    <skos:prefLabel xml:lang="en">Production and industrial facilities</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Industrial production sites, including installations covered by Council Directive 96/61/EC of 24 September 1996 concerning integrated pollution prevention and control (1) and water abstraction facilities, mining, storage sites.</skos:scopeNote>
+    <skos:altLabel>pf</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/sr">
+    <skos:prefLabel xml:lang="en">Sea regions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical conditions of seas and saline water bodies divided into regions and sub-regions with common characteristics.</skos:scopeNote>
+    <skos:altLabel>sr</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/so">
+    <skos:prefLabel xml:lang="en">Soil</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Soils and subsoil characterised according to depth, texture, structure and content of particles and organic material, stoniness, erosion, where appropriate mean slope and anticipated water storage capacity.</skos:scopeNote>
+    <skos:altLabel>so</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/sd">
+    <skos:prefLabel xml:lang="en">Species distribution</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical distribution of occurrence of animal and plant species aggregated by grid, region, administrative unit or other analytical unit.</skos:scopeNote>
+    <skos:altLabel>sd</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/su">
+    <skos:prefLabel xml:lang="en">Statistical units</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Units for dissemination or use of statistical information.</skos:scopeNote>
+    <skos:altLabel>su</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/us">
+    <skos:prefLabel xml:lang="en">Utility and governmental services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Includes utility facilities such as sewage, waste management, energy supply and water supply, administrative and social governmental services such as public administrations, civil protection sites, schools and hospitals.</skos:scopeNote>
+    <skos:altLabel>us</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/mf">
+    <skos:prefLabel xml:lang="en">Meteorological geographical features</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Weather conditions and their measurements; precipitation, temperature, evapotranspiration, wind speed and direction.</skos:scopeNote>
+    <skos:altLabel>mf</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+</rdf:RDF>
+

--- a/datafeeder/src/main/resources/inspire-themes-and-topiccategory.xsl
+++ b/datafeeder/src/main/resources/inspire-themes-and-topiccategory.xsl
@@ -1,0 +1,452 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common" xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                version="2.0" exclude-result-prefixes="#all">
+  <!--
+      Analyze topic categories and INSPIRE themes in the metadata record and suggest to add matching :
+
+      * missing topic category for current INSPIRE Themes
+      * missing INSPIRE theme for current topic category.
+      It makes easier to fill topic category according to INSPIRE themes and vice versa.
+
+      The process is disabled by default in GeoNetwork because related to INSPIRE only. See iso19139/suggest.xsl file for configuration
+
+      Mapping has been proposed by "Guide de saisie des éléments de métadonnées INSPIRE"
+
+  TODO : Add INSPIRE themes translations when metadata record is multilingual
+  -->
+  <xsl:import href="process-utility.xsl"/>
+
+  <xsl:variable name="inspire-th"
+                select="document(concat('file:///', replace(util:getConfigValue('codeListDir'), '\\', '/'), '/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf'))"/>
+
+  <xsl:variable name="itheme-topiccat-map">
+    <!-- <entry>
+        <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/1</itheme>
+        All
+        </entry>-->
+    <!--<entry>
+        <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/2</itheme>
+        All
+        </entry>-->
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/3</itheme>
+      <topiccat>location</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/4</itheme>
+      <topiccat>boundaries</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/5</itheme>
+      <topiccat>location</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/6</itheme>
+      <topiccat>planningCadastre</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/7</itheme>
+      <topiccat>transportation</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/8</itheme>
+      <topiccat>inlandWaters</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/9</itheme>
+      <topiccat>environment</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/10</itheme>
+      <topiccat>elevation</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/11</itheme>
+      <topiccat>imageryBaseMapsEarthCover</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/12</itheme>
+      <topiccat>imageryBaseMapsEarthCover</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/13</itheme>
+      <topiccat>geoscientificInformation</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/14</itheme>
+      <topiccat>boundaries</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/15</itheme>
+      <topiccat>structure</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/16</itheme>
+      <topiccat>geoscientificInformation</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/17</itheme>
+      <topiccat>planningCadastre</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/18</itheme>
+      <topiccat>health</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/19</itheme>
+      <topiccat>utilitiesCommunication</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/20</itheme>
+      <topiccat>structure</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/21</itheme>
+      <topiccat>structure</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/22</itheme>
+      <topiccat>farming</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/23</itheme>
+      <topiccat>society</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/24</itheme>
+      <topiccat>planningCadastre</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/25</itheme>
+      <topiccat>geoscientificInformation</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/26</itheme>
+      <topiccat>climatologyMeteorologyAtmosphere</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/27</itheme>
+      <topiccat>climatologyMeteorologyAtmosphere</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/28</itheme>
+      <topiccat>oceans</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/29</itheme>
+      <topiccat>oceans</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/30</itheme>
+      <topiccat>biota</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/31</itheme>
+      <topiccat>biota</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/32</itheme>
+      <topiccat>biota</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/33</itheme>
+      <topiccat>economy</topiccat>
+    </entry>
+    <entry>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/34</itheme>
+      <topiccat>economy</topiccat>
+    </entry>
+  </xsl:variable>
+
+  <!-- i18n information -->
+  <xsl:variable name="itheme-topiccat-loc">
+    <msg id="a" xml:lang="eng">INSPIRE Themes and/or topic categories found with missing matching
+      items. Run this suggestion to add all corresponding
+      values.
+    </msg>
+    <msg id="a" xml:lang="dut">INSPIRE Thema's gevonden met ontbrekende overeenkomstige
+       items. Voer deze suggestie uit om alle overeenkomstige items toe te voegen
+       waarden.
+    </msg>
+    <msg id="a" xml:lang="fre">Thèmes INSPIRE et/ou des catégories ont été trouvés avec des
+      correspondances manquantes. Lancer ce processus pour ajouter les correspondances.
+    </msg>
+  </xsl:variable>
+
+
+  <xsl:template name="list-inspire-themes-and-topiccategory">
+    <suggestion process="inspire-themes-and-topiccategory"/>
+  </xsl:template>
+
+  <!-- Analyze the metadata record and return available suggestion
+      for that process -->
+  <xsl:template name="analyze-inspire-themes-and-topiccategory">
+    <xsl:param name="root"/>
+    <xsl:variable name="lang" select="if (normalize-space($root//gmd:MD_Metadata/gmd:language/gco:CharacterString
+            |$root//gmd:MD_Metadata/gmd:language/gmd:LanguageCode/@codeListValue)='')
+            then 'en'
+            else
+            substring($root//gmd:MD_Metadata/gmd:language/gco:CharacterString
+            |$root//gmd:MD_Metadata/gmd:language/gmd:LanguageCode/@codeListValue, 1, 2)
+            "/>
+    <xsl:variable name="mappingAvailable">
+      <!-- For all theme in metadata language -->
+      <xsl:for-each
+        select="$inspire-th//skos:Concept[skos:prefLabel/@xml:lang = normalize-space($lang)]">
+        <xsl:variable name="themeLabel"
+                      select="skos:prefLabel[@xml:lang = normalize-space($lang)]"/>
+
+        <!-- if in metadata -->
+        <xsl:if test="$root//gmd:keyword[gco:CharacterString = $themeLabel]">
+          <xsl:variable name="themeId" select="@rdf:about"/>
+          <!-- and corresponding topic cat does not exist in metadata -->
+          <xsl:for-each select="$itheme-topiccat-map/entry[itheme=$themeId]/topiccat">
+            <xsl:variable name="tcId" select="."/>
+            <xsl:if
+              test="count($root//gmd:topicCategory[gmd:MD_TopicCategoryCode = normalize-space($tcId)]) != 1">
+              YES
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:if>
+      </xsl:for-each>
+      <xsl:for-each select="$root//gmd:topicCategory/gmd:MD_TopicCategoryCode">
+        <xsl:variable name="tcId" select="."/>
+
+        <xsl:for-each select="$itheme-topiccat-map/entry[topiccat = $tcId]/itheme">
+          <xsl:variable name="themeId" select="."/>
+          <xsl:variable name="themeLabel"
+                        select="$inspire-th//skos:Concept[@rdf:about = $themeId]/skos:prefLabel[@xml:lang = normalize-space($lang)]"/>
+
+          <xsl:if test="count($root//gmd:keyword[gco:CharacterString = $themeLabel]) != 1">
+            YES
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:for-each>
+    </xsl:variable>
+
+
+    <xsl:if test="normalize-space($mappingAvailable)!=''">
+      <suggestion process="inspire-themes-and-topiccategory" category="keyword" target="keyword">
+        <name>
+          <xsl:value-of select="geonet:i18n($itheme-topiccat-loc, 'a', $guiLang)"/>
+        </name>
+        <operational>true</operational>
+        <form/>
+      </suggestion>
+    </xsl:if>
+  </xsl:template>
+
+
+  <xsl:template
+    match="gmd:identificationInfo/*"
+    priority="2">
+
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <!-- Copy all elements from AbstractMD_IdentificationType-->
+      <xsl:copy-of
+        select="gmd:citation
+                |gmd:abstract
+                |gmd:purpose
+                |gmd:credit
+                |gmd:status
+                |gmd:pointOfContact
+                |gmd:resourceMaintenance
+                |gmd:graphicOverview
+                |gmd:resourceFormat
+                |gmd:descriptiveKeywords[not(contains(*/gmd:thesaurusName[1]/gmd:CI_Citation/gmd:title/gco:CharacterString, 'INSPIRE'))]"/>
+
+      <!-- Add INSPIRE themes according to topic category. -->
+      <xsl:variable name="existingInspireThemes"
+                    select="gmd:descriptiveKeywords[contains(*/gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, 'INSPIRE')]"/>
+
+      <!-- Default language is english if not set
+          else use the 2 first letter of the language code (skos xml:lang attribute is ISO 2 letters code)
+      -->
+      <xsl:variable name="lang" select="if (normalize-space(//gmd:MD_Metadata/gmd:language/gco:CharacterString
+                |//gmd:MD_Metadata/gmd:language/gmd:LanguageCode/@codeListValue)='')
+                then 'en'
+                else
+                substring(//gmd:MD_Metadata/gmd:language/gco:CharacterString
+                |//gmd:MD_Metadata/gmd:language/gmd:LanguageCode/@codeListValue, 1, 2)
+                "/>
+      <xsl:variable name="mdKeywords" select="gmd:descriptiveKeywords"/>
+      <xsl:variable name="missing-inspirethemes">
+        <xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
+          <xsl:variable name="tcId" select="."/>
+
+          <xsl:for-each select="$itheme-topiccat-map/entry[topiccat = $tcId]/itheme">
+            <xsl:variable name="themeId" select="."/>
+            <xsl:variable name="themeLabel"
+                          select="$inspire-th//skos:Concept[@rdf:about = $themeId]/skos:prefLabel[@xml:lang = normalize-space($lang)]"/>
+
+            <xsl:if test="count($mdKeywords//gmd:keyword[gco:CharacterString = $themeLabel]) != 1">
+              <elem>
+                <xsl:value-of select="$themeLabel"/>
+              </elem>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:choose>
+        <xsl:when test="normalize-space($missing-inspirethemes) != ''">
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <xsl:copy-of select="$existingInspireThemes/gmd:MD_Keywords/gmd:keyword"/>
+              <xsl:for-each-group select="exslt:node-set($missing-inspirethemes)//elem"
+                                  group-by=".">
+                <gmd:keyword>
+                  <!-- TODO : add translation according to gmd:locale-->
+                  <gco:CharacterString>
+                    <xsl:value-of select="."/>
+                  </gco:CharacterString>
+                </gmd:keyword>
+              </xsl:for-each-group>
+
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode
+                  codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+                  codeListValue="theme"/>
+              </gmd:type>
+              <xsl:choose>
+                <xsl:when test="$existingInspireThemes/gmd:MD_Keywords/gmd:thesaurusName">
+                  <xsl:copy-of
+                    select="$existingInspireThemes[1]/gmd:MD_Keywords/gmd:thesaurusName"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <gmd:thesaurusName>
+                    <gmd:CI_Citation>
+                      <gmd:title>
+                        <gco:CharacterString>
+                          <xsl:value-of select="$inspire-th//skos:ConceptScheme/dc:title"/>
+                        </gco:CharacterString>
+                      </gmd:title>
+                      <gmd:date>
+                        <gmd:CI_Date>
+                          <gmd:date>
+                            <gco:Date>
+                              <xsl:value-of
+                                select="$inspire-th//skos:ConceptScheme/dcterms:issued"/>
+                            </gco:Date>
+                          </gmd:date>
+                          <gmd:dateType>
+                            <gmd:CI_DateTypeCode
+                              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                              codeListValue="publication"/>
+                          </gmd:dateType>
+                        </gmd:CI_Date>
+                      </gmd:date>
+                    </gmd:CI_Citation>
+                  </gmd:thesaurusName>
+                </xsl:otherwise>
+              </xsl:choose>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="$existingInspireThemes"/>
+        </xsl:otherwise>
+      </xsl:choose>
+
+      <xsl:copy-of
+        select="gmd:resourceSpecificUsage
+                |gmd:resourceConstraints
+                |gmd:aggregationInfo"/>
+      <xsl:copy-of
+        select="gmd:spatialRepresentationType
+                |gmd:spatialResolution
+                |gmd:language
+                |gmd:characterSet
+                |gmd:topicCategory"/>
+
+      <!-- Add topic categories according to INSPIRE themes. -->
+      <xsl:variable name="ident" select="."/>
+      <xsl:variable name="missing-topiccat">
+        <xsl:for-each
+          select="$inspire-th//skos:Concept[skos:prefLabel/@xml:lang = normalize-space($lang)]">
+          <xsl:variable name="themeLabel"
+                        select="skos:prefLabel[@xml:lang = normalize-space($lang)]"/>
+          <!-- if in metadata -->
+          <xsl:if test="$ident//gmd:keyword[gco:CharacterString = $themeLabel]">
+            <xsl:variable name="themeId" select="@rdf:about"/>
+            <!-- and corresponding topic cat does not exist in metadata -->
+            <xsl:for-each select="$itheme-topiccat-map/entry[itheme=$themeId]/topiccat">
+              <xsl:variable name="tcId" select="."/>
+              <xsl:if
+                test="count($ident//gmd:topicCategory[gmd:MD_TopicCategoryCode = normalize-space($tcId)]) != 1">
+                <elem>
+                  <xsl:value-of select="$tcId"/>
+                </elem>
+              </xsl:if>
+            </xsl:for-each>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:for-each-group select="exslt:node-set($missing-topiccat)//elem" group-by=".">
+        <gmd:topicCategory>
+          <gmd:MD_TopicCategoryCode>
+            <xsl:value-of select="."/>
+          </gmd:MD_TopicCategoryCode>
+        </gmd:topicCategory>
+      </xsl:for-each-group>
+
+      <xsl:copy-of
+        select="gmd:environmentDescription
+                |gmd:extent
+                |gmd:supplementalInformation"/>
+
+
+      <!-- Service -->
+      <xsl:copy-of
+        select="srv:*
+                "/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+
+</xsl:stylesheet>

--- a/datafeeder/src/main/resources/inspire-themes-and-topiccategory.xsl
+++ b/datafeeder/src/main/resources/inspire-themes-and-topiccategory.xsl
@@ -23,7 +23,8 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:exslt="http://exslt.org/common" xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:exslt="http://exslt.org/common" 
+                xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -32,7 +33,8 @@
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
-                version="2.0" exclude-result-prefixes="#all">
+                version="2.0" 
+                exclude-result-prefixes="#all">
   <!--
       Analyze topic categories and INSPIRE themes in the metadata record and suggest to add matching :
 

--- a/datafeeder/src/main/resources/inspire-themes-and-topiccategory.xsl
+++ b/datafeeder/src/main/resources/inspire-themes-and-topiccategory.xsl
@@ -50,8 +50,10 @@
   -->
   <xsl:import href="process-utility.xsl"/>
 
+<!--   <xsl:variable name="inspire-th" -->
+<!--                 select="document(concat('file:///', replace(util:getConfigValue('codeListDir'), '\\', '/'), '/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf'))"/> -->
   <xsl:variable name="inspire-th"
-                select="document(concat('file:///', replace(util:getConfigValue('codeListDir'), '\\', '/'), '/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf'))"/>
+                select="document('external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf')"/>
 
   <xsl:variable name="itheme-topiccat-map">
     <!-- <entry>

--- a/datafeeder/src/main/resources/process-utility.xsl
+++ b/datafeeder/src/main/resources/process-utility.xsl
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:java="java:org.fao.geonet.util.XslUtil"
+                xmlns:exslt="http://exslt.org/common" xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                version="2.0" exclude-result-prefixes="exslt java">
+
+  <!-- Language of the GUI -->
+  <xsl:param name="guiLang" select="'eng'"/>
+
+  <!-- Webapp name-->
+  <xsl:param name="baseUrl" select="''"/>
+
+  <!-- Catalog URL from protocol to lang -->
+  <xsl:param name="catalogUrl" select="''"/>
+  <xsl:param name="nodeId" select="''"/>
+
+  <!-- Search for any of the searchStrings provided -->
+  <xsl:function name="geonet:parseBoolean" as="xs:boolean">
+    <xsl:param name="arg"/>
+    <xsl:value-of
+      select="if ($arg='on' or $arg=true() or $arg='true' or $arg='1') then true() else false()"/>
+  </xsl:function>
+
+  <!-- Return the message identified by the id in the required language
+  or return the english message if not found. -->
+  <xsl:function name="geonet:i18n" as="xs:string">
+    <xsl:param name="loc"/>
+    <xsl:param name="id"/>
+    <xsl:param name="lang"/>
+    <xsl:value-of
+      select="if ($loc/msg[@id=$id and @xml:lang=$lang]) then $loc/msg[@id=$id and @xml:lang=$lang] else $loc/msg[@id=$id and @xml:lang='en']"/>
+  </xsl:function>
+
+  <!--
+  Retrive a WMS capabilities document.
+  -->
+  <xsl:function name="geonet:get-wms-capabilities" as="node()">
+    <xsl:param name="url" as="xs:string"/>
+    <xsl:param name="version" as="xs:string"/>
+
+    <xsl:copy-of
+      select="geonet:get-wxs-capabilities($url, 'WMS', $version)"/>
+
+  </xsl:function>
+
+  <xsl:function name="geonet:get-wxs-capabilities" as="node()">
+    <xsl:param name="url" as="xs:string"/>
+    <xsl:param name="type" as="xs:string"/>
+    <xsl:param name="version" as="xs:string"/>
+    <xsl:variable name="sep" select="if (contains($url, '?')) then '&amp;' else '?'"/>
+
+    <xsl:variable name="proxyhost"><xsl:value-of select="java:getSettingValue('system/proxy/host')"/></xsl:variable>
+    <xsl:variable name="baseHost"><xsl:value-of select="java:getSettingValue('system/server/host')"/></xsl:variable>
+    <xsl:variable name="protocol"><xsl:value-of select="java:getSettingValue('system/server/protocol')"/></xsl:variable>
+    <xsl:variable name="basePort">
+      <xsl:choose>
+        <xsl:when test="$protocol = 'https'">
+          <xsl:value-of select="java:getSettingValue('system/server/securePort')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="java:getSettingValue('system/server/port')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+        
+    <xsl:variable name="fullUrl"><xsl:value-of select="concat($url, $sep, 'SERVICE=', $type, '&amp;VERSION=', $version, '&amp;REQUEST=GetCapabilities')"/></xsl:variable>
+
+    <xsl:copy-of select="java:getUrlContent($fullUrl)"/>
+
+  </xsl:function>
+
+  <!-- Create a GetMap request for the layer which could be used to set a thumbnail.
+  TODO : add projection, width, heigth
+  -->
+  <xsl:function name="geonet:get-wms-thumbnail-url" as="xs:string">
+    <xsl:param name="url" as="xs:string"/>
+    <xsl:param name="version" as="xs:string"/>
+    <xsl:param name="layer" as="xs:string"/>
+    <xsl:param name="bbox" as="xs:string"/>
+
+    <xsl:value-of
+      select="concat($url, '?SERVICE=WMS&amp;VERSION=', $version, '&amp;REQUEST=GetMap&amp;SRS=EPSG:4326&amp;WIDTH=400&amp;HEIGHT=400&amp;FORMAT=image/png&amp;STYLES=&amp;LAYERS=', $layer, '&amp;BBOX=', $bbox)"/>
+
+  </xsl:function>
+
+
+  <!-- Create an ISO 19139 extent fragment -->
+  <xsl:function name="geonet:make-iso-extent" as="node()">
+    <xsl:param name="w" as="xs:string"/>
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:param name="e" as="xs:string"/>
+    <xsl:param name="n" as="xs:string"/>
+    <xsl:param name="description" as="xs:string?"/>
+
+    <gmd:EX_Extent>
+      <xsl:if test="normalize-space($description)!=''">
+        <gmd:description>
+          <gco:CharacterString>
+            <xsl:value-of select="$description"/>
+          </gco:CharacterString>
+        </gmd:description>
+      </xsl:if>
+      <gmd:geographicElement>
+        <gmd:EX_GeographicBoundingBox>
+          <gmd:westBoundLongitude>
+            <gco:Decimal>
+              <xsl:value-of select="$w"/>
+            </gco:Decimal>
+          </gmd:westBoundLongitude>
+          <gmd:eastBoundLongitude>
+            <gco:Decimal>
+              <xsl:value-of select="$e"/>
+            </gco:Decimal>
+          </gmd:eastBoundLongitude>
+          <gmd:southBoundLatitude>
+            <gco:Decimal>
+              <xsl:value-of select="$s"/>
+            </gco:Decimal>
+          </gmd:southBoundLatitude>
+          <gmd:northBoundLatitude>
+            <gco:Decimal>
+              <xsl:value-of select="$n"/>
+            </gco:Decimal>
+          </gmd:northBoundLatitude>
+        </gmd:EX_GeographicBoundingBox>
+      </gmd:geographicElement>
+    </gmd:EX_Extent>
+  </xsl:function>
+
+</xsl:stylesheet>

--- a/datafeeder/src/main/resources/process-utility.xsl
+++ b/datafeeder/src/main/resources/process-utility.xsl
@@ -60,40 +60,40 @@
   <!--
   Retrive a WMS capabilities document.
   -->
-  <xsl:function name="geonet:get-wms-capabilities" as="node()">
-    <xsl:param name="url" as="xs:string"/>
-    <xsl:param name="version" as="xs:string"/>
+<!--   <xsl:function name="geonet:get-wms-capabilities" as="node()"> -->
+<!--     <xsl:param name="url" as="xs:string"/> -->
+<!--     <xsl:param name="version" as="xs:string"/> -->
 
-    <xsl:copy-of
-      select="geonet:get-wxs-capabilities($url, 'WMS', $version)"/>
+<!--     <xsl:copy-of -->
+<!--       select="geonet:get-wxs-capabilities($url, 'WMS', $version)"/> -->
 
-  </xsl:function>
+<!--   </xsl:function> -->
 
-  <xsl:function name="geonet:get-wxs-capabilities" as="node()">
-    <xsl:param name="url" as="xs:string"/>
-    <xsl:param name="type" as="xs:string"/>
-    <xsl:param name="version" as="xs:string"/>
-    <xsl:variable name="sep" select="if (contains($url, '?')) then '&amp;' else '?'"/>
+<!--   <xsl:function name="geonet:get-wxs-capabilities" as="node()"> -->
+<!--     <xsl:param name="url" as="xs:string"/> -->
+<!--     <xsl:param name="type" as="xs:string"/> -->
+<!--     <xsl:param name="version" as="xs:string"/> -->
+<!--     <xsl:variable name="sep" select="if (contains($url, '?')) then '&amp;' else '?'"/> -->
 
-    <xsl:variable name="proxyhost"><xsl:value-of select="java:getSettingValue('system/proxy/host')"/></xsl:variable>
-    <xsl:variable name="baseHost"><xsl:value-of select="java:getSettingValue('system/server/host')"/></xsl:variable>
-    <xsl:variable name="protocol"><xsl:value-of select="java:getSettingValue('system/server/protocol')"/></xsl:variable>
-    <xsl:variable name="basePort">
-      <xsl:choose>
-        <xsl:when test="$protocol = 'https'">
-          <xsl:value-of select="java:getSettingValue('system/server/securePort')"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="java:getSettingValue('system/server/port')"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
+<!--     <xsl:variable name="proxyhost"><xsl:value-of select="java:getSettingValue('system/proxy/host')"/></xsl:variable> -->
+<!--     <xsl:variable name="baseHost"><xsl:value-of select="java:getSettingValue('system/server/host')"/></xsl:variable> -->
+<!--     <xsl:variable name="protocol"><xsl:value-of select="java:getSettingValue('system/server/protocol')"/></xsl:variable> -->
+<!--     <xsl:variable name="basePort"> -->
+<!--       <xsl:choose> -->
+<!--         <xsl:when test="$protocol = 'https'"> -->
+<!--           <xsl:value-of select="java:getSettingValue('system/server/securePort')"/> -->
+<!--         </xsl:when> -->
+<!--         <xsl:otherwise> -->
+<!--           <xsl:value-of select="java:getSettingValue('system/server/port')"/> -->
+<!--         </xsl:otherwise> -->
+<!--       </xsl:choose> -->
+<!--     </xsl:variable> -->
         
-    <xsl:variable name="fullUrl"><xsl:value-of select="concat($url, $sep, 'SERVICE=', $type, '&amp;VERSION=', $version, '&amp;REQUEST=GetCapabilities')"/></xsl:variable>
+<!--     <xsl:variable name="fullUrl"><xsl:value-of select="concat($url, $sep, 'SERVICE=', $type, '&amp;VERSION=', $version, '&amp;REQUEST=GetCapabilities')"/></xsl:variable> -->
 
-    <xsl:copy-of select="java:getUrlContent($fullUrl)"/>
+<!--     <xsl:copy-of select="java:getUrlContent($fullUrl)"/> -->
 
-  </xsl:function>
+<!--   </xsl:function> -->
 
   <!-- Create a GetMap request for the layer which could be used to set a thumbnail.
   TODO : add projection, width, heigth

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapperTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapperTest.java
@@ -61,8 +61,9 @@ public class GeorchestraTemplateMapperTest {
     @Test
     public void loadTransform_URI_not_provided_returns_default() {
         config.setTemplateTransform(null);
-        String xslContents = mapper.loadTransform();
-        String expected = mapper.loadDefaultTransform();
+        URI xslContents = mapper.resolveTransformURI();
+        URI expected = mapper.getDefaultTransformURI();
+
         assertEquals(expected, xslContents);
     }
 
@@ -71,8 +72,8 @@ public class GeorchestraTemplateMapperTest {
         URI uri = getClass().getResource("just_id_transform.xsl").toURI();
         config.setTemplateTransform(uri);
 
-        String defaultXSL = mapper.loadDefaultTransform();
-        String actualXSL = mapper.loadTransform();
+        URI defaultXSL = mapper.getDefaultTransformURI();
+        URI actualXSL = mapper.resolveTransformURI();
         assertNotNull(actualXSL);
         assertNotEquals(defaultXSL, actualXSL);
     }


### PR DESCRIPTION
WIP.

I've got as far as importing `inspire-themes-and-topiccategory.xsl` from `datafeeder/src/main/resources/default_iso_2005_gmd.xsl` (which carries over `process-utility.xsl` and `httpinspireeceuropaeutheme-theme.rdf`:

* Resolve XSL using URI to allow engine to resolve includes/imports
* Add thesaurus `httpinspireeceuropaeutheme-theme.rdf`
    Add the `httpinspireeceuropaeutheme-theme.rdf` thesaurus, required
    by `inspire-themes-and-topiccategory.xsl`, and adapt the path where it's
    looked up on, as a relative path, to avoid an error due to a non
    existent Java function `util:getConfigValue()` (from GN's `XslUtil`).
* Coment out XSL functions requiring custom Java code
    - Convert `default_iso_2005_gmd.xsl` from XSL 1.0 to XSL 2.0.
    - Comment out functions defined in `process-utility.xsl` (from
      GeoNetwork) that require custom Java code and are not used by
    `inspire-themes-and-topiccategory.xsl`.
* Initial import of GN's INSPIRE topic categories XSL

But I don't really know what's expected from here, what should it be producing/what should I be checking for.

@fvanderbiest maybe someone with more GN/metadata knowledge can give a hand?