### PR TITLE
refix debian package version, matching on branch name instead of SNAPSHOT

### DIFF
--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -633,8 +633,8 @@
                             <target>
                                 <condition property="project.packageVersion"
                                   value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                                  else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                                <matches string="${project.version}" pattern="SNAPSHOT$" />
+                                  else="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                                <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
                               </condition>
                             </target>
                           </configuration>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1135,8 +1135,8 @@
                   <target>
                       <condition property="project.packageVersion"
                         value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                        else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                        else="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
                     </condition>
                   </target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -625,8 +625,8 @@
               <target>
                   <condition property="project.packageVersion"
                     value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                    else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                  <matches string="${project.version}" pattern="SNAPSHOT$" />
+                    else="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                  <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
                 </condition>
               </target>
             </configuration>


### PR DESCRIPTION
same as #3711

same change done with 5409a104 in master branch
followup to 993e7c7e, 0715664 and #3709

with that, the logic is:
- on stable branches (eg matching \d{2}\.\d\.x$, so 20.1.x, 22.0.x...) start the package version with the closest tag name
- on other branches (master, pull requests, experimental branches..) use 99.master

tested with the diff local on 22.0.x, dpkg --info on the resulting debs gives
me the expected `Version: 22.0.0.202204071436~ae8bbaf` for all georchestra
packages (but geonetwork)

on the master branch with 5409a104, i get `Version: 99.master.202204071442~5409a10`