### PR TITLE
LDAP: support both backends HDB/MDB for first_run check

### DIFF
--- a/ldap/docker-root/docker-entrypoint.d/00-init
+++ b/ldap/docker-root/docker-entrypoint.d/00-init
@@ -12,7 +12,7 @@ SLAPD_FORCE_RECONFIGURE="${SLAPD_FORCE_RECONFIGURE:-false}"
 
 first_run=true
 
-if [[ -f "/var/lib/ldap/DB_CONFIG" ]]; then
+if [[ -f "/var/lib/ldap/DB_CONFIG" || -f "/var/lib/ldap/data.mdb" ]]; then
     first_run=false
 fi
 


### PR DESCRIPTION
since PR #3612 , the ldap backend will be MDB for newer installation, HDB for existing ones.

this PR updates the *first_run* test , so it check for either a previously HDB or MDB install.

note that this boolean `first_run` is only used there :
https://github.com/georchestra/georchestra/blob/ef26a0137251ee97e7b1465adbe4bee7dfaaf1d8/ldap/docker-root/docker-entrypoint.d/00-init#L109-L112

and `/etc/ldap/prepopulate` will probably be empty in most (if not all) situations.
