### PR TITLE
Add GN_USERADMIN profile mapping to GeoNetwork UserAdmin Profile

### DIFF
--- a/.github/workflows/geonetwork.yml
+++ b/.github/workflows/geonetwork.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 45
     steps:
     - name: "Checking out"
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: "Checking out submodules"
       run: git submodule update --init --recursive --depth 1 geonetwork/
@@ -78,7 +78,7 @@ jobs:
       if: github.repository == 'georchestra/georchestra'
       run: |
         cd geonetwork/web
-        ../../mvnw package docker:build -Pdocker -DdockerImageName=georchestra/geonetwork -DdockerImageTags=${{ steps.version.outputs.VERSION }},latest -DskipTests
+        ../../mvnw package docker:build -Pdocker -DdockerImageName=georchestra/geonetwork -DdockerImageTags=${{ steps.version.outputs.VERSION }},latest -DskipTests -ntp
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v1

--- a/.github/workflows/geonetwork.yml
+++ b/.github/workflows/geonetwork.yml
@@ -4,13 +4,19 @@ on:
     paths:
       - "commons/**"
       - "security-proxy-spring-integration/**"
-      - "geonetwork/**"
+      - "geonetwork"
       - ".github/workflows/geonetwork.yml"
+      - "ldap-account-management/**"
+      - "console/**"
+      - "ldap/**"
   pull_request:
     paths:
       - "commons/**"
       - "security-proxy-spring-integration/**"
-      - "geonetwork/**"
+      - "geonetwork"
+      - "ldap-account-management/**"
+      - "console/**"
+      - "ldap/**"
 
 jobs:
   build:

--- a/.github/workflows/geonetwork.yml
+++ b/.github/workflows/geonetwork.yml
@@ -56,6 +56,15 @@ jobs:
       working-directory: geonetwork/
       run: ../mvnw install -DskipTests -T1C -ntp -B -Dadditionalparam=-Xdoclint:none
 
+    - name: "Build required docker images (ldap, database)"
+      run: |
+        docker build -t georchestra/ldap:latest ./ldap
+        docker build -t georchestra/database:latest ./postgresql
+
+    - name: "Build required docker image (console)"
+      run: |
+        ./mvnw -pl :console -am clean install docker:build -P-all,console,docker -DdockerImageName=georchestra/console:latest -DskipTests -ntp -Dskip.npm -Dfmt.skip
+
     - name: "Run Georchestra Integration Tests"
       working-directory: geonetwork/georchestra-integration/
       run: ../../mvnw verify -ntp -Dadditionalparam=-Xdoclint:none

--- a/console/src/main/webapp/manager/app/services/roles.es6
+++ b/console/src/main/webapp/manager/app/services/roles.es6
@@ -23,6 +23,7 @@ angular.module('manager')
       'SUPERUSER',
       'ADMINISTRATOR',
       'GN_ADMIN',
+      'GN_USERADMIN',
       'GN_EDITOR',
       'GN_REVIEWER',
       'ORGADMIN',

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/UserMapper.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/UserMapper.java
@@ -34,6 +34,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ERROR, uses = UUIDMapper.class)
 abstract class UserMapper {
@@ -53,12 +54,18 @@ abstract class UserMapper {
 
     @AfterMapping
     protected void addRoles(Account source, @MappingTarget GeorchestraUser target) {
-
         List<String> roles = findRoles(source);
         target.setRoles(roles);
 
         String hash = GeorchestraUserHasher.createHash(target);
         target.setLastUpdated(hash);
+    }
+
+    @AfterMapping
+    protected void setOrgToNullIfEmpty(Account source, @MappingTarget GeorchestraUser target) {
+        if (!StringUtils.hasLength(source.getOrg())) {
+            target.setOrganization(null);
+        }
     }
 
     private List<String> findRoles(Account source) {

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/UsersApiImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/UsersApiImpl.java
@@ -33,7 +33,6 @@ import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.NameNotFoundException;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 @Service
 public class UsersApiImpl implements UsersApi {
@@ -47,7 +46,6 @@ public class UsersApiImpl implements UsersApi {
         try {
             return this.accountsDao.findAll(notPending().and(notProtected()))//
                     .stream()//
-                    .filter(u -> StringUtils.hasLength(u.getOrg()))//
                     .map(mapper::map)//
                     .collect(Collectors.toList());
         } catch (DataServiceException e) {
@@ -59,7 +57,9 @@ public class UsersApiImpl implements UsersApi {
     public Optional<GeorchestraUser> findById(String id) {
         try {
             UUID uuid = UUID.fromString(id);
-            return Optional.of(this.accountsDao.findById(uuid)).filter(notPending()).filter(notProtected())
+            return Optional.of(//
+                    this.accountsDao.findById(uuid))//
+                    .filter(notPending().and(notProtected()))//
                     .map(mapper::map);
         } catch (NameNotFoundException e) {
             return Optional.empty();
@@ -71,7 +71,8 @@ public class UsersApiImpl implements UsersApi {
     @Override
     public Optional<GeorchestraUser> findByUsername(String username) {
         try {
-            return Optional.of(this.accountsDao.findByUID(username)).filter(notPending()).filter(notProtected())
+            return Optional.of(this.accountsDao.findByUID(username))//
+                    .filter(notPending().and(notProtected()))//
                     .map(mapper::map);
         } catch (NameNotFoundException e) {
             return Optional.empty();

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -69,9 +69,9 @@ public class InternalSecurityApiImplIT {
         List<GeorchestraUser> defaultUsers = loadJson("/defaultUsers.json", GeorchestraUser.class);
         List<Organization> defaultOrganizations = loadJson("/defaultOrganizations.json", Organization.class);
         List<Role> defaultRoles = loadJson("/defaultRoles.json", Role.class);
-        assertEquals(3, defaultUsers.size());
+        assertEquals(6, defaultUsers.size());
         assertEquals(2, defaultOrganizations.size());
-        assertEquals(14, defaultRoles.size());
+        assertEquals(15, defaultRoles.size());
 
         expectedUsers = toMap(defaultUsers, GeorchestraUser::getId);
         expectedOrganizations = toMap(defaultOrganizations, Organization::getId);

--- a/ldap-account-management/src/test/resources/defaultOrganizations.json
+++ b/ldap-account-management/src/test/resources/defaultOrganizations.json
@@ -8,10 +8,11 @@
 		"category": "Association",
 		"description": "Association PSC geOrchestra",
 		"notes": "Internal CRM notes on PSC",
-		"lastUpdated": "2200a6051fcef499884e1cfa8b6625766e76df75d18ce2316c23b421db99e147",
+		"lastUpdated": "53c634aad30ebd750630fe2e16470d9cce2c9e27a4d35b5d1e0dcbc7fa53b6ff",
 		"members": [
 			"testadmin",
-			"testuser"
+			"testuser",
+			"testuseradmin"
 		]
 	},
 	{

--- a/ldap-account-management/src/test/resources/defaultRoles.json
+++ b/ldap-account-management/src/test/resources/defaultRoles.json
@@ -1,11 +1,28 @@
 [
 	{
-		"id": "67148edb-ac2a-4959-a42c-8361fcb057bd",
-		"name": "ORGADMIN",
-		"description": "This role is automatically granted to all users holding an admin delegation",
-		"lastUpdated": "bfbfc6658089c91218b41ce195c68cd1afc385ecedbc5dd1c891bb51fb55a07b",
+		"id": "6b98583f-0ff0-465f-bb29-e9696a634c74",
+		"name": "ADMINISTRATOR",
+		"description": "This role grants admin access to GeoServer",
+		"lastUpdated": "3a33e37f8ca3dcd35e6806001da8b1da827ede7bbdba15032270031677770aa7",
 		"members": [
-			"testdelegatedadmin"
+			"geoserver_privileged_user",
+			"testadmin"
+		]
+	},
+	{
+		"id": "7637a7bc-e540-4a5a-b828-dc2530540017",
+		"name": "CKAN_ADMIN",
+		"description": "This role grants admin rights in CKAN, scoped to user's org",
+		"lastUpdated": "f3f31065d550f0f0da979a306cff55853c0152272e52950bea0ab6305b073502",
+		"members": []
+	},
+	{
+		"id": "9354df17-ed78-42e2-8d5b-089bfbe9fd0c",
+		"name": "CKAN_EDITOR",
+		"description": "This role grants metadata edit rights in CKAN, scoped to user's org",
+		"lastUpdated": "f0241fc015f032e3d24bdddfbc1009e21a777d113fb82572d1bfe04bad9d2807",
+		"members": [
+			"testeditor"
 		]
 	},
 	{
@@ -18,10 +35,28 @@
 		]
 	},
 	{
-		"id": "7ca8708f-8056-48d0-abff-0c34ed66328a",
-		"name": "MAPSTORE_ADMIN",
-		"description": "This role grants administrative access to MapStore2",
-		"lastUpdated": "e769f6007949980f048f3e40aa670e4f7bb2ca227551dd4440f906cfb2cca613",
+		"id": "2b5150f7-6451-4bd7-8ecb-b44ffa39fa08",
+		"name": "EMAILPROXY",
+		"description": "This role allows to use the emailProxy webservice from the console",
+		"lastUpdated": "319f6ecacc25d6f146e2d482b47d4811b6d6c04871ab55bf91e9b825e88c8daa",
+		"members": [
+			"testadmin"
+		]
+	},
+	{
+		"id": "7a75bb00-6f0a-4917-96d2-41e90f7b8651",
+		"name": "EXTRACTORAPP",
+		"description": "This role allows users to extract geodata",
+		"lastUpdated": "31819308e18f275855187718f5a7967d4da659728e6b8ccff17cc81cf7c2070f",
+		"members": [
+			"testadmin"
+		]
+	},
+	{
+		"id": "ab9d8932-a17c-4767-840d-940a183654f3",
+		"name": "GN_ADMIN",
+		"description": "This role grants admin access to GeoNetwork",
+		"lastUpdated": "23d138ea682a104ef579712a308444899440c607a1c7253c3ba0760aa500ae1a",
 		"members": [
 			"testadmin"
 		]
@@ -45,11 +80,31 @@
 		]
 	},
 	{
-		"id": "7637a7bc-e540-4a5a-b828-dc2530540017",
-		"name": "CKAN_ADMIN",
-		"description": "This role grants admin rights in CKAN, scoped to user's org",
-		"lastUpdated": "f3f31065d550f0f0da979a306cff55853c0152272e52950bea0ab6305b073502",
-		"members": []
+		"id": "5fd23d51-0d68-4d60-98ab-59fb383ebe39",
+		"name": "GN_USERADMIN",
+		"description": "This role grants admin access to the user's GeoNetwork group",
+		"lastUpdated": "03db56d413ee6220212b0a6b5b47b217407d212a5bd2c3ef95f42b07db006aa3",
+		"members": [
+			"testuseradmin"
+		]
+	},
+	{
+		"id": "7ca8708f-8056-48d0-abff-0c34ed66328a",
+		"name": "MAPSTORE_ADMIN",
+		"description": "This role grants administrative access to MapStore2",
+		"lastUpdated": "e769f6007949980f048f3e40aa670e4f7bb2ca227551dd4440f906cfb2cca613",
+		"members": [
+			"testadmin"
+		]
+	},
+	{
+		"id": "67148edb-ac2a-4959-a42c-8361fcb057bd",
+		"name": "ORGADMIN",
+		"description": "This role is automatically granted to all users holding an admin delegation",
+		"lastUpdated": "bfbfc6658089c91218b41ce195c68cd1afc385ecedbc5dd1c891bb51fb55a07b",
+		"members": [
+			"testdelegatedadmin"
+		]
 	},
 	{
 		"id": "26aa3643-5c37-4e10-961f-4ad1bccd85c0",
@@ -68,62 +123,17 @@
 		]
 	},
 	{
-		"id": "ab9d8932-a17c-4767-840d-940a183654f3",
-		"name": "GN_ADMIN",
-		"description": "This role grants admin access to GeoNetwork",
-		"lastUpdated": "23d138ea682a104ef579712a308444899440c607a1c7253c3ba0760aa500ae1a",
-		"members": [
-			"testadmin"
-		]
-	},
-	{
-		"id": "2b5150f7-6451-4bd7-8ecb-b44ffa39fa08",
-		"name": "EMAILPROXY",
-		"description": "This role allows to use the emailProxy webservice from the console",
-		"lastUpdated": "319f6ecacc25d6f146e2d482b47d4811b6d6c04871ab55bf91e9b825e88c8daa",
-		"members": [
-			"testadmin"
-		]
-	},
-	{
-		"id": "6b98583f-0ff0-465f-bb29-e9696a634c74",
-		"name": "ADMINISTRATOR",
-		"description": "This role grants admin access to GeoServer",
-		"lastUpdated": "3a33e37f8ca3dcd35e6806001da8b1da827ede7bbdba15032270031677770aa7",
-		"members": [
-			"geoserver_privileged_user",
-			"testadmin"
-		]
-	},
-	{
-		"id": "7a75bb00-6f0a-4917-96d2-41e90f7b8651",
-		"name": "EXTRACTORAPP",
-		"description": "This role allows users to extract geodata",
-		"lastUpdated": "31819308e18f275855187718f5a7967d4da659728e6b8ccff17cc81cf7c2070f",
-		"members": [
-			"testadmin"
-		]
-	},
-	{
-		"id": "9354df17-ed78-42e2-8d5b-089bfbe9fd0c",
-		"name": "CKAN_EDITOR",
-		"description": "This role grants metadata edit rights in CKAN, scoped to user's org",
-		"lastUpdated": "f0241fc015f032e3d24bdddfbc1009e21a777d113fb82572d1bfe04bad9d2807",
-		"members": [
-			"testeditor"
-		]
-	},
-	{
 		"id": "ad243705-eeec-4d1c-aa28-abb631e23a65",
 		"name": "USER",
 		"description": "This role is required to log into geOrchestra",
-		"lastUpdated": "6e125ba6fafdecb6b9cd46c269f0db64e4e1c49315f9766c9cd82d768493bff0",
+		"lastUpdated": "712b4da15da3614510052e2fe956ae10af74b792532bcd4f452c1ab924e10cf7",
 		"members": [
 			"testuser",
 			"testeditor",
 			"testreviewer",
 			"testadmin",
-			"testdelegatedadmin"
+			"testdelegatedadmin",
+			"testuseradmin"
 		]
 	}
 ]

--- a/ldap-account-management/src/test/resources/defaultUsers.json
+++ b/ldap-account-management/src/test/resources/defaultUsers.json
@@ -16,6 +16,23 @@
 		"notes": "Internal CRM notes on testuser"
 	},
 	{
+		"username": "testreviewer",
+		"roles": [
+			"GN_REVIEWER",
+			"USER"
+		],
+		"organization": null,
+		"id": "5f6ce744-4f36-4432-9543-7f6025fab02c",
+		"lastUpdated": "047b2c52239c66fad08638b5a584f2392772ab53169dfc2f9dbc92bac8ef4b7e",
+		"firstName": "Test",
+		"lastName": "REVIEWER",
+		"email": "psc+testreviewer@georchestra.org",
+		"postalAddress": null,
+		"telephoneNumber": null,
+		"title": null,
+		"notes": null
+	},
+	{
 		"username": "testeditor",
 		"roles": [
 			"GN_EDITOR",
@@ -24,14 +41,31 @@
 		],
 		"organization": "C2C",
 		"id": "e75b336d-a9fc-4671-8002-e1a49c2acf2c",
-		"lastUpdated": "da930fd1379f2cca2e4932a508f882548e314485332521df1f18ff16f3311997",
-		"firstName": "Test",
+		"lastUpdated": "673077112eccd42a8091e47af29db45f5c879e0cc89fc79f2e7270e4cded428d",
+		"firstName": null,
 		"lastName": "EDITOR",
 		"email": "psc+testeditor@georchestra.org",
 		"postalAddress": null,
 		"telephoneNumber": null,
 		"title": null,
 		"notes": null
+	},
+	{
+		"username": "testuseradmin",
+		"roles": [
+			"GN_USERADMIN",
+			"USER"
+		],
+		"organization": "PSC",
+		"id": "e75b336d-a9fc-4671-8002-e1a49c2ac123",
+		"lastUpdated": "4822e624d3cad3f5f4e03cd0067374cf2da872f387418abe5290358a26b34c37",
+		"firstName": "Test",
+		"lastName": "USERADMIN",
+		"email": "psc+testuseradmin@georchestra.org",
+		"postalAddress": null,
+		"telephoneNumber": null,
+		"title": null,
+		"notes": "Test user with UserAdmin GeoNetwork profile "
 	},
 	{
 		"username": "testadmin",
@@ -55,5 +89,22 @@
 		"telephoneNumber": null,
 		"title": null,
 		"notes": "Internal CRM notes on testadmin"
+	},
+	{
+		"username": "testdelegatedadmin",
+		"roles": [
+			"USER",
+			"ORGADMIN"
+		],
+		"organization": null,
+		"id": "003860e1-19d9-4fda-a3e8-3eda577b4918",
+		"lastUpdated": "6481a3d4a1b5ca2d4c02d62351dac15bdf7e76772cc43a0dadd762a740abbd6e",
+		"firstName": "Test",
+		"lastName": "DELEGATEDADMIN",
+		"email": "psc+testdelegatedadmin@georchestra.org",
+		"postalAddress": null,
+		"telephoneNumber": null,
+		"title": null,
+		"notes": null
 	}
 ]

--- a/ldap/docker-root/georchestra.ldif
+++ b/ldap/docker-root/georchestra.ldif
@@ -55,13 +55,30 @@ objectClass: person
 objectClass: shadowAccount
 objectClass: top
 uid: testeditor
-givenName: Test
 sn: EDITOR
 description: editor
 userPassword:: e1NIQX1mVTFvSmdzV0FEZ1ZtTHBHeHBxdFBVa2RiekU9
 mail: psc+testeditor@georchestra.org
 cn: testeditor
 georchestraObjectIdentifier: e75b336d-a9fc-4671-8002-e1a49c2acf2c
+
+# testuseradmin, users, georchestra.org
+dn: uid=testuseradmin,ou=users,dc=georchestra,dc=org
+objectClass: georchestraUser
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: shadowAccount
+objectClass: top
+uid: testuseradmin
+givenName: Test
+sn: USERADMIN
+description: UserAdmin
+userPassword:: e1NIQX1kREU1SkEvMkVpVTRGMFFObUt5eXpuazUrN1E9
+mail: psc+testuseradmin@georchestra.org
+knowledgeInformation: Test user with UserAdmin GeoNetwork profile 
+cn: testuseradmin
+georchestraObjectIdentifier: e75b336d-a9fc-4671-8002-e1a49c2ac123
 
 # testadmin, users, georchestra.org
 dn: uid=testadmin,ou=users,dc=georchestra,dc=org
@@ -183,6 +200,16 @@ description: This role grants admin access to GeoNetwork
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
 georchestraObjectIdentifier: ab9d8932-a17c-4767-840d-940a183654f3
 
+# GN_USERADMIN, roles, georchestra.org
+dn: cn=GN_USERADMIN,ou=roles,dc=georchestra,dc=org
+objectClass: top
+objectClass: groupOfMembers
+objectClass: georchestraRole
+cn: GN_USERADMIN
+description: This role grants admin access to the user's GeoNetwork group
+member: uid=testuseradmin,ou=users,dc=georchestra,dc=org
+georchestraObjectIdentifier: 5fd23d51-0d68-4d60-98ab-59fb383ebe39
+
 # GN_EDITOR, roles, georchestra.org
 dn: cn=GN_EDITOR,ou=roles,dc=georchestra,dc=org
 objectClass: top
@@ -253,6 +280,7 @@ member: uid=testeditor,ou=users,dc=georchestra,dc=org
 member: uid=testreviewer,ou=users,dc=georchestra,dc=org
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
 member: uid=testdelegatedadmin,ou=users,dc=georchestra,dc=org
+member: uid=testuseradmin,ou=users,dc=georchestra,dc=org
 georchestraObjectIdentifier: ad243705-eeec-4d1c-aa28-abb631e23a65
 
 # ORGADMIN, roles, georchestra.org
@@ -370,6 +398,7 @@ cn: PSC
 description: 2A004,2B033
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
 member: uid=testuser,ou=users,dc=georchestra,dc=org
+member: uid=testuseradmin,ou=users,dc=georchestra,dc=org
 o: Project Steering Committee
 ou: PSC
 seeAlso: o=PSC,ou=orgs,dc=georchestra,dc=org


### PR DESCRIPTION
Add a new `GN_USERADMIN` default profile to `ldap` and `console`, and a `testuseradmin` user[1].

In GeoNetwork's `externalized-accounts` mappings, it maps to `UserAdmin` by means of `georchestra.properties` in the data directory, and results in the user being a UserAdmin for the georchestra org/geonetwork group it belongs to.

This is backwards compatible with role mappings for previous versions and allows set accounts to be group admins in geonetwork.

See:
- https://github.com/georchestra/datadir/commit/bbb4d0d057d16879cbe8c2e41c5984abe708e0f5
- https://github.com/georchestra/geonetwork/commit/ba04ec7e107b6d84ce421230fd016248eae1e6c8
- https://github.com/georchestra/geonetwork/commit/bea88e6a8afa8bb6aa765349399bb4ec34ff53d6

[1] The `testuseradmin` user currently has `testadmin` password cause I couldn't figure out how to properly set it to `testuseradmin` in `georchestra.ldif`.