### PR TITLE
correct mapstore label in Admin Header panel

### DIFF
--- a/header/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/header/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -352,10 +352,10 @@ if(sec_roles != null) {
                         <c:when test='<%= msadmin == true %>'>
                         <c:choose>
                             <c:when test='<%= active.equals("msadmin") %>'>
-                        <li class="active"><a><fmt:message key="mapstore"/></a></li>
+                        <li class="active"><a><fmt:message key="maps"/></a></li>
                             </c:when>
                             <c:otherwise>
-                        <li><a href="/mapstore/#/admin"><fmt:message key="mapstore"/></a></li>
+                        <li><a href="/mapstore/#/admin"><fmt:message key="maps"/></a></li>
                             </c:otherwise>
                         </c:choose>
                         </c:when>

--- a/header/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/header/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -352,10 +352,10 @@ if(sec_roles != null) {
                         <c:when test='<%= msadmin == true %>'>
                         <c:choose>
                             <c:when test='<%= active.equals("msadmin") %>'>
-                        <li class="active"><a><fmt:message key="maps"/></a></li>
+                        <li class="active"><a><fmt:message key="viewer"/></a></li>
                             </c:when>
                             <c:otherwise>
-                        <li><a href="/mapstore/#/admin"><fmt:message key="maps"/></a></li>
+                        <li><a href="/mapstore/#/admin"><fmt:message key="viewer"/></a></li>
                             </c:otherwise>
                         </c:choose>
                         </c:when>


### PR DESCRIPTION
follow-up to #3695 
While logged in as an admin user, the _mapstore admin_ link was displayed as `???mapstore???` because it couldn't find a proper translation.