### PR TITLE
refix debian package version, matching on branch name instead of SNAPSHOT

### DIFF
--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -632,9 +632,9 @@
                             <exportAntProperties>true</exportAntProperties>
                             <target>
                                 <condition property="project.packageVersion"
-                                  value="99-master.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                                  else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                                <matches string="${project.version}" pattern="SNAPSHOT$" />
+                                  value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                                  else="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                                <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
                               </condition>
                             </target>
                           </configuration>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1134,9 +1134,9 @@
                   <exportAntProperties>true</exportAntProperties>
                   <target>
                       <condition property="project.packageVersion"
-                        value="99-master.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                        else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                        value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                        else="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
                     </condition>
                   </target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -624,9 +624,9 @@
               <exportAntProperties>true</exportAntProperties>
               <target>
                 <condition property="project.packageVersion"
-                  value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                  else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                  <matches string="${project.version}" pattern="SNAPSHOT$" />
+                  value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                  else="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                  <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
                 </condition>
               </target>
             </configuration>


### PR DESCRIPTION
followup to 993e7c7e, 0715664 and #3709

with that, the logic is:
- on stable branches (eg matching \d{2}\.\d\.x$, so 20.1.x, 22.0.x...) start the package version with the closest tag name
- on other branches (master, pull requests, experimental branches..) use 99.master

for geonetwork and cas-server, the upstream version is used (eg 4.0.6-georchestra or 6.3.7.4)

another PR targetting 22.0.x with the same login is coming.