### PR TITLE
gh actions - backport 20.1.x -  being able to launch workflows from the web ui

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -1,5 +1,6 @@
 name: "analytics"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -1,5 +1,6 @@
 name: "atlas"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/cas.yml
+++ b/.github/workflows/cas.yml
@@ -1,5 +1,6 @@
 name: "cas"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -1,5 +1,6 @@
 name: "console"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -1,5 +1,6 @@
 name: "PostGreSQL"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "postgresql/**"

--- a/.github/workflows/extractorapp.yml
+++ b/.github/workflows/extractorapp.yml
@@ -1,5 +1,6 @@
 name: "extractorapp"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -1,5 +1,6 @@
 name: "geoserver"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -1,5 +1,6 @@
 name: "geowebcache"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -1,5 +1,6 @@
 name: "header"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/ldap.yml
+++ b/.github/workflows/ldap.yml
@@ -1,5 +1,6 @@
 name: "LDAP"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "ldap/**"

--- a/.github/workflows/mapfishapp.yml
+++ b/.github/workflows/mapfishapp.yml
@@ -1,5 +1,6 @@
 name: "mapfishapp"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -1,5 +1,6 @@
 name: "security-proxy"
 on:
+  workflow_dispatch:
   push:
     paths:
       - "commons/**"


### PR DESCRIPTION
Backport from master

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

This could help debug the github actions more easily. Either way, we
need to trigger by committing / pushing. If the build fails because of
an external component, it can be cumbersome.
