### PR TITLE
Make OrgsDaoImpl.findAllWithExt() org to ext matching case insensitive

### DIFF
--- a/ldap-account-management/src/main/java/org/georchestra/ds/orgs/OrgsDaoImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/orgs/OrgsDaoImpl.java
@@ -58,8 +58,6 @@ import org.springframework.ldap.filter.Filter;
 import org.springframework.ldap.support.LdapNameBuilder;
 import org.springframework.util.StringUtils;
 
-import lombok.Setter;
-
 /**
  * This class manage organization membership
  */
@@ -325,9 +323,11 @@ public class OrgsDaoImpl implements OrgsDao {
                 orgExtension.getAttributeMapper(true));
 
         Stream<Org> orgs = Stream.concat(active.stream(), pending.stream());
-        final Map<String, OrgExt> exts = this.findAllExt().collect(toMap(OrgExt::getId, identity()));
+        // Use lower-case id matching, as per
+        // https://github.com/georchestra/georchestra/issues/3626
+        final Map<String, OrgExt> exts = this.findAllExt().collect(toMap(ext -> ext.getId().toLowerCase(), identity()));
 
-        Stream<Org> all = orgs.map(o -> o.setOrgExt(exts.get(o.getId())));
+        Stream<Org> all = orgs.map(o -> o.setOrgExt(exts.get(o.getId().toLowerCase())));
         return all;
     }
 


### PR DESCRIPTION
Fixes #3626 

OpenLdap seach (e.g. `o=c2c`) is case insensitive, meaning
org's id may be stored as `C2C` but its link to the `OrgExt`
as `seeAlso: o=c2c,ou=orgs,dc=georchestra,dc=org`.

`findAllWithExt()` hence needs to match Org to OrgExt ids
in a case insensitive way.

Single-object searches though will match without special
treatment because they'll use the case-sensitiveness matching
of the underlying LDAP server.