### PR TITLE
Fixing geoserver dependencies calculation (#3459)

### DIFF
--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -54,13 +54,13 @@ jobs:
     - name: "Building docker image with native security"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-log4j,authkey,mapstore2,sldservice -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,log4j-logstash,sentry-log4j,authkey,mapstore2,sldservice -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }} -DskipTests
 
 
     - name: "Building docker image with geofence"
       if: github.repository == 'georchestra/georchestra'
       working-directory: geoserver/webapp
-      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-log4j,authkey,mapstore2,sldservice -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
+      run: ../../mvnw --no-transfer-progress clean package docker:build -Pdocker,colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,geofence,log4j-logstash,sentry-log4j,authkey,mapstore2,sldservice -DdockerImageName=georchestra/geoserver:${{ steps.version.outputs.VERSION }}-geofence -DskipTests
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Docker related targets
 
-GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,importer,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2,sldservice
+GEOSERVER_EXTENSION_PROFILES=colormap,mbtiles,wps-download,app-schema,control-flow,csw,feature-pregeneralized,inspire,libjpeg-turbo,monitor,pyramid,wps,css,s3-geotiff,jp2k,authkey,mapstore2,sldservice
 BTAG=20.1.x
 
 docker-pull-jetty:

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -888,7 +888,7 @@
                       </run>
                     </image>
                     <image>
-                      <name>georchestra/ldap</name>
+                      <name>georchestra/ldap:20.1.x</name>
                       <alias>ldap</alias>
                       <run>
                         <ports> <!-- expose the mapped port as the ldap_container.port maven property -->

--- a/console/src/test/java/org/georchestra/console/integration/UsersIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/UsersIT.java
@@ -11,6 +11,7 @@ import org.georchestra.console.integration.ds.PostgresExtendedDataTypeFactory;
 import org.georchestra.console.integration.instruments.WithMockRandomUidUser;
 import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker;
 import org.georchestra.console.ws.backoffice.users.GDPRAccountWorker.DeletedAccountSummary;
+import org.hamcrest.text.IsEqualIgnoringCase;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -89,7 +90,8 @@ public class UsersIT {
                 .content(support.readResourceToString("/testData/createUserPayload.json").replace("{uuid}", newUserName)
                         .replace("psc", "C2C")));
 
-        support.perform(get("/private/users/" + newUserName)).andExpect(jsonPath("$.org").value("C2C"))
+        support.perform(get("/private/users/" + newUserName))
+                .andExpect(jsonPath("$.org").value(new IsEqualIgnoringCase("C2C")))
                 .andExpect(jsonPath("$.uid").value(newUserName));
     }
 

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <!--
   <parent>
     <groupId>org.georchestra</groupId>
     <artifactId>root</artifactId>
     <version>20.1-SNAPSHOT</version>
-  </parent>
+      </parent>
+  -->
+  <groupId>org.georchestra</groupId>
   <artifactId>geoserver-root</artifactId>
+  <version>20.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
     <gs.version>2.18.3</gs.version>
     <gt.version>24.3</gt.version>
-    <geofence.version>3.4.6.1</geofence.version>
+    <geofence.version>3.5.0</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>
     <jackson.version>2.10.5</jackson.version>
-    <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.1.16.RELEASE</spring.version>
-    <spring-security.version>5.1.11.RELEASE</spring-security.version>
+    <spring.version>5.1.20.RELEASE</spring.version>
+    <spring-security.version>5.1.13.RELEASE</spring-security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
-<!--
-    <commons-beanutils.version>1.8.0</commons-beanutils.version>
-    <commons-digester.version>1.7</commons-digester.version>
--->
   </properties>
   <modules>
     <module>geoserver-submodule/src/main</module>

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <!--
   <parent>
     <groupId>org.georchestra</groupId>
     <artifactId>root</artifactId>
     <version>20.1-SNAPSHOT</version>
-      </parent>
-  -->
+  </parent>
   <groupId>org.georchestra</groupId>
   <artifactId>geoserver-root</artifactId>
   <version>20.1-SNAPSHOT</version>
@@ -47,4 +45,55 @@
       </modules>
     </profile>
   </profiles>
+  <!-- forcing dependency versions for GeoServer
+       these come from a comparison with the released upstream GS version (single war) available on sourceforge -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.ehcache</groupId>
+        <artifactId>ehcache</artifactId>
+        <version>3.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.freemarker</groupId>
+        <artifactId>freemarker</artifactId>
+        <version>2.3.31</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>30.1-jre</version>
+      </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>1.1.119</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.janino</groupId>
+        <artifactId>janino</artifactId>
+        <version>3.0.8</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>5.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>5.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.8.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial</groupId>
+        <artifactId>sqlite-jdbc</artifactId>
+        <version>3.34.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <packageName>georchestra-geoserver</packageName>
     <context.name>geoserver</context.name>
+    <server>generic</server> <!-- from georchestra root pom -->
   </properties>
   <dependencies>
     <dependency>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <packageName>georchestra-geoserver</packageName>
     <context.name>geoserver</context.name>
-    <server>generic</server> <!-- from georchestra root pom -->
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
-	<scope>provided</scope>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -113,7 +113,7 @@
       <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-	  <version>${postgres.version}</version>
+          <version>${postgres.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
See issue #3459  for the context of this commit. Main proposal here, apart from fixing the versions required by GS upstream, is to unplug the geoserver-georchestra root pom from the georchestra root pom.

Note: checking the dependencies against an official GS webapp from sourceforge, there are still some differences after build between geor &  upstream:

```
upstream: commons-collections-3.2.2.jar
geor:     commons-collections-3.2.1.jar

upstream: slf4j-api-1.6.4.jar
geor:     slf4j-api-1.7.21.jar

upstream: spring-tx-5.1.20.RELEASE.jar
geor:     spring-tx-4.2.5.RELEASE.jar

upstream: xml-apis-1.4.01.jar
geor:     xml-apis-1.3.04.jar
```

These differences go beyond my maven understanding (asking @groldan for help :)), as I cannot track down why they appear in these specific versions in our custom build.

Also I cannot get why we have in the georchestra version junit as a dependency into the classpath, but it seems to be a dependency from gt-geojson.
