### PR TITLE
re-enable save button for pending users (#3658)

### DIFF
--- a/console/src/main/webapp/manager/app/components/user/user.tpl.html
+++ b/console/src/main/webapp/manager/app/components/user/user.tpl.html
@@ -43,7 +43,7 @@
         <hr>
 
         <div class="pull-right">
-          <button ng-click="user.save()" class="btn btn-primary" translate data-ng-disabled="user.user.pending || !adminUserForm.$valid">user.save</button>
+          <button ng-click="user.save()" class="btn btn-primary" translate data-ng-disabled="!adminUserForm.$valid">user.save</button>
         </div>
 
       </div>


### PR DESCRIPTION
Fix #3658 .
For pending users, to sort out a possible confusion between ***Confirm user*** and ***Save*** actions,  the *Save* button was deactivated in #3410 for pending users. 

Not being able to "**Save**" a pending user without "**Confirming**" it before led to a loss of functionality : one cannot add/modify user information and especially "_Internal Notes_" to pending users.

Some customers used this _Internal Notes_ field to exchange information _before_ confirming the user, and this was not possible anymore.

This PR aims at re-enable this "Save" action, and back to the old behavior, just keep in mind that _Saving_ a user does not _Confirm_ it.