### PR TITLE
header - using 3 letters for GN admin UI (#3515)

### DIFF
--- a/header/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/header/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -62,6 +62,28 @@ if (forcedLang != null) {
         lang = detectedLanguage;
     } 
 }
+String longLang = lang;
+
+switch(lang) {
+  case "en":
+    longLang = "eng";
+    break;
+  case "es":
+    longLang = "spa";
+    break;
+  case "fr":
+    longLang = "fre";
+    break;
+  case "de":
+    longLang = "ger";
+    break;
+  case "nl":
+    longLang = "dut";
+    break;
+  default:
+    longLang = "eng";
+}
+
 
 javax.servlet.jsp.jstl.core.Config.set(
     request,
@@ -318,12 +340,12 @@ if(sec_roles != null) {
                             <c:when test='<%= active.equals("geonetwork") %>'>
                         <!-- GN2 or GN3 -->
                         <!--li class="active"><a href="/geonetwork/srv/<%= lang %>/admin"><fmt:message key="catalogue"/></a></li-->
-                        <li class="active"><a href="/geonetwork/srv/<%= lang %>/admin.console"><fmt:message key="catalogue"/></a></li>
+                        <li class="active"><a href="/geonetwork/srv/<%= longLang %>/admin.console"><fmt:message key="catalogue"/></a></li>
                             </c:when>
                             <c:otherwise>
                         <!-- GN2 or GN3 -->
                         <!--li><a href="/geonetwork/srv/<%= lang %>/admin"><fmt:message key="catalogue"/></a></li-->
-                        <li><a href="/geonetwork/srv/<%= lang %>/admin.console"><fmt:message key="catalogue"/></a></li>
+                        <li><a href="/geonetwork/srv/<%= longLang %>/admin.console"><fmt:message key="catalogue"/></a></li>
                             </c:otherwise>
                         </c:choose>
                         </c:when>


### PR DESCRIPTION
tests: runtime into an ansible deployment:

* locales FR => /fre/
* locales EN => /eng/