### PR TITLE
[datafeeder-ui] add *.css to resources mapping

### DIFF
--- a/datafeeder-ui/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/datafeeder-ui/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -19,6 +19,7 @@
     <mvc:resources mapping="/*.ico" location="/" />
     <mvc:resources mapping="/*.html" location="/" />
     <mvc:resources mapping="/*.js" location="/" />
+    <mvc:resources mapping="/*.css" location="/" />
     <mvc:resources mapping="/*.map" location="/" />
     <mvc:resources mapping="/assets/**" location="/assets/" />
 


### PR DESCRIPTION
fixes css display for datafeeder, otherwise the browser gets a 404.

thanks @pmauduit for the pointer, tested working fine with georchestra/ansible#86