### PR TITLE
GS - make sure we use the customized georchestra version of geofence [backport]

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1281,7 +1281,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-geofence</artifactId>
-          <version>${gs.version}</version>
+          <version>${gs.version}-georchestra</version>
           <exclusions>
             <exclusion>
               <groupId>org.geoserver.geofence</groupId>
@@ -1296,7 +1296,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-geofence-server</artifactId>
-          <version>${gs.version}</version>
+          <version>${gs.version}-georchestra</version>
           <exclusions>
             <exclusion>
               <groupId>cglib</groupId>


### PR DESCRIPTION
backport of https://github.com/georchestra/georchestra/pull/3480

Following https://github.com/georchestra/geoserver/pull/28: updating
the GS submodule, and make sure the webapp maven module will make use of
the customized versions of the geofence jars.

tested on a local instance