### PR TITLE
mapfishapp - results_with_summary is unsupported with GN4

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
@@ -1001,7 +1001,7 @@ Ext.app.FreetextField = Ext.extend(Ext.form.TwinTriggerField, {
         this.store.load({
             params: {
                 xmlData: new OpenLayers.Format.CSWGetRecords().write({
-                    resultType: "results_with_summary",
+                    resultType: "results",
                     Query: {
                         ElementSetName: {
                             value: "full"


### PR DESCRIPTION
Untested for now - there's no garantee this will be enough for mapfishapp's layer search through CSW to work as expected.
What I can say is that it's a required move.