### PR TITLE
mapfishapp: Fix build

### DIFF
--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -15,35 +15,28 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: "Checking out"
-      uses: actions/checkout@v1
-
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+      uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: '8.x'
+        distribution: 'temurin'
+        java-version: '8'
+        cache: 'maven'
 
-    - name: "Configuring Maven"
-      run: |
-          mkdir -p $HOME/.m2
-          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
-
-    - name: "Maven repository caching"
-      uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+# Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:1.5.19.RELEASE from/to artifactory-georchestra
+#    - name: "Configuring Maven"
+#      run: |
+#          mkdir -p $HOME/.m2
+#          cp .github/resources/m2-settings.xml $HOME/.m2/settings.xml
 
     - name: "Installing & checking formatting"
-      run: ./mvnw --no-transfer-progress -B -P-all,mapfishapp -Dfmt.action=validate install -Dadditionalparam=-Xdoclint:none -DskipTests
+      run: ./mvnw install -pl mapfishapp -am -ntp -B -P-all,mapfishapp -Dfmt.action=validate -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: "Running tests"
-      working-directory: mapfishapp/
-      run: ../mvnw --no-transfer-progress clean verify -Pit -Dfmt.skip=true -Dadditionalparam=-Xdoclint:none -Dorg.geotools.referencing.forceXY=true
+      run: ./mvnw verify -pl mapfishapp -Pit -ntp -Dfmt.skip -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra'
@@ -52,8 +45,7 @@ jobs:
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
-      working-directory: mapfishapp/
-      run: ../mvnw --no-transfer-progress clean package docker:build -Pdocker,log4j-logstash,sentry-log4j  -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ./mvnw clean package -pl mapfishapp docker:build -ntp -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -36,7 +36,7 @@ jobs:
       run: ./mvnw install -pl mapfishapp -am -ntp -B -P-all,mapfishapp -Dfmt.action=validate -Dadditionalparam=-Xdoclint:none -DskipTests
 
     - name: "Running tests"
-      run: ./mvnw verify -pl mapfishapp -Pit -ntp -Dfmt.skip -Dadditionalparam=-Xdoclint:none
+      run: ./mvnw verify -pl mapfishapp -P-all,mapfishapp -ntp -Dfmt.skip -Dadditionalparam=-Xdoclint:none
 
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra'
@@ -45,7 +45,7 @@ jobs:
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'
-      run: ./mvnw clean package -pl mapfishapp docker:build -ntp -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
+      run: ./mvnw clean package -pl mapfishapp docker:build -ntp -P-all,mapfishapp,docker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapfishapp:${{ steps.version.outputs.VERSION }} -DskipTests
 
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -285,6 +285,14 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>${skipUT}</skip>
+          <!-- reuseForks=false to isolate test cases from geotools initialization -->
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
     <resources>
       <resource>

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -14,6 +14,7 @@
     <maven.test.skip>false</maven.test.skip>
     <!-- Override parent version with 2.1.1-georchestra. Revisit. -->
     <mapfish.version>2.1.1-georchestra</mapfish.version>
+    <gt.version>26.1</gt.version>
     <!--
     	downgrade parent's 20180813 version or org.mapfish.print.servlet.MapPrinterServlet.getInfo
     	throws java.lang.NoSuchMethodError: org.json.JSONWriter.<init>(Ljava/io/Writer;)V

--- a/mapfishapp/pom.xml
+++ b/mapfishapp/pom.xml
@@ -53,11 +53,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1-atlassian-2</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/classif/SLDClassifier.java
+++ b/mapfishapp/src/main/java/org/georchestra/mapfishapp/ws/classif/SLDClassifier.java
@@ -301,11 +301,10 @@ public class SLDClassifier {
             // create a Rule. A Rule is composed by one Filter and one Symbolizer
             Rule rule = styleFactory.createRule();
             Filter filter = filters.next();
-            rule.setSymbolizers(new Symbolizer[] { symbolizers.next() });
+            rule.symbolizers().add(symbolizers.next());
             rule.setFilter(filter.getGISFilter());
             rule.setName(filter.getName());
-            rule.setTitle(filter.getName());
-            fts.addRule(rule);
+            fts.rules().add(rule);
         }
 
         if (filters.hasNext()) {
@@ -513,8 +512,7 @@ public class SLDClassifier {
         // add a custom style to the user layer
         Style style = styleFactory.createStyle();
         style.setName(_command.getFeatureTypeName());
-        style.setTitle(_command.getFeatureTypeName() + "_classification");
-        style.addFeatureTypeStyle(fts);
+        style.featureTypeStyles().add(fts);
         layer.addStyle(style);
 
         return sld;

--- a/mapfishapp/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/mapfishapp/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -3,6 +3,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:p="http://www.springframework.org/schema/p"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
     http://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/context
@@ -12,6 +13,10 @@
  
     <context:property-placeholder location="file:${georchestra.datadir}/default.properties, file:${georchestra.datadir}/mapfishapp/mapfishapp.properties" ignore-resource-not-found="true" ignore-unresolvable="true" />
 
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" 
+        p:targetObject="#{@systemProperties}" p:targetMethod="setProperty"
+        p:arguments="#{{'org.geotools.referencing.forceXY','true'}}"/>
+        
     <!-- autoscan these packages, the classic beans are defined in
          the next of the file. -->
     <context:component-scan base-package="org.georchestra.mapfishapp.addons.*"/>

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/UploadGeoFileControllerTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/UploadGeoFileControllerTest.java
@@ -28,6 +28,8 @@ public class UploadGeoFileControllerTest {
     private MockHttpServletResponse response;
 
     public static @BeforeClass void setUpGeoToolsReferencing() {
+        // set org.geotools.referencing.forceXY to true, set by ws-servlet.xml when
+        // running the spring app
         System.setProperty("org.geotools.referencing.forceXY", "true");
     }
 

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/classif/MockWFSDataStoreFactory.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/classif/MockWFSDataStoreFactory.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 
-import org.geotools.data.ows.SimpleHttpClient;
+import org.geotools.http.SimpleHttpClient;
 import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.internal.WFSClient;

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/classif/PointSymbolizerFactoryTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/classif/PointSymbolizerFactoryTest.java
@@ -5,13 +5,16 @@ import static org.junit.Assert.assertEquals;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import org.georchestra.mapfishapp.ws.classif.PointSymbolizerFactory;
+import org.geotools.styling.Graphic;
 import org.geotools.styling.Mark;
 import org.geotools.styling.PointSymbolizer;
 import org.geotools.styling.StyleBuilder;
 import org.geotools.styling.Symbolizer;
 import org.junit.Test;
+import org.opengis.style.GraphicalSymbol;
 
 /**
  * Test PointSymbolizerFactory
@@ -142,7 +145,10 @@ public class PointSymbolizerFactoryTest {
         Iterator<Symbolizer> symbolizers = psf.iterator();
 
         PointSymbolizer ps = (PointSymbolizer) symbolizers.next();
-        Mark[] marks = ps.getGraphic().getMarks();
+        Graphic graphic = ps.getGraphic();
+        List<GraphicalSymbol> graphicalSymbols = graphic.graphicalSymbols();
+        Mark[] marks = graphicalSymbols.stream().filter(Mark.class::isInstance).map(Mark.class::cast)
+                .toArray(Mark[]::new);
         assertEquals(StyleBuilder.MARK_STAR, marks[0].getWellKnownName().toString()); // check shape name
         assertEquals("0.2", ps.getGraphic().getOpacity().toString()); // check opacity
         assertEquals("#00FF00", marks[0].getFill().getColor().toString()); // check color

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/classif/SLDClassifierTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/classif/SLDClassifierTest.java
@@ -31,7 +31,7 @@ public class SLDClassifierTest {
             .<String, UsernamePasswordCredentials>emptyMap();
 
     // Use version=2.0 to ensure the SLDClassifier downgrades it to 1.1.0
-    private static final String wfsUrl = "https://geobretagne.fr/geoserver/ccpbs/wfs?service=WFS&request=GetCapabilities&VERSION=2.0";
+    private static final String wfsUrl = "https://geobretagne.fr/geoserver/ccpbs/wfs?service=WFS&request=GetCapabilities&VERSION=2.0.0";
 
     private WFSDataStoreFactory dataStoreFactory;
 
@@ -43,7 +43,7 @@ public class SLDClassifierTest {
     public void testChoropleths() throws Exception {
 
         // build JSON request
-        String featureTypeName = "ccpbs:dechet_zone_collecte";
+        String featureTypeName = "ccpbs:dechet_zone_collecte_om";
         String propertyName = "NUM";
         String firstColor = "#0000ff";
         String lastColor = "#ff0000";

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/upload/GeotoolsFeatureReaderTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/upload/GeotoolsFeatureReaderTest.java
@@ -36,6 +36,12 @@ public class GeotoolsFeatureReaderTest {
 
     private FeatureGeoFileReader reader;
 
+    public static @BeforeClass void setUpGeoToolsReferencing() {
+        // set org.geotools.referencing.forceXY to true, set by ws-servlet.xml when
+        // running the spring app
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+    }
+
     @Before
     public void setup() {
         reader = new GeotoolsFeatureReader();

--- a/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagementGTImplTest.java
+++ b/mapfishapp/src/test/java/org/georchestra/mapfishapp/ws/upload/UpLoadFileManagementGTImplTest.java
@@ -19,6 +19,7 @@ import org.geotools.referencing.CRS;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.locationtech.jts.geom.Point;
 import org.opengis.feature.simple.SimpleFeature;
@@ -32,6 +33,12 @@ import org.opengis.feature.simple.SimpleFeature;
  * 
  */
 public class UpLoadFileManagementGTImplTest {
+
+    public static @BeforeClass void setUpGeoToolsReferencing() {
+        // set org.geotools.referencing.forceXY to true, set by ws-servlet.xml when
+        // running the spring app
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+    }
 
     /**
      * Test method for


### PR DESCRIPTION
- Force System property `org.geotools.referencing.forceXY=true` for the application itself
- Set `org.geotools.referencing.forceXY=true`  on tests that require it and force forking the jvm when surefire runs tests so prior runs don't interfer with each other re geotools initialization
- Update SLDClassifierTest online WFS test with working parameters
- Improvements to CI build workflow