### PR TITLE
[datafeeder] Fix (workaround) issue with GeoServer REST API

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/AuthorizationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/AuthorizationService.java
@@ -24,6 +24,7 @@ import org.georchestra.config.security.GeorchestraUserDetails;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.UserInfo;
 import org.georchestra.datafeeder.service.DataUploadService;
+import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
@@ -43,7 +44,7 @@ import lombok.NonNull;
 public class AuthorizationService {
 
     private @Autowired DataUploadService uploadService;
-    private @Autowired UserInfoMapper userInfoMapper;
+    public static final UserInfoMapper userInfoMapper = Mappers.getMapper(UserInfoMapper.class);
 
     public @NonNull String getUserName() {
         SecurityContext context = SecurityContextHolder.getContext();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/FileUploadApiController.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
-import javax.validation.Valid;
 
 import org.georchestra.datafeeder.api.mapper.FileUploadResponseMapper;
 import org.georchestra.datafeeder.model.BoundingBoxMetadata;
@@ -52,7 +51,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
 
 @Controller
 @Api(tags = { "File Upload" }) // hides the empty file-upload-api-controller entry in swagger-ui.html

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/api/UserInfoMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/api/UserInfoMapper.java
@@ -4,7 +4,7 @@ import org.georchestra.config.security.GeorchestraUserDetails;
 import org.georchestra.datafeeder.model.UserInfo;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper
 public interface UserInfoMapper {
 
     UserInfo map(GeorchestraUserDetails principal);

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
@@ -51,6 +51,19 @@ public class GeorchestraNameNormalizer {
     }
 
     /**
+     * The datastore name is composed of {@code <workspaceName>_datafeeder} to make
+     * it unique across workspaces (with {@code workspaceName} as resolved by
+     * {@link #resolveWorkspaceName}) since workspace is tied to the organization
+     * name. Can't use a fixed datastore name despite being on different workspaces
+     * because GeoServer's REST api implementation is dumb and will try to use the
+     * first data store with a given name even if it's not the one that belongs to
+     * the requested workspace.
+     */
+    public String resolveDataStoreName(String workspaceName) {
+        return String.format("datafeeder_%s", workspaceName);
+    }
+
+    /**
      * @return {@link #normalizeName normalized} {@code proposedName}
      */
     public String resolveLayerName(@NonNull String proposedName) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/PrepareTargetDataStoreTasklet.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/batch/publish/PrepareTargetDataStoreTasklet.java
@@ -34,8 +34,6 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.Assert;
-import org.springframework.web.bind.WebDataBinder;
-import org.springframework.web.bind.annotation.InitBinder;
 
 import com.google.common.base.Throwables;
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -103,7 +103,7 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
                 "importedName is required to resolve the native feature type name");
 
         final String workspaceName = resolveWorkspace(user);
-        final String dataStoreName = resolveDataStoreName(dataset);
+        final String dataStoreName = nameResolver.resolveDataStoreName(workspaceName);
         final String publishedLayerName = resolveUniqueLayerName(workspaceName, publishing.getPublishedName());
 
         Optional<DataStoreResponse> dataStore = geoserver.findDataStore(workspaceName, dataStoreName);
@@ -152,7 +152,7 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         requireNonNull(publishing);
 
         final String workspace = publishing.getPublishedWorkspace();
-        final String dataStore = resolveDataStoreName(dataset);
+        final String dataStore = nameResolver.resolveDataStoreName(workspace);
         final String layerName = publishing.getPublishedName();
         final String metadataRecordId = publishing.getMetadataRecordId();
 
@@ -217,10 +217,6 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
             }
         }
         return new HashMap<>(connectionParams);
-    }
-
-    public String resolveDataStoreName(@NonNull DatasetUploadState dataset) {
-        return "datafeeder";
     }
 
     private FeatureTypeInfo buildPublishingFeatureType(String workspace, String dataStore, String layerName,

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/TemplateMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/TemplateMapper.java
@@ -20,13 +20,11 @@ package org.georchestra.datafeeder.service.publish.impl;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;

--- a/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraAuthenticationTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/config/security/GeorchestraAuthenticationTestSupport.java
@@ -38,36 +38,67 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.georchestra.commons.security.SecurityHeaders;
+import org.georchestra.datafeeder.api.AuthorizationService;
+import org.georchestra.datafeeder.model.UserInfo;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.springframework.http.HttpHeaders;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 @Data
+@Accessors(chain = true, fluent = true)
 public class GeorchestraAuthenticationTestSupport implements TestRule {
 
-    private String secProxy = "true";
-    private String secUsername = "testUser";
-    private String secFirstname = "Gábriel";
-    private String secLastname = "Roldán";
-    private String secOrg = "test'org";
-    private String secOrgname = "ジョルケストラコミュニティ";
-    private String secRoles = "ROLE_USER";
-    private String secEmail = "test@email.com";
-    private String secTel = "123456";
-    private String secAddress = "Test Postal Address";
-    private String secTitle = "Test Title";
-    private String secNotes = "Test User notes";
-    private String secOrgLinkage = "http://test.com";
-    private String secOrgAddress = "Test organization address";
-    private String secOrgCategory = "Testcategory";
-    private String secOrgDescription = "Test org description";
+    private String secProxy;
+    private String secUsername;
+    private String secFirstname;
+    private String secLastname;
+    private String secOrg;
+    private String secOrgname;
+    private String secRoles;
+    private String secEmail;
+    private String secTel;
+    private String secAddress;
+    private String secTitle;
+    private String secNotes;
+    private String secOrgLinkage;
+    private String secOrgAddress;
+    private String secOrgCategory;
+    private String secOrgDescription;
 
     @Override
     public Statement apply(Statement base, Description description) {
+        secProxy = "true";
+        secUsername = "testUser";
+        secFirstname = "Gábriel";
+        secLastname = "Roldán";
+        secOrg = "DF TEST ORG";
+        secOrgname = "ジョルケストラコミュニティ";
+        secRoles = "ROLE_USER";
+        secEmail = "test@email.com";
+        secTel = "123456";
+        secAddress = "Test Postal Address";
+        secTitle = "Test Title";
+        secNotes = "Test User notes";
+        secOrgLinkage = "http://test.com";
+        secOrgAddress = "Test organization address";
+        secOrgCategory = "Testcategory";
+        secOrgDescription = "Test org description";
         return base;
+    }
+
+    public GeorchestraUserDetails buildUserDetails() {
+        Map<String, String> headers = buildHeaders();
+        GeorchestraUserDetails userDetails = GeorchestraUserDetails.fromHeaders(headers);
+        return userDetails;
+    }
+
+    public UserInfo buildUser() {
+        GeorchestraUserDetails principal = buildUserDetails();
+        return AuthorizationService.userInfoMapper.map(principal);
     }
 
     public HttpHeaders buildHttpHeaders() {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/ConfigApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/ConfigApiControllerTest.java
@@ -1,12 +1,12 @@
 package org.georchestra.datafeeder.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.net.URI;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.service.DatasetsService;
 import org.junit.After;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/api/DataPublishingApiControllerTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/api/DataPublishingApiControllerTest.java
@@ -39,7 +39,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
 import org.georchestra.datafeeder.app.DataFeederApplicationConfiguration;
-import org.georchestra.datafeeder.model.BoundingBoxMetadata;
 import org.georchestra.datafeeder.model.CoordinateReferenceSystemMetadata;
 import org.georchestra.datafeeder.model.DataUploadJob;
 import org.georchestra.datafeeder.model.DatasetUploadState;

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.georchestra.config.security.GeorchestraAuthenticationTestSupport;
 import org.georchestra.datafeeder.app.DataFeederApplicationConfiguration;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.model.BoundingBoxMetadata;
@@ -70,6 +71,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GeorchestraMetadataPublicationServiceIT {
 
+    public @Rule GeorchestraAuthenticationTestSupport authSupport = new GeorchestraAuthenticationTestSupport();
     public @Autowired @Rule IntegrationTestSupport support;
 
     private @Autowired GeorchestraMetadataPublicationService service;
@@ -140,7 +142,7 @@ public class GeorchestraMetadataPublicationServiceIT {
         publishing.setPublishedName(PULISHED_LAYERNAME);
         publishing.setSrs("EPSG:4326");
 
-        service.publish(shpDataset, support.user());
+        service.publish(shpDataset, authSupport.buildUser());
 
         final String createdMdId = publishing.getMetadataRecordId();
         assertNotNull(createdMdId);
@@ -277,7 +279,7 @@ public class GeorchestraMetadataPublicationServiceIT {
     // https://geobretagne.fr/geonetwork/srv/api/records/633f2882-2a90-4f98-9739-472a72d31b64/formatters/xml
     private void assertResponsibleParty(Document dom) {
         final String rp = "MD_Metadata/identificationInfo/MD_DataIdentification/pointOfContact/CI_ResponsibleParty";
-        UserInfo user = support.user();
+        UserInfo user = authSupport.buildUser();
         String individualName = user.getFirstName() + " " + user.getLastName();
         String organizationName = user.getOrganization().getName();
         String email = user.getEmail();
@@ -293,7 +295,7 @@ public class GeorchestraMetadataPublicationServiceIT {
     // email = sec-email
     private void assertPointOfContact(Document dom) {
         final String poc = "MD_Metadata/contact/CI_ResponsibleParty";
-        UserInfo user = support.user();
+        UserInfo user = authSupport.buildUser();
         String individualName = user.getFirstName() + " " + user.getLastName();
         String organizationName = user.getOrganization().getName();
         String email = user.getEmail();

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/IntegrationTestSupport.java
@@ -38,8 +38,6 @@ import java.util.Map;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.BackendConfiguration;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.ExternalApiConfiguration;
-import org.georchestra.datafeeder.model.UserInfo;
-import org.georchestra.datafeeder.model.UserInfo.Organization;
 import org.georchestra.datafeeder.service.geonetwork.GeoNetworkRemoteService;
 import org.geotools.data.postgis.PostgisNGDataStoreFactory;
 import org.junit.Rule;
@@ -55,7 +53,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -69,42 +66,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public @Service class IntegrationTestSupport extends ExternalResource {
 
-    public static final String ORGANIZATION_NAME = "Datafeeder Test Org";
-    public static final String EXPECTED_SCHEMA_NAME = "datafeeder_test_org";
-    public static final String EXPECTED_WORKSPACE = "datafeeder_test_org";
-
     private @Autowired @Getter DataFeederConfigurationProperties appConfiguration;
     private @Autowired @Getter TestRestTemplate template;
     private @Autowired(required = false) GeoNetworkRemoteService geoNetwork;
-
-    private UserInfo user;
 
     @Override
     protected void before() throws Throwable {
         checkDatabaseAvailability();
         checkGeoServerAvailability();
         checkGeoNetworkAvailability();
-
-        Organization org = new Organization();
-        org.setId(ORGANIZATION_NAME);
-        org.setName("Test Organization Full Name");
-        org.setDescription("Test organization description");
-        org.setLinkage("http://test.org.com");
-        org.setPostalAddress("123 rue du test");
-
-        user = new UserInfo();
-        user.setUsername("testuser");
-        user.setOrganization(org);
-        user.setEmail("testuser@test.com");
-        user.setFirstName("John");
-        user.setLastName("Doe");
-        user.setTelephoneNumber("+54-341-1234");
-        user.setPostalAddress("11th street of testing");
-        user.setTitle("Test advocate");
-    }
-
-    public UserInfo user() {
-        return user;
     }
 
     private void checkDatabaseAvailability() throws SQLException {

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/test/MultipartTestSupport.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/test/MultipartTestSupport.java
@@ -69,6 +69,10 @@ public class MultipartTestSupport extends ExternalResource {
                 "shapes/chinese_poly.shx");
     }
 
+    public List<MockMultipartFile> loadDatafeederTestShapefile(String typeName) {
+        return loadDatafeederTestShapefile(typeName, true);
+    }
+
     public List<MockMultipartFile> loadDatafeederTestShapefile(String typeName, boolean loadPrj) {
         String[] names = Stream.of(".shp", ".dbf", ".shx", ".prj").filter(ext -> loadPrj ? true : !".prj".equals(ext))
                 .map(ext -> typeName + ext).toArray(String[]::new);


### PR DESCRIPTION
Change GeoServer datastore names from `datafeeder` to
`<workspace>_datafeeder`.

Using `datafeeder` as the GeoServer data store name for all workspaces
should be possible, but GeoServer has a bug where the requested
workspace/datastore name pair is ignored, and tries to use the first
datastore with the requested name ignoring the requested workspace,
when, for example, posting a FeatureType.

This resulted in unpredictable errors when publishing from georchestra
accounts in different organizations.