### PR TITLE
datafeeder - being able to override the resource type (#3627)

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -89,6 +89,7 @@ public @Data class DataFeederConfigurationProperties {
         private String templateRecordId;
         private URI templateRecord;
         private URI templateTransform;
+        private String defaultResourceType = "series";
     }
 
     @Data

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -107,7 +107,9 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
             m.setKeywords(new ArrayList<>(publishing.getKeywords()));
         m.setCreationDate(publishing.getDatasetCreationDate());
         m.setLineage(publishing.getDatasetCreationProcessDescription());
-        m.setResourceType("series");
+
+        m.setResourceType(publishingConfiguration.getGeonetwork().getDefaultResourceType());
+
         m.getOnlineResources().add(wmsOnlineResource(d));
         m.getOnlineResources().add(wfsOnlineResource(d));
         m.getOnlineResources().add(downloadOnlineResource(d));

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapper.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapper.java
@@ -56,7 +56,7 @@ public class GeorchestraTemplateMapper extends TemplateMapper {
         if (transformURI != null) {
             return transformURI;
         }
-        log.info("No metadata template provided in georchstra datadir, using default XSL transform");
+        log.info("No metadata template provided in georchestra datadir, using default XSL transform");
         return super.resolveTransformURI();
     }
 

--- a/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
+++ b/datafeeder/src/main/resources/default_iso_2005_gmd.xsl
@@ -220,9 +220,10 @@ Default template to apply MetadataRecordProperties.java properties to a record t
     </gco:CharacterString>
   </xsl:template>
 
-  <xsl:template match="//gmd:hierarchyLevel/gmd:MD_ScopeCode">
-    <gmd:MD_ScopeCode
-      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="series" />
+  <xsl:template match="gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue">
+    <xsl:attribute name="codeListValue">
+      <xsl:value-of select="$props//resourceType" />
+    </xsl:attribute>
   </xsl:template>
 
   <xsl:template

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/TemplateMapperTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/TemplateMapperTest.java
@@ -106,6 +106,21 @@ public class TemplateMapperTest {
 
     }
 
+    @Test
+    public void testApplyTemplateResourceType() {
+        final MetadataRecordProperties mdprops = new MetadataPropertiesTestSupport().createTestProps();
+        mdprops.setResourceType("dataset");
+        Supplier<String> recordSupplier = mapper.apply(mdprops);
+        assertNotNull(recordSupplier);
+        String record = recordSupplier.get();
+        assertNotNull(record);
+        log.info(record);
+        Document dom = parse(record);
+
+        assertXpath(dom, "MD_Metadata/hierarchyLevel/MD_ScopeCode/@codeListValue", mdprops.getResourceType());
+
+    }
+
     private Document parse(String record) {
         Document dom;
         try {

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -78,6 +78,7 @@ datafeeder.publishing.geonetwork.template-record:
 datafeeder.publishing.geonetwork.template-transform:
 #datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml
 #datafeeder.publishing.geonetwork.template-transform: file:${georchestra.datadir}/datafeeder/metadata_transform.xsl
+datafeeder.publishing.geonetwork.defaultResourceType=dataset
 
 datafeeder.publishing.backend.local.dbtype=postgis
 datafeeder.publishing.backend.local.host=${pgsqlHost}

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -78,7 +78,7 @@ datafeeder.publishing.geonetwork.template-record:
 datafeeder.publishing.geonetwork.template-transform:
 #datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml
 #datafeeder.publishing.geonetwork.template-transform: file:${georchestra.datadir}/datafeeder/metadata_transform.xsl
-datafeeder.publishing.geonetwork.defaultResourceType=dataset
+datafeeder.publishing.geonetwork.defaultResourceType=series
 
 datafeeder.publishing.backend.local.dbtype=postgis
 datafeeder.publishing.backend.local.host=${pgsqlHost}


### PR DESCRIPTION
1. Taking back basically what has been done as PR onto the [datadir](https://github.com/georchestra/datadir/pull/233), but adding a test & modifying the default xsl bundled into the DF.
2. adds the possibility to set the default resource type into the properties file from the datadir.

tests: testsuite updated, runtime tested in a vagrant / ansible setup.

