### PR TITLE
add MAPSTORE_ADMIN to system roles

### DIFF
--- a/console/src/main/webapp/manager/app/services/roles.es6
+++ b/console/src/main/webapp/manager/app/services/roles.es6
@@ -28,6 +28,7 @@ angular.module('manager')
       'GN_REVIEWER',
       'ORGADMIN',
       'EXTRACTORAPP',
+      'MAPSTORE_ADMIN',
       'USER',
       'PENDING',
       'EXPIRED',


### PR DESCRIPTION
fix #3609
I don't really know if there is other implication, but at least this works in the console.
This PR makes `MAPSTORE_ADMIN` appear in the *geOrchestra roles* section, and the role now cannot be _managed_ (deleted).
