### PR TITLE
gs - upgrade to 2.18.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ docker-build-geoserver: docker-pull-jetty
 
 docker-build-geoserver-geofence: docker-pull-jetty
 	cd geoserver; \
-	LANG=C mvn clean install -DskipTests -Dfmt.skip=true -Pgeofence-server,${GEOSERVER_EXTENSION_PROFILES} ; \
+	LANG=C mvn clean install -DskipTests -Dfmt.skip=true -Pgeofence,${GEOSERVER_EXTENSION_PROFILES} ; \
 	cd webapp; \
-	mvn clean install docker:build -DdockerImageTags=${BTAG} -Pdocker,geofence,${GEOSERVER_EXTENSION_PROFILES} -DskipTests
+	mvn clean install docker:build -DdockerImageTags=geofence-${BTAG} -Pdocker,geofence,${GEOSERVER_EXTENSION_PROFILES} -DskipTests
 
 docker-build-geowebcache: docker-pull-jetty
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests -pl geowebcache-webapp

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,8 +8,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.18.3</gs.version>
-    <gt.version>24.3</gt.version>
+    <gs.version>2.18.6</gs.version>
+    <gt.version>24.6</gt.version>
     <geofence.version>3.5.0</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>
@@ -17,7 +17,7 @@
     <packageDatadirScmVersion>22.0</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.1.20.RELEASE</spring.version>
+    <spring.version>5.2.20.RELEASE</spring.version>
     <spring-security.version>5.1.13.RELEASE</spring-security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--
@@ -54,6 +54,11 @@
       <url>https://repo.osgeo.org/repository/release/</url>
       <snapshots><enabled>false</enabled></snapshots>
       <releases><enabled>true</enabled></releases>
+    </repository>
+    <repository>
+      <id>geosolutions</id>
+      <name>geosolutions</name>
+      <url>http://maven.geo-solutions.it/</url>
     </repository>
   </repositories>
 </project>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1384,7 +1384,7 @@
         <packageName>georchestra-geoserver-geofence</packageName>
         <dockerGeoserverDatadirScmVersion>geofence</dockerGeoserverDatadirScmVersion>
         <dockerImageName>georchestra/geoserver:geofence-${project.parent.version}</dockerImageName>
-        <hibernate-spatial-version>1.1.3.1</hibernate-spatial-version>
+        <hibernate-spatial-version>1.1.3.2</hibernate-spatial-version>
         <jdbc-postgis-version>1.3.3</jdbc-postgis-version>
       </properties>
       <dependencies>


### PR DESCRIPTION
Note: geofence testsuite is broken, I don't expect this to work at
runtime (at least with geofence enabled). It compiles with skipped
tests though.

Note2: we need to add a maven repository to geo-solutions, because this
is the only place where hibernate-spatial-postgis is available (in
version 1.1.3.2).