### PR TITLE
Fix geoserver pom file to include sentry and logstash dependencies correctly

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1474,5 +1474,28 @@
         </dependency>
       </dependencies>
     </profile>
+    
+    
+    <profile>
+      <id>log4j-logstash</id>
+      <dependencies>
+        <dependency>
+          <groupId>net.logstash.log4j</groupId>
+          <artifactId>jsonevent-layout</artifactId>
+          <version>1.7</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>sentry-log4j</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.sentry</groupId>
+          <artifactId>sentry-log4j</artifactId>
+          <version>1.7.30</version>
+        </dependency>
+      </dependencies>
+    </profile> 
+    
   </profiles>
 </project>


### PR DESCRIPTION
Profiles defined for logstash and sentry at pom.xml root level 
```
<profile>
      <id>log4j-logstash</id>
      <dependencies>
        <dependency>
          <groupId>net.logstash.log4j</groupId>
          <artifactId>jsonevent-layout</artifactId>
          <version>1.7</version>
        </dependency>
      </dependencies>
    </profile>
...
    <profile>
      <id>sentry-log4j</id>
      <dependencies>
        <dependency>
          <groupId>io.sentry</groupId>
          <artifactId>sentry-log4j</artifactId>
          <version>1.7.30</version>
        </dependency>
      </dependencies>
    </profile>
```

are not really doing anything related to including dependencies on the Geoserver build process as in here _georchestra/.github/workflows/geoserver.yml_ :
```
run: ../../mvnw ... clean package docker:build -Pdocker,${{ env.GEOSERVER_EXTENSION_PROFILES }},geofence,log4j-logstash,sentry-log4j .... 
```
Adding the profiles in geoserver/webapp/pom.xml  fixed the build, including these jar files in the resulting WEB-INF/lib folder:

- /WEB-INF/lib/commons-lang-2.6.jar
- /WEB-INF/lib/jsonevent-layout-1.7.jar
- /WEB-INF/lib/json-smart-1.1.1.jar
- /WEB-INF/lib/sentry-1.7.30.jar
- /WEB-INF/lib/sentry-log4j-1.7.30.jar

