### PR TITLE
sp - implements webdav specific http verbs

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/Proxy.java
+++ b/security-proxy/src/main/java/org/georchestra/security/Proxy.java
@@ -977,6 +977,9 @@ public class Proxy {
             }
 
             HttpMethod meth = HttpMethod.resolve(method);
+            if (meth == null) {
+                throw new IllegalArgumentException(method + " is not supported.");
+            }
 
             switch (meth) {
             case GET: {

--- a/security-proxy/src/main/java/org/georchestra/security/webdav/PropFindMethod.java
+++ b/security-proxy/src/main/java/org/georchestra/security/webdav/PropFindMethod.java
@@ -1,0 +1,24 @@
+package org.georchestra.security.webdav;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+public class PropFindMethod extends HttpEntityEnclosingRequestBase {
+
+    public final static String METHOD_NAME = "PROPFIND";
+
+    public PropFindMethod() {
+        super();
+    }
+
+    public PropFindMethod(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+}

--- a/security-proxy/src/main/java/org/georchestra/security/webdav/SearchMethod.java
+++ b/security-proxy/src/main/java/org/georchestra/security/webdav/SearchMethod.java
@@ -1,0 +1,24 @@
+package org.georchestra.security.webdav;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+public class SearchMethod extends HttpEntityEnclosingRequestBase {
+
+    public final static String METHOD_NAME = "SEARCH";
+
+    public SearchMethod() {
+        super();
+    }
+
+    public SearchMethod(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+}

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -17,20 +17,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.sql.DataSource;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ProxyTest {
     private Proxy proxy;
@@ -293,4 +288,14 @@ public class ProxyTest {
         }
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonExistingVerb() {
+        request = new MockHttpServletRequest("NONSTANDARDVERB", "/nextcloud/plop");
+        response = new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.OK.value(), "NONSTANDARDVERB worked");
+        response.setHeader("X-Test-Header", "NONSTANDARDVERB worked");
+        httpResponse = new MockHttpServletResponse();
+
+        proxy.handleRequest(request, httpResponse);
+
+    }
 }

--- a/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
+++ b/security-proxy/src/test/java/org/georchestra/security/ProxyTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,7 @@ public class ProxyTest {
         targets = Maps.newHashMap();
         targets.put("geonetwork", "http://www.google.com/geonetwork-private");
         targets.put("extractorapp", "http://localhost/extractorapp-private");
+        targets.put("nextcloud", "http://localhost/nextcloud");
         proxy.setTargets(targets);
 
         proxy.setDefaultTarget("/mapfishapp/");
@@ -260,16 +262,34 @@ public class ProxyTest {
     }
 
     @Test
-    public void testVerb() throws UnsupportedEncodingException {
+    public void testVerb() {
 
         for (RequestMethod e : RequestMethod.values()) {
             request = new MockHttpServletRequest(e.toString(), "/extractorapp/home");
             response = new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.OK.value(), e.toString() + " worked");
             response.setHeader("X-Test-Header", e.toString() + " worked");
             httpResponse = new MockHttpServletResponse();
+
             proxy.handleRequest(request, httpResponse);
+
             assertEquals(HttpStatus.OK.value(), httpResponse.getStatus());
             assertEquals(e.toString() + " worked", httpResponse.getHeader("X-Test-Header"));
+        }
+    }
+
+    @Test
+    public void testWebDavVerb() {
+
+        for (String webDavVerb : Arrays.asList("PROPFIND", "SEARCH")) {
+            request = new MockHttpServletRequest(webDavVerb, "/nextcloud/plop");
+            response = new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.OK.value(), webDavVerb + " worked");
+            response.setHeader("X-Test-Header", webDavVerb + " worked");
+            httpResponse = new MockHttpServletResponse();
+
+            proxy.handleRequest(request, httpResponse);
+
+            assertEquals(HttpStatus.OK.value(), httpResponse.getStatus());
+            assertEquals(webDavVerb + " worked", httpResponse.getHeader("X-Test-Header"));
         }
     }
 


### PR DESCRIPTION
This is required in order to be able to proxify webdav requests, e.g. to interact with a NextCloud instance behind the SP.
 
