### PR TITLE
debianize datafeeder & datafeeder-ui (#3405)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ deb-build-geowebcache: war-build-geowebcache
 	mvn package deb:package -pl geowebcache-webapp -PdebianPackage -DskipTests -Dfmt.skip=true ${DEPLOY_OPTS}
 
 deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver deb-build-geowebcache
-	mvn package deb:package -pl atlas,cas-server-webapp,security-proxy,header,mapfishapp,extractorapp,analytics,console,geonetwork/web -PdebianPackage -DskipTests ${DEPLOY_OPTS}
+	mvn package deb:package -pl atlas,cas-server-webapp,datafeeder,datafeeder-ui,security-proxy,header,mapfishapp,extractorapp,analytics,console,geonetwork/web -PdebianPackage -DskipTests ${DEPLOY_OPTS}
 
 # Base geOrchestra common modules
 build-deps:

--- a/datafeeder-ui/pom.xml
+++ b/datafeeder-ui/pom.xml
@@ -87,4 +87,28 @@
           </plugin>
       </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>debianPackage</id>
+      <build>
+        <finalName>import</finalName>
+         <plugins>
+                <plugin>
+                    <groupId>net.sf.debian-maven</groupId>
+                    <artifactId>debian-maven-plugin</artifactId>
+                    <version>1.0.6</version>
+                    <configuration>
+                        <packageName>georchestra-datafeeder-ui</packageName>
+                        <packageDescription>geOrchestra Data Feeder (UI)</packageDescription>
+                        <packageVersion>${project.packageVersion}</packageVersion>
+                        <projectOrganization>geOrchestra</projectOrganization>
+                        <maintainerName>PSC</maintainerName>
+                        <maintainerEmail>psc@georchestra.org</maintainerEmail>
+                        <excludeAllDependencies>true</excludeAllDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+  </profiles>
 </project>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -530,6 +530,113 @@
   </build>
   <profiles>
     <profile>
+      <id>debianPackage</id>
+      <build>
+        <finalName>${project.artifactId}</finalName>
+         <plugins>
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-plugin</artifactId>
+                    <version>1.11.2</version>
+                    <configuration>
+                        <checkoutDirectory>${project.build.directory}/deb/etc/georchestra</checkoutDirectory>
+                        <connectionUrl>scm:git:https://github.com/georchestra/datadir.git</connectionUrl>
+                        <pushChanges>false</pushChanges>
+                        <scmVersion>${packageDatadirScmVersion}</scmVersion>
+                        <scmVersionType>branch</scmVersionType>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>checkout-deb-default-datadir</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>checkout</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-resources-plugin</artifactId>
+                  <version>2.3</version>
+                  <executions>
+                    <execution>
+                      <id>copy-deb-resources</id>
+                      <phase>process-resources</phase>
+                      <goals><goal>copy-resources</goal></goals>
+                      <configuration>
+                        <overwrite>true</overwrite>
+                        <outputDirectory>${project.build.directory}/deb</outputDirectory>
+                        <resources>
+                          <resource>
+                            <directory>src/deb/resources</directory>
+                          </resource>
+                        </resources>
+                      </configuration>
+                    </execution>
+                  </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.7</version>
+                    <executions>
+                        <execution>
+                            <id>remove-useless-directories</id>
+                            <phase>package</phase>
+                            <configuration>
+                                <target>
+                                    <delete includeemptydirs="true">
+                                        <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
+                                            <include name="**/*" />
+                                            <exclude name="datafeeder/**" />
+                                        </fileset>
+                                    </delete>
+                                </target>
+                            </configuration>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>fix-permissions</id>
+                            <phase>package</phase>
+                            <configuration>
+                                <target>
+                                    <chmod perm="ugo+x">
+                                        <fileset dir="${project.basedir}/target/deb">
+                                            <include name="**/bin/**"/>
+                                            <include name="**/sbin/**"/>
+                                            <include name="DEBIAN/post*"/>
+                                            <include name="DEBIAN/pre*"/>
+                                        </fileset>
+                                    </chmod>
+                                </target>
+                            </configuration>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>net.sf.debian-maven</groupId>
+                    <artifactId>debian-maven-plugin</artifactId>
+                    <version>1.0.6</version>
+                    <configuration>
+                        <packageName>georchestra-datafeeder</packageName>
+                        <packageDescription>geOrchestra Data Feeder</packageDescription>
+                        <packageVersion>${project.packageVersion}</packageVersion>
+                        <projectOrganization>geOrchestra</projectOrganization>
+                        <maintainerName>PSC</maintainerName>
+                        <maintainerEmail>psc@georchestra.org</maintainerEmail>
+                        <excludeAllDependencies>true</excludeAllDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    <profile>
       <id>docker</id>
       <properties>
         <dockerImageName>georchestra/${project.artifactId}:${project.version}</dockerImageName>

--- a/datafeeder/src/deb/resources/etc/systemd/system/datafeeder.service
+++ b/datafeeder/src/deb/resources/etc/systemd/system/datafeeder.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=geOrchestra datafeeder backend
+After=syslog.target
+
+[Service]
+User=www-data
+ExecStart=/usr/bin/java -Dserver.port=8480 -jar /usr/share/lib/georchestra-datafeeder/datafeeder-bin.jar
+SuccessExitStatus=143
+StandardOutput=append:/tmp/datafeeder.log
+StandardError=append:/tmp/datafeeder.log
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
a bit WIP, but produces two debian packages:
- `datafeeder/target/georchestra-datafeeder_21.0+202106102113-1_all.deb`
-  `datafeeder-ui/target/georchestra-datafeeder-ui_99.master.202106101806~ba0ad6e-1_all.deb`

first one ships the backend and the datadir subdir, + a systemd service. versioning is wrong since the `<parent>` bit was commented out in b2495efe it cant reach `project.packageVersion` defined in the parent. @groldan, is it still necessary ?

second one ships `import.war`.

untested at runtime yet, but will allow improving the integration discussed in #3405, and rework what was done in georchestra/ansible#77

at some point will `datafeeder-ui/pom.xml` point to a fixed commit in the https://github.com/georchestra/geonetwork-ui remote repo ? otherwise the build isnt much reproducible... (yeah i know its still wip :)