### PR TITLE
sp - fixing failing tests on non-existing dns records (#3429)

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/permissions/ResolverDelegate.java
+++ b/security-proxy/src/main/java/org/georchestra/security/permissions/ResolverDelegate.java
@@ -1,0 +1,8 @@
+package org.georchestra.security.permissions;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public interface ResolverDelegate {
+    public InetAddress[] resolve(String host) throws UnknownHostException;
+}


### PR DESCRIPTION
1. don't fail if we build a urimatcher from a hostname which does not
   resolve. Instead it will initialize a urimatcher which won't be used
   (because containing any host addresses)
2. introducing a ResolverDelegate so that we can fake the DNS resolution
   and are able to describe our test scenario without relying on
   external systems (DNS).

Note: I try {} caught {} the unknownhostexception, but maybe it would make
more sense to throw a runtimeException if caught to keep a behaviour
coherent with what we have currently.

tests: `mvn clean test` OK.
