### PR TITLE
console Dockerfile: remove jetty embedded mail system

### DIFF
--- a/console/src/docker/Dockerfile
+++ b/console/src/docker/Dockerfile
@@ -1,5 +1,12 @@
 FROM jetty:9-jre11
 
+# remove jetty embedded "JavaMail", we have our own.
+# fix #3692 : ClassNotFoundException: javax.activation.DataSource
+# https://github.com/eclipse/jetty.docker/issues/10
+USER root
+RUN rm -r /usr/local/jetty/lib/mail
+USER jetty
+
 ENV XMS=512M XMX=1G
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded

--- a/console/src/main/webapp/manager/package-lock.json
+++ b/console/src/main/webapp/manager/package-lock.json
@@ -946,7 +946,7 @@
       "dev": true,
       "requires": {
         "requirejs": "^2.1.15",
-        "route-recognizer": "git://github.com/btford/route-recognizer.git",
+        "route-recognizer": "https://github.com/btford/route-recognizer.git",
         "traceur": "^0.0.72"
       }
     },
@@ -5809,8 +5809,8 @@
       }
     },
     "route-recognizer": {
-      "version": "git://github.com/btford/route-recognizer.git#24bde1b66fb8868f2b37c1d9d13ac70152198eaf",
-      "from": "git://github.com/btford/route-recognizer.git",
+      "version": "https://github.com/btford/route-recognizer.git#24bde1b66fb8868f2b37c1d9d13ac70152198eaf",
+      "from": "https://github.com/btford/route-recognizer.git",
       "dev": true
     },
     "rsvp": {


### PR DESCRIPTION
fixes #3692 
Both "user creation" and "forgot password" features failed with :
```
NoClassDefFoundError: javax/activation/DataSource
```

it turns out *jetty9-jre11* has some issues with `javax.activation` package:
https://github.com/eclipse/jetty.docker/issues/10

This PR removes the jetty *embedded* mail libs, and therefore its `JETTY_HOME` restricted classpath.
we don't need those because we bring our own mail libs :
https://github.com/georchestra/georchestra/blob/05c3864a4ca7cdcb65ba0caca2341c79e3cbdaf2/pom.xml#L157-L159

