### PR TITLE
remove CKAN-related roles

### DIFF
--- a/ldap-account-management/src/test/resources/defaultRoles.json
+++ b/ldap-account-management/src/test/resources/defaultRoles.json
@@ -10,31 +10,6 @@
 		]
 	},
 	{
-		"id": "7637a7bc-e540-4a5a-b828-dc2530540017",
-		"name": "CKAN_ADMIN",
-		"description": "This role grants admin rights in CKAN, scoped to user's org",
-		"lastUpdated": "f3f31065d550f0f0da979a306cff55853c0152272e52950bea0ab6305b073502",
-		"members": []
-	},
-	{
-		"id": "9354df17-ed78-42e2-8d5b-089bfbe9fd0c",
-		"name": "CKAN_EDITOR",
-		"description": "This role grants metadata edit rights in CKAN, scoped to user's org",
-		"lastUpdated": "f0241fc015f032e3d24bdddfbc1009e21a777d113fb82572d1bfe04bad9d2807",
-		"members": [
-			"testeditor"
-		]
-	},
-	{
-		"id": "fdff2189-2321-455f-b59c-e831fa14f084",
-		"name": "CKAN_SYSADMIN",
-		"description": "This role grants full admin rights to CKAN",
-		"lastUpdated": "7ccffd8b2a71e529be7e2ac24f90aff751578ba789497f5268b5765695f8ce77",
-		"members": [
-			"testadmin"
-		]
-	},
-	{
 		"id": "2b5150f7-6451-4bd7-8ecb-b44ffa39fa08",
 		"name": "EMAILPROXY",
 		"description": "This role allows to use the emailProxy webservice from the console",

--- a/ldap-account-management/src/test/resources/defaultUsers.json
+++ b/ldap-account-management/src/test/resources/defaultUsers.json
@@ -36,7 +36,6 @@
 		"username": "testeditor",
 		"roles": [
 			"GN_EDITOR",
-			"CKAN_EDITOR",
 			"USER"
 		],
 		"organization": "C2C",
@@ -74,7 +73,6 @@
 			"SUPERUSER",
 			"EXTRACTORAPP",
 			"GN_ADMIN",
-			"CKAN_SYSADMIN",
 			"USER",
 			"MAPSTORE_ADMIN",
 			"EMAILPROXY"

--- a/ldap/docker-root/georchestra.ldif
+++ b/ldap/docker-root/georchestra.ldif
@@ -230,35 +230,6 @@ description: This role grants reviewer (publish) rights in GeoNetwork
 member: uid=testreviewer,ou=users,dc=georchestra,dc=org
 georchestraObjectIdentifier: 3ebc8f3f-a211-4a4d-996e-e1236c380bad
 
-# CKAN_SYSADMIN, roles, georchestra.org
-dn: cn=CKAN_SYSADMIN,ou=roles,dc=georchestra,dc=org
-objectClass: top
-objectClass: groupOfMembers
-objectClass: georchestraRole
-cn: CKAN_SYSADMIN
-description: This role grants full admin rights to CKAN
-member: uid=testadmin,ou=users,dc=georchestra,dc=org
-georchestraObjectIdentifier: fdff2189-2321-455f-b59c-e831fa14f084
-
-# CKAN_ADMIN, roles, georchestra.org
-dn: cn=CKAN_ADMIN,ou=roles,dc=georchestra,dc=org
-objectClass: top
-objectClass: groupOfMembers
-objectClass: georchestraRole
-cn: CKAN_ADMIN
-description: This role grants admin rights in CKAN, scoped to user's org
-georchestraObjectIdentifier: 7637a7bc-e540-4a5a-b828-dc2530540017
-
-# CKAN_EDITOR, roles, georchestra.org
-dn: cn=CKAN_EDITOR,ou=roles,dc=georchestra,dc=org
-objectClass: top
-objectClass: groupOfMembers
-objectClass: georchestraRole
-cn: CKAN_EDITOR
-description: This role grants metadata edit rights in CKAN, scoped to user's org
-member: uid=testeditor,ou=users,dc=georchestra,dc=org
-georchestraObjectIdentifier: 9354df17-ed78-42e2-8d5b-089bfbe9fd0c
-
 # REFERENT, roles, georchestra.org
 dn: cn=REFERENT,ou=roles,dc=georchestra,dc=org
 objectClass: top


### PR DESCRIPTION
CKAN is an optional module, which is rarely deployed.
At some point we were thinking it made sense to have these roles in the main repo, but it does not anymore.