### PR TITLE
geoserver - align web.xml with upstream 2.18.x

### DIFF
--- a/geoserver/webapp/src/docker/web.xml
+++ b/geoserver/webapp/src/docker/web.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-	      version="3.0">
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app>
     <display-name>GeoServer</display-name>
   
       <context-param>
@@ -170,30 +167,50 @@
      -->
    </filter>
 
-   <!-- Uncomment following filter to enable CORS-->
-   <filter>
-        <filter-name>cross-origin</filter-name>
-        <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
-       <init-param>
-           <param-name>chainPreflight</param-name>
-           <param-value>false</param-value>
-       </init-param>
-       <init-param>
-           <param-name>allowedOrigins</param-name>
-           <param-value>*</param-value>
-       </init-param>
-       <init-param>
-           <param-name>allowedMethods</param-name>
-           <param-value>GET,POST,PUT,DELETE,HEAD,OPTIONS</param-value>
-       </init-param>
-       <init-param>
-           <param-name>allowedHeaders</param-name>
-           <param-value>*</param-value>
-       </init-param>
+   <!-- Uncomment following filter to enable CORS in Jetty. Do not forget the second config block further down. -->
+    <filter>
+      <filter-name>cross-origin</filter-name>
+      <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
+      <init-param>
+        <param-name>chainPreflight</param-name>
+        <param-value>false</param-value>
+      </init-param>
+      <init-param>
+        <param-name>allowedOrigins</param-name>
+        <param-value>*</param-value>
+      </init-param>
+      <init-param>
+        <param-name>allowedMethods</param-name>
+        <param-value>GET,POST,PUT,DELETE,HEAD,OPTIONS</param-value>
+      </init-param>
+      <init-param>
+        <param-name>allowedHeaders</param-name>
+        <param-value>*</param-value>
+      </init-param>
     </filter>
 
-    <!--
-      THIS FILTER MUST BE THE FIRST ONE, otherwise we end up with ruined chars in the input from the GUI
+    
+   <!-- Uncomment following filter to enable CORS in Tomcat. Do not forget the second config block further down.
+    <filter>
+      <filter-name>cross-origin</filter-name>
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
+      <init-param>
+        <param-name>cors.allowed.origins</param-name>
+        <param-value>*</param-value>
+      </init-param>
+      <init-param>
+        <param-name>cors.allowed.methods</param-name>
+        <param-value>GET,POST,PUT,DELETE,HEAD,OPTIONS</param-value>
+      </init-param>
+      <init-param>
+        <param-name>cors.allowed.headers</param-name>
+        <param-value>*</param-value>
+      </init-param>
+    </filter>
+    -->
+
+    <!-- 
+      THIS FILTER MAPPING MUST BE THE FIRST ONE, otherwise we end up with ruined chars in the input from the GUI
       See the "Note" in the Tomcat character encoding guide:
       http://wiki.apache.org/tomcat/FAQ/CharacterEncoding
     -->
@@ -294,10 +311,6 @@
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
     
-    <session-config>
-      <tracking-mode>COOKIE</tracking-mode>
-    </session-config>
-
     <mime-mapping>
       <extension>xsl</extension>
       <mime-type>text/xml</mime-type>


### PR DESCRIPTION
This file was introduced one year ago by 699b1e0 to enable CORS for jetty/docker