### PR TITLE
ldap - migrating to mdb (#3574)

### DIFF
--- a/console/src/test/java/org/georchestra/console/integration/IntegrationTestSupport.java
+++ b/console/src/test/java/org/georchestra/console/integration/IntegrationTestSupport.java
@@ -91,7 +91,7 @@ public @Service class IntegrationTestSupport extends ExternalResource {
         LOGGER.debug(String.format("############# %s: pgsqlPort: %s, ldapPort: %s\n", testName.getMethodName(),
                 psqlPort, ldapPort));
         // pre-flight sanity check
-        assertNotNull(ldapTemplate.lookup("cn=admin"));
+        assertNotNull(ldapTemplate.lookup("ou=users"));
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }
 

--- a/console/src/test/java/org/georchestra/console/integration/UsersIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/UsersIT.java
@@ -77,7 +77,7 @@ public class UsersIT extends ConsoleIntegrationTest {
     public @Before void before() {
         this.createdUsers = new HashSet<>();
         // pre-flight sanity check
-        assertNotNull(ldapTemplateSanityCheck.lookup("cn=admin"));
+        assertNotNull(ldapTemplateSanityCheck.lookup("ou=users"));
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }
 

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -71,7 +71,7 @@ public class InternalSecurityApiImplIT {
         List<Role> defaultRoles = loadJson("/defaultRoles.json", Role.class);
         assertEquals(6, defaultUsers.size());
         assertEquals(2, defaultOrganizations.size());
-        assertEquals(15, defaultRoles.size());
+        assertEquals(12, defaultRoles.size());
 
         expectedUsers = toMap(defaultUsers, GeorchestraUser::getId);
         expectedOrganizations = toMap(defaultOrganizations, Organization::getId);

--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -2,9 +2,9 @@
 # Dockerfile for the geOrchestra openldap service
 #
 
-FROM debian:buster
+FROM debian:bullseye
 
-ENV OPENLDAP_VERSION 2.4.47
+ENV OPENLDAP_VERSION 2.4.57
 ENV RUN_AS_UID 101
 ENV RUN_AS_GID 101
 

--- a/ldap/docker-root/docker-entrypoint.d/00-init
+++ b/ldap/docker-root/docker-entrypoint.d/00-init
@@ -40,7 +40,7 @@ if [[ ! -d /etc/ldap/slapd.d || "$SLAPD_FORCE_RECONFIGURE" == "true" ]]; then
         slapd slapd/password2 password $SLAPD_PASSWORD
         slapd shared/organization string $SLAPD_ORGANIZATION
         slapd slapd/domain string $SLAPD_DOMAIN
-        slapd slapd/backend select HDB
+        slapd slapd/backend select MDB
         slapd slapd/allow_ldap_v2 boolean false
         slapd slapd/purge_database boolean false
         slapd slapd/move_old_database boolean true
@@ -58,8 +58,11 @@ EOF
 
     base_string="BASE ${dc_string:1}"
 
-    sed -i "s/^#BASE.*/${base_string}/g" /etc/ldap/ldap.conf
-
+    if [ -f /etc/ldap/ldap.conf ] ; then
+      sed -i "s/^#BASE.*/${base_string}/g" /etc/ldap/ldap.conf
+    else
+        echo $base_string > /etc/ldap/ldap.conf
+    fi
     if [[ -n "$SLAPD_CONFIG_PASSWORD" ]]; then
         password_hash=`slappasswd -s "${SLAPD_CONFIG_PASSWORD}"`
 

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -33,7 +33,6 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
     done
 
     echo "Populating LDAP tree..."
-    sed -i 's/mdb/hdb/' /memberof.ldif
     ldapadd -Y EXTERNAL -H ldapi:/// -f /georchestraSchema.ldif
     ldapadd -Y EXTERNAL -H ldapi:/// -f /memberof.ldif
     if [ "$IGNORE_DATA" = 'true' ]; then

--- a/ldap/docker-root/etc/ldap.dist/modules/ppolicy.ldif
+++ b/ldap/docker-root/etc/ldap.dist/modules/ppolicy.ldif
@@ -3,7 +3,7 @@ objectClass: olcModuleList
 cn: module
 olcModuleLoad: ppolicy.la
 
-dn: olcOverlay=ppolicy,olcDatabase={1}hdb,cn=config
+dn: olcOverlay=ppolicy,olcDatabase={1}mdb,cn=config
 objectClass: olcOverlayConfig
 objectClass: olcPPolicyConfig
 olcOverlay: ppolicy

--- a/ldap/docker-root/indexes.ldif
+++ b/ldap/docker-root/indexes.ldif
@@ -1,8 +1,8 @@
-dn: olcDatabase={1}hdb,cn=config
+dn: olcDatabase={1}mdb,cn=config
 add: olcDbIndex
 olcDbIndex: mail eq,sub,subfinal
 
-dn: olcDatabase={1}hdb,cn=config
+dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcDbIndex
 olcDbIndex: cn,uid eq


### PR DESCRIPTION
This mainly affects the docker image, which was still making use of hdb
as backend for the openldap database.

tests: docker build & run:

* Ldapsearch reveals:
  * the georchestra schema is still here
  * the memberOf overlay still functions
* checking by hand into /etc/ldap/slapd.d proves that the georchestra db
  is now making use of mdb.