### PR TITLE
[header] add link to ms2 home on /mapstore/#/home

### DIFF
--- a/header/src/main/resources/_header/i18n/index_de.properties
+++ b/header/src/main/resources/_header/i18n/index_de.properties
@@ -5,6 +5,7 @@ logo=geOrchestra
 catalogue=Katalog
 viewer=Viewer
 mapstore=Mapstore
+mapstore.home=Mapstore Home
 datafeeder=Importieren
 extractor=Extraktor
 services=Services

--- a/header/src/main/resources/_header/i18n/index_en.properties
+++ b/header/src/main/resources/_header/i18n/index_en.properties
@@ -5,6 +5,7 @@ logo=geOrchestra
 catalogue=catalogue
 viewer=viewer
 mapstore=mapstore
+mapstore.home=mapstore home
 datafeeder=import
 extractor=extractor
 services=services

--- a/header/src/main/resources/_header/i18n/index_es.properties
+++ b/header/src/main/resources/_header/i18n/index_es.properties
@@ -5,6 +5,7 @@ logo=geOrchestra
 catalogue=catálogo
 viewer=visualizador
 mapstore=mapstore
+mapstore.home=Mapstore Home
 datafeeder=importar
 extractor=extractor
 services=servicios

--- a/header/src/main/resources/_header/i18n/index_fr.properties
+++ b/header/src/main/resources/_header/i18n/index_fr.properties
@@ -5,6 +5,7 @@ logo=geOrchestra
 catalogue=catalogue
 viewer=visualiseur
 mapstore=mapstore
+mapstore.home=Mapstore Home
 datafeeder=importer
 extractor=extracteur
 services=services

--- a/header/src/main/resources/_header/i18n/index_nl.properties
+++ b/header/src/main/resources/_header/i18n/index_nl.properties
@@ -5,6 +5,7 @@ logo=geOrchestra
 catalogue=catalogus
 viewer=viewer
 mapstore=mapstore
+mapstore.home=Mapstore Home
 datafeeder=importeren
 extractor=afzuigkap
 services=diensten

--- a/header/src/main/resources/_header/i18n/index_ru.properties
+++ b/header/src/main/resources/_header/i18n/index_ru.properties
@@ -5,6 +5,7 @@ logo=geOrchestra
 catalogue=Каталог
 viewer=вьюера
 mapstore=mapstore
+mapstore.home=Mapstore Home
 datafeeder=import
 extractor=Скачать
 services=сервисов

--- a/header/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/header/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -289,7 +289,7 @@ if(sec_roles != null) {
             <li class="active"><a><fmt:message key="mapstore.home"/></a></li>
             </c:when>
             <c:otherwise>
-            <li><a href="/mapstore/#/home"><fmt:message key="mapstore.home"/></a></li>
+            <li><a href="/mapstore/#home"><fmt:message key="mapstore.home"/></a></li>
             </c:otherwise>
         </c:choose>
 

--- a/header/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/header/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -285,6 +285,15 @@ if(sec_roles != null) {
         </c:choose>
 
         <c:choose>
+            <c:when test='<%= active.equals("mapstore_home") %>'>
+            <li class="active"><a><fmt:message key="mapstore.home"/></a></li>
+            </c:when>
+            <c:otherwise>
+            <li><a href="/mapstore/#/home"><fmt:message key="mapstore.home"/></a></li>
+            </c:otherwise>
+        </c:choose>
+
+        <c:choose>
             <c:when test='<%= active.equals("geoserver") %>'>
             <li class="active"><a href="/geoserver/web/"><fmt:message key="services"/></a></li>
             </c:when>


### PR DESCRIPTION
fixes georchestra/mapstore2-georchestra#459

to be discussed wether this should replace the direct link to the viewer or next to it, for the default header i think it makes sense to have both for discoverability and ppl are free to comment one or the other. @fvanderbiest ?

while here i noticed the `active` mechanism is partly broken, doesnt seem to work all the time, clicking on 'services' properly yields to geoserver but the `services` div doesnt end up with the `active` class, same thing for mapstore home.