### PR TITLE
[datafeeder] point at the right dir when packaging the war

### DIFF
--- a/datafeeder-ui/pom.xml
+++ b/datafeeder-ui/pom.xml
@@ -112,7 +112,7 @@
               <configuration>
                   <webResources>
                       <resource>
-                          <directory>${project.build.directory}/datafeeder-ui/dist/datafeeder</directory>
+                          <directory>${project.build.directory}/datafeeder-ui/dist/apps/datafeeder</directory>
                       </resource>
                   </webResources>
               </configuration>


### PR DESCRIPTION
right now, trying to package the datafeeder-ui war blows hard:
```
Caused by: java.lang.IllegalStateException: basedir /data/src/georchestra/georchestra/datafeeder-ui/target/datafeeder-ui/dist/datafeeder does not exist
    at org.codehaus.plexus.util.DirectoryScanner.scan (DirectoryScanner.java:308)
    at org.apache.maven.plugin.war.packaging.WarProjectPackagingTask.getFilesToCopy (WarProjectPackagingTask.java:351)
    at org.apache.maven.plugin.war.packaging.WarProjectPackagingTask.copyResources (WarProjectPackagingTask.java:299)
    at org.apache.maven.plugin.war.packaging.WarProjectPackagingTask.handleWebResources (WarProjectPackagingTask.java:132)
    at org.apache.maven.plugin.war.packaging.WarProjectPackagingTask.performPackaging (WarProjectPackagingTask.java:83)
    at org.apache.maven.plugin.war.AbstractWarMojo.buildWebapp (AbstractWarMojo.java:483)
    at org.apache.maven.plugin.war.AbstractWarMojo.buildExplodedWebapp (AbstractWarMojo.java:411)
    at org.apache.maven.plugin.war.WarMojo.performPackaging (WarMojo.java:213)
    at org.apache.maven.plugin.war.WarMojo.execute (WarMojo.java:176)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
```

so lets point at the right dir, which allows the war and the deb to package fine:
```
[WARNING] dpkg-deb: building package 'georchestra-datafeeder-ui' in '/data/src/georchestra/georchestra/datafeeder-ui/target/georchestra-datafeeder-ui_99.master.202108241030~8dd7024-1_all.deb'.
```
