### PR TITLE
datahub: update CI to use node 16.15

### DIFF
--- a/.github/workflows/datahub.yml
+++ b/.github/workflows/datahub.yml
@@ -6,6 +6,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [ 16.15.0 ]
+
     steps:
 
     - name: "Checking out"
@@ -14,7 +19,7 @@ jobs:
         repository: "geonetwork/geonetwork-ui"
 
     - name: "npm install"
-      run: npm i
+      run: npm ci
 
     - name: "building the docker image"
       run: node_modules/.bin/nx run datahub:docker-build --tag=georchestra/datahub


### PR DESCRIPTION
Force the usage of `npm` version `<= 8.5.5` otherwise the `npm install` fails cause of `peerDependencies`.