### PR TITLE
Makefile: also pass -DskipTests to maven in war-build-georchestra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ war-build-gn3:
 	mvn clean install -f geonetwork/pom.xml -DskipTests
 
 war-build-georchestra: war-build-gn3 war-build-geoserver
-	mvn -Dmaven.test.skip=true clean install
+	mvn -Dmaven.test.skip=true -DskipTests clean install
 
 
 # DEB related targets


### PR DESCRIPTION
otherwise docker-compose is required when using the Makefile..


cf https://packages.georchestra.org/bot/#/builders/3/builds/3/steps/1/logs/stdio, datafeeder only skips tests when `skipTests` is set, `maven.test.skip=true` isnt enough.