### PR TITLE
Mapfishapp compatible with GN4

### DIFF
--- a/mapfishapp/src/main/webapp/app/js/GEOR_config.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_config.js
@@ -331,7 +331,7 @@ GEOR.config = (function() {
          * Defaults to "subject"
          */
         CSW_GETDOMAIN_PROPERTY: getCustomParameter("CSW_GETDOMAIN_PROPERTY",
-            "subject"),
+            "tag.default"),
 
 
         /**

--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswbrowser.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswbrowser.js
@@ -287,21 +287,38 @@ GEOR.cswbrowser = (function() {
         cleanTree(tree);
         var getDomainFormat = new OpenLayers.Format.CSWGetDomain();
         OpenLayers.Request.POST({
-            url: GEONETWORK_URL + '/csw',
-            data: getDomainFormat.write({
-                PropertyName: GEOR.config.CSW_GETDOMAIN_PROPERTY
+            url: GEONETWORK_URL + "/../api/search/records/_search?bucket=bucket",
+            data: JSON.stringify({
+                aggregations: {
+                    "keywords": {
+                        "terms": {
+                            "field": GEOR.config.CSW_GETDOMAIN_PROPERTY,
+                            "include": ".*",
+                            "size": 10000
+                        },
+                        "meta": {
+                            "caseInsensitiveInclude": true
+                        }
+                    }
+                },
+                from: 0,
+                size: 10
             }),
+            headers: {
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            },
             success: function(response) {
-                var r = getDomainFormat.read(response.responseXML || response.responseText);
-                Ext.each(r.DomainValues[0].ListOfValues, function (item) {
-                    appendKeyword(tree, item.Value.value);
+                var json = Ext.decode(response.responseText)
+                Ext.each(json.aggregations["keywords"].buckets, function (item) {
+                    appendKeyword(tree, item.key);
                 }, this);
                 mask && mask.hide();
             },
             failure: function() {
                 mask && mask.hide();
                 GEOR.util.errorDialog({
-                    msg: tr("The getDomain CSW query failed")
+                    msg: tr("The request to GeoNetwork 4 aggregations failed")
                 });
             }
         });

--- a/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
+++ b/mapfishapp/src/main/webapp/app/js/GEOR_cswquerier.js
@@ -1001,7 +1001,7 @@ Ext.app.FreetextField = Ext.extend(Ext.form.TwinTriggerField, {
         this.store.load({
             params: {
                 xmlData: new OpenLayers.Format.CSWGetRecords().write({
-                    resultType: "results_with_summary",
+                    resultType: "results",
                     Query: {
                         ElementSetName: {
                             value: "full"


### PR DESCRIPTION
Implement small adjustments to make Mapfishapp compatible with Geonetwork 4.

- [ ] Replace the `GetDomain` query to feed the keyword tree and use the GN4 aggregation api
- [ ] Replace CSW `GetRecords` type `results_with_summary` by `results`
- [ ] Ensure main search works with GN4 CSW


At the moment, GN4 CSW service does not correctly work so the migration is not complete.
See https://github.com/geonetwork/core-geonetwork/issues/5910 for more info.