### PR TITLE
deb - improve version calculation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,10 @@
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <skipPoms>false</skipPoms>
           <verbose>false</verbose>
+          <gitDescribe>
+            <tags>true</tags>
+          </gitDescribe>
+          <injectIntoSysProperties>true</injectIntoSysProperties>
         </configuration>
       </plugin>
       <plugin>
@@ -627,7 +631,7 @@
               <exportAntProperties>true</exportAntProperties>
               <target>
                 <condition property="project.packageVersion"
-                  value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                    value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
                   else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
                   <matches string="${project.version}" pattern="SNAPSHOT$" />
                 </condition>
@@ -643,7 +647,7 @@
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
           <version>${formatter-maven-plugin.version}</version>
-	  <inherited>true</inherited>
+          <inherited>true</inherited>
           <executions>
             <execution>
               <goals>
@@ -671,7 +675,7 @@
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-	  <version>4.0.0</version>
+          <version>4.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* using git-commit-id plugin to get the closest tag from the current commit
* injecting the value as a system property
* Accessing it while overriding the packageVersion to set it according to the previously obtained version.

runtime-tested on extractorapp, this produced a package named after the following file:

```
[WARNING] dpkg-deb: building package 'georchestra-extractorapp' in '/home/pmauduit/projects/georchestra/georchestra/extractorapp/target/georchestra-extractorapp_20.1.3.202107191450~903ced7-1_all.deb'.
```