### PR TITLE
re-enable save button for pending users (#3658)

### DIFF
--- a/console/src/main/webapp/manager/app/components/user/user.tpl.html
+++ b/console/src/main/webapp/manager/app/components/user/user.tpl.html
@@ -43,7 +43,7 @@
         <hr>
 
         <div class="pull-right">
-          <button ng-click="user.save()" class="btn btn-primary" translate data-ng-disabled="user.user.pending || !adminUserForm.$valid">user.save</button>
+          <button ng-click="user.save()" class="btn btn-primary" translate data-ng-disabled="!adminUserForm.$valid">user.save</button>
         </div>
 
       </div>


### PR DESCRIPTION
(cherry picked from commit 9fa5029a17e80a1f3e867b968d197ae833dcab22)

relates to #3541 
fixes #3658
backport of #3660

Not being able to "Save" a pending user without "Confirming" it beforehand led to a loss of functionality : one cannot add/modify user information of pending users.
This PR aims at re-enable this "Save" action, and back to the old behavior, just keep in mind that Saving a user does not Confirm it.