### PR TITLE
extract user and pass from jdbcUrl in pool creation

### DIFF
--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -17,7 +17,10 @@
     </bean>
 
     <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource" depends-on="waitForDb">
-        <property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}?user=${pgsqlUser}&amp;password=${pgsqlPassword}"/>
+        <!-- $pgsqlDatabase may contain special PG parameters such as "georchestra?sslmode=require" . see default|analytics.properties files-->
+        <property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}"/>
+        <property name="user" value="${pgsqlUser}" />
+        <property name="password" value="${pgsqlPassword}" />
         <property name="driverClass" value="org.postgresql.Driver"/>
         <property name="initialPoolSize" value="2"/>
         <property name="minPoolSize" value="${dataSource.minPoolSize:2}"/>

--- a/extractorapp/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/extractorapp/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -16,7 +16,10 @@
 
     <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource" destroy-method="close">
         <property name="driverClass" value="org.postgresql.Driver"/>
-        <property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}?user=${pgsqlUser}&amp;password=${pgsqlPassword}"/>
+        <!-- $pgsqlDatabase may contain special PG parameters such as "georchestra?sslmode=require" . see .properties files-->
+        <property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}"/>
+        <property name="user" value="${pgsqlUser}" />
+        <property name="password" value="${pgsqlPassword}" />
         <property name="initialPoolSize" value="2"/>
         <property name="minPoolSize" value="${dataSource.minPoolSize:2}"/>
         <property name="maxPoolSize" value="${dataSource.maxPoolSize:10}"/>

--- a/mapfishapp/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/mapfishapp/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -27,7 +27,10 @@
     <bean class="org.georchestra.mapfishapp.ws.OGCProxy" />
 
     <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource">
-        <property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}?user=${pgsqlUser}&amp;password=${pgsqlPassword}"/>
+        <!-- $pgsqlDatabase may contain special PG parameters such as "georchestra?sslmode=require" . see default|mapfishapp.properties -->
+        <property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}"/>
+        <property name="user" value="${pgsqlUser}" />
+        <property name="password" value="${pgsqlPassword}" />
         <property name="driverClass" value="org.postgresql.Driver"/>
         <property name="initialPoolSize" value="2"/>
         <property name="minPoolSize" value="${dataSource.minPoolSize:2}"/>


### PR DESCRIPTION
same as  #3662  for the `20.1` branch

_description_:
Sometimes, `pgsqlDatabase` contains special parameters string.
like `$pgsqlDatabase=georchestra?sslmode=require`

This can confuse the `jdbcUrl` connection string like this (for data pools): 
```
<property name="jdbcUrl" value="jdbc:postgresql://${pgsqlHost}:${pgsqlPort}/${pgsqlDatabase}?user=${pgsqlUser}&amp;password=${pgsqlPassword}"/>
=>
"jdbc:postgresql://10.0.0.42:5432/georchestra?sslmode=require?user=georchestra&password=nope"
```
(note the double character `?`)

There is some workaround by setting in *.properties* files :
```
pgsqlUser=georchestra&sslmode=require
```
it takes care of the double `?` but is not really readable and then confuse https://github.com/georchestra/georchestra/blob/48fb57feda89b38ff83926e96477757c3e052008/commons/src/main/java/org/georchestra/commons/WaitForDb.java#L25

So we will probably be better off splitting this jdbcUrl into small chunks...
