### PR TITLE
Update geoserver submodule to include fix for WFS geo+json NPE

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -32,11 +32,7 @@
     <module>geoserver-submodule/src/web/core</module>
     <!-- this ones are not provided onto the osgeo m2 repo -->
     <module>geoserver-submodule/src/extension/wmts-multi-dimensional</module>
-    <module>geoserver-submodule/src/community/ogcapi/ogcapi-styles</module>
-    <module>geoserver-submodule/src/community/ogcapi/ogcapi-tiles</module>
-    <module>geoserver-submodule/src/community/ogcapi/ogcapi-images</module>
-    <module>geoserver-submodule/src/community/ogcapi/ogcapi-changeset</module>
-    <module>geoserver-submodule/src/community/ogcapi/ogcapi-tiled-features</module>
+    <module>geoserver-submodule/src/community/ogcapi</module>
     <module>webapp</module>
   </modules>
   <profiles>


### PR DESCRIPTION
Update geoserver submodule to include fix for WFS geo+json NPE
    
Submodule cherry picked commit "ogcapi's geo+json output formats cause NPE when request comes from WFS"
    
This can be removed once the submodule is updated to an upstream version that has [1] merged.
    
[1] https://github.com/geoserver/geoserver/pull/5843