### PR TITLE
[datafeeder] Allow overriding native CRS on getBounds/getSampleFeature

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -129,6 +129,11 @@ paths:
       operationId: getSampleFeature
       description: Obtain a sample dataset feature in GeoJSON format, optionally specifying a feature index, crs, and/or dataset's character encoding.
                    The response encoding is always UTF-8. The 'encoding' parameter can be used to force reading the native data in a different charset.
+                   The returned geometry CRS is controlled by the "srs", and "srsOverride" query parameters.
+                   If none is provided, the geometry is returned as-is, in the dataset's native CRS (possibly null).
+                   The "srsOverride" parameter allows to override the dataset's native CRS, which also means assuming a native CRS when the
+                   dataset didn't provide a native CRS (e.g. a shapefile uploaded without .prj side-car file).
+                   The "srs" parameter specifies the output geometry CRS. The geometry will be reprojected from the source CRS to the output CRS.
       parameters:
       - $ref: '#/components/parameters/jobId'
       - $ref: '#/components/parameters/typeName'
@@ -152,13 +157,15 @@ paths:
         required: false
         schema:
           type: string
-      - name: srs_reproject
+      - name: srsOverride
         in: query
-        description: Optional, whether to reproject from the native CRS to the one provided in the srs parameter. If false or not provided, the srs parameter overrides the native CRS
+        description: Optional, EPSG SRS used to override the native CRS, or assume a native SRS when the native CRS is unknown (for example, a shapefile uploaded without .prj side-car file).
+                     This allows to request a feature using a source CRS for datasets that do not specify a native CRS, and still get a reprojected response to
+                     another CRS in combination with the "srs" parameter.
         required: false
         schema:
-          type: boolean
-          default: false
+          type: string
+        example: EPSG:4326
       responses:
         202:
           $ref: '#/components/responses/SampleFeatureResponse'
@@ -175,22 +182,29 @@ paths:
         - File Upload
       operationId: getBounds
       description: Get the bounding box of the dataset, optionally indicating the CRS and whether to reproject from the native CRS to the new one
+                   The returned geometry CRS is controlled by the "srs", and "srsOverride" query parameters.
+                   If none is provided, the geometry is returned as-is, in the dataset's native CRS (possibly null).
+                   The "srsOverride" parameter allows to override the dataset's native CRS, which also means assuming a native CRS when the
+                   dataset didn't provide a native CRS (e.g. a shapefile uploaded without .prj side-car file).
+                   The "srs" parameter specifies the output geometry CRS. The geometry will be reprojected from the source CRS to the output CRS.
       parameters:
       - $ref: '#/components/parameters/jobId'
       - $ref: '#/components/parameters/typeName'
       - name: srs
         in: query
-        description: Optional, coordinate reference system (e.g. 'EPSG:3857')
+        description: Optional, output coordinate reference system (e.g. 'EPSG:3857')
         required: false
         schema:
           type: string
-      - name: srs_reproject
+      - name: srsOverride
         in: query
-        description: Optional, whether to reproject from the native CRS to the one provided in the srs parameter. If false or not provided, the srs parameter overrides the native CRS
+        description: Optional, EPSG SRS used to override the native CRS, or assume a native SRS when the native CRS is unknown (for example, a shapefile uploaded without .prj side-car file).
+                     This allows to request the dataset bounds using a user defined native CRS for datasets that do not specify a native CRS, 
+                     and still get a reprojected response to another CRS in combination with the "srs" parameter.
         required: false
         schema:
-          type: boolean
-          default: false
+          type: string
+        example: EPSG:4326
       responses:
         202:
           $ref: '#/components/responses/BoundingBoxResponse'

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/BoundingBoxMetadata.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/BoundingBoxMetadata.java
@@ -20,12 +20,17 @@ package org.georchestra.datafeeder.model;
 
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
+import javax.persistence.Transient;
 
 import lombok.Data;
 
 @Data
 @Embeddable
 public class BoundingBoxMetadata {
+
+    private @Transient CoordinateReferenceSystemMetadata nativeCrs;
+    private @Transient boolean reprojected;
+
     @Embedded
     private CoordinateReferenceSystemMetadata crs;
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/DataUploadService.java
@@ -18,6 +18,7 @@
  */
 package org.georchestra.datafeeder.service;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,6 +36,7 @@ import org.georchestra.datafeeder.model.DatasetUploadState;
 import org.georchestra.datafeeder.model.JobStatus;
 import org.georchestra.datafeeder.model.UserInfo;
 import org.georchestra.datafeeder.repository.DataUploadJobRepository;
+import org.georchestra.datafeeder.service.DatasetsService.FeatureResult;
 import org.opengis.feature.simple.SimpleFeature;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
@@ -102,19 +104,20 @@ public class DataUploadService {
     }
 
     public SimpleFeature sampleFeature(@NonNull UUID jobId, @NonNull String typeName, int featureN, Charset encoding,
-            String srs, boolean srsReproject) {
+            String srs, String nativeSrsOverride) throws IOException {
 
         DatasetUploadState dataset = getDataset(jobId, typeName);
         Path path = Paths.get(dataset.getAbsolutePath());
-        return datasetsService.getFeature(path, typeName, encoding, featureN, srs, srsReproject);
+        FeatureResult result = datasetsService.getFeature(path, typeName, encoding, featureN, srs, nativeSrsOverride);
+        return result.getFeature();
     }
 
-    public BoundingBoxMetadata computeBounds(@NonNull UUID jobId, @NonNull String typeName, String srs,
-            boolean reproject) {
+    public BoundingBoxMetadata computeBounds(@NonNull UUID jobId, @NonNull String typeName, String targetSrs,
+            String nativeSrsOverride) throws IOException {
 
         DatasetUploadState dataset = getDataset(jobId, typeName);
         Path path = Paths.get(dataset.getAbsolutePath());
-        return datasetsService.getBounds(path, typeName, srs, reproject);
+        return datasetsService.getBounds(path, typeName, targetSrs, nativeSrsOverride);
     }
 
     private DatasetUploadState getDataset(UUID jobId, String typeName) {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/FileUploadApiControllerTest.java
@@ -410,8 +410,10 @@ public class FileUploadApiControllerTest {
                 dataset.getEncoding());
         // correct chinese_poly's dbf charset: GB18030, NAME: 黑龙江省
         final String encoding = "GB18030";
+        final String targetSrs = null;
+        final String sourceSrs = null;
         ResponseEntity<Object> response = controller.getSampleFeature(upload.getJobId(), "chinese_poly", 0, encoding,
-                null, false);
+                targetSrs, sourceSrs);
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
         String geoJsonFeature = response.getBody().toString();
@@ -439,8 +441,10 @@ public class FileUploadApiControllerTest {
         assertEquals("encoding from .cpg file not detected", "GB18030", dataset.getEncoding());
 
         final String encodingParam = null;
+        final String targetSrs = null;
+        final String sourceSrs = null;
         ResponseEntity<Object> response = controller.getSampleFeature(upload.getJobId(), "chinese_poly", 0,
-                encodingParam, null, false);
+                encodingParam, targetSrs, sourceSrs);
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
         String geoJsonFeature = response.getBody().toString();


### PR DESCRIPTION
When an uploaded shapefile doesn't provide a .prj file, reprojecting to
the target CRS is impossible.

This API change allows the getBounds and getSampleFeature end points to
provide a "srsOverride" query parameter in addition to the "srs"
parameter, in order to define the source and target CRS for the
reprojection.

It also simplifies the semantics by removing the "srs_reproject"
parameter:

- If the "srs" parameter is provided, reprojection DOES HAPPEN.
- If there's no native CRS, it can be overridden with the "srsOverride"
  parameter. Otherwise, an error is thrown since it's not possible to
reproject from an unknown CRS.

Client-side logic shall be updated to:

For:

`GET /upload/{jobId}/{typeName}/bounds`
`GET /upload/{jobId}/{typeName}/sampleFeature`

Based on `GET /upload/{jobId}`'s:

* If `datasets[0].nativeBounds.crs` OR `datasets[0].nativeBounds.crs.srs` is `null`, then provide a `srsOverride` parameter.
* `GET /upload/{jobId}/{typeName}/bounds?srsOverride=EPSG:4326&srs=EPSG:3857` ignores the native CRS and interprets the native dataset as `EPSG:4326`, then reprojects to `EPSG:3857`
* `GET /upload/{jobId}/{typeName}/bounds` also returns the native CRS, so the returned `BoundingBox`'s `crs` or `crs.srs` could be `null`. In which case, `srsOverride` is mandatory to perform reprojection to `srs`.
* 

