### PR TITLE
geoserver - 20.1.x - docker - fix regression with the web.xml provided

### DIFF
--- a/geoserver/webapp/src/docker/web.xml
+++ b/geoserver/webapp/src/docker/web.xml
@@ -310,6 +310,10 @@
         <servlet-name>dispatcher</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
+
+    <session-config>
+      <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
     
     <mime-mapping>
       <extension>xsl</extension>


### PR DESCRIPTION
fixes https://github.com/georchestra/georchestra/issues/3458, not needed in master where there's already a fixed version of the web.xml