### PR TITLE
extractorapp - fixing javax.activation issue (#3704)

### DIFF
--- a/extractorapp/src/docker/Dockerfile
+++ b/extractorapp/src/docker/Dockerfile
@@ -2,12 +2,18 @@ FROM jetty:9-jre11
 
 ENV XMS=1G XMX=2G
 
+
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
 COPY --chown=jetty:jetty . /
 
 # Temporary switch to root
 USER root
+# remove jetty embedded "JavaMail", we have our own.
+# fix #3692, #3704: ClassNotFoundException: javax.activation.DataSource
+# https://github.com/eclipse/jetty.docker/issues/10
+RUN rm -r /usr/local/jetty/lib/mail
+
 
 RUN mkdir /mnt/extractorapp_extracts && \
     chown jetty:jetty /etc/georchestra /mnt/extractorapp_extracts


### PR DESCRIPTION
Following the Java11 upgrade

"runtime tested" by removing the mentioned directory directly in a running container & restarting it.
