### PR TITLE
GS - make sure we use the customized georchestra version of geofence

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1349,7 +1349,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-geofence</artifactId>
-          <version>${gs.version}</version>
+          <version>${gs.version}-georchestra</version>
           <exclusions>
             <exclusion>
               <groupId>org.geoserver.geofence</groupId>
@@ -1364,7 +1364,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-geofence-server</artifactId>
-          <version>${gs.version}</version>
+          <version>${gs.version}-georchestra</version>
           <exclusions>
             <exclusion>
               <groupId>cglib</groupId>


### PR DESCRIPTION
Following https://github.com/georchestra/geoserver/pull/28: updating the GS submodule, and make sure the webapp maven module will make use of the customized versions of the geofence jars.

Tests: only at compilation time, suffixed version of the jars are bundled into the generated webapp.
