### PR TITLE
df,gs - fixing debian package calculation

### DIFF
--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -121,7 +121,7 @@
         <artifactId>gt-shapefile</artifactId>
         <version>${gt.version}</version>
       </dependency>
-      <!-- 
+      <!--
       <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-geopkg</artifactId>
@@ -361,7 +361,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- test scoped for spring boot's (1.5.19.RELEASE) TestRestTemplate pass request headers (sec-* headers ignored with 
+      <!-- test scoped for spring boot's (1.5.19.RELEASE) TestRestTemplate pass request headers (sec-* headers ignored with
         default java client) -->
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
@@ -547,9 +547,34 @@
   <profiles>
     <profile>
       <id>debianPackage</id>
+      <properties>
+        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
          <plugins>
+             <plugin>
+               <groupId>pl.project13.maven</groupId>
+               <artifactId>git-commit-id-plugin</artifactId>
+     	         <version>4.0.0</version>
+               <executions>
+                 <execution>
+                   <goals>
+                     <goal>revision</goal>
+                   </goals>
+                 </execution>
+               </executions>
+               <configuration>
+                 <prefix>build</prefix>
+                 <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                 <skipPoms>false</skipPoms>
+                 <verbose>false</verbose>
+                 <gitDescribe>
+                   <tags>true</tags>
+                 </gitDescribe>
+                 <injectIntoSysProperties>true</injectIntoSysProperties>
+               </configuration>
+             </plugin>
              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-plugin</artifactId>
@@ -597,6 +622,23 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.7</version>
                     <executions>
+                        <execution>
+                          <id>set-project-packageversion</id>
+                          <phase>package</phase>
+                          <goals>
+                            <goal>run</goal>
+                          </goals>
+                          <configuration>
+                            <exportAntProperties>true</exportAntProperties>
+                            <target>
+                                <condition property="project.packageVersion"
+                                  value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                                  else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                                <matches string="${project.version}" pattern="SNAPSHOT$" />
+                              </condition>
+                            </target>
+                          </configuration>
+                        </execution>
                         <execution>
                             <id>remove-useless-directories</id>
                             <phase>package</phase>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1071,8 +1071,33 @@
     </profile>
     <profile>
       <id>debianPackage</id>
+      <properties>
+        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+      </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+  	        <version>4.0.0</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>revision</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <prefix>build</prefix>
+              <failOnNoGitDirectory>false</failOnNoGitDirectory>
+              <skipPoms>false</skipPoms>
+              <verbose>false</verbose>
+              <gitDescribe>
+                <tags>true</tags>
+              </gitDescribe>
+              <injectIntoSysProperties>true</injectIntoSysProperties>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-scm-plugin</artifactId>
@@ -1099,6 +1124,23 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.7</version>
             <executions>
+              <execution>
+                <id>set-project-packageversion</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                      <condition property="project.packageVersion"
+                        value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                        else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                    </condition>
+                  </target>
+                </configuration>
+              </execution>
               <execution>
                 <id>remove-useless-directories</id>
                 <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-	  <version>4.0.0</version>
+	        <version>4.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/3701#issuecomment-1081828335
This shall harmonize the calculation on the datafeeder + geoserver
package, as these modules are disconnected from the root pom. We
basically need to copy the missing maven configuration / plugin parts
defined in the root pom.

tests: locally tested a `mvn package deb:package -PdebianPackage`:

* df generated: `georchestra-datafeeder_22.0.0.202204061354~2851446-1_all.deb`
* gs generated: `georchestra-geoserver_22.0.0.202204061357~2851446-1_all.deb`

Note: we probably should port the same modification to master.