### PR TITLE
df-frontend - harmonizing build

### DIFF
--- a/.github/workflows/datafeeder.yml
+++ b/.github/workflows/datafeeder.yml
@@ -77,6 +77,10 @@ jobs:
       if: github.repository == 'georchestra/georchestra'
       run: ./mvnw -f datafeeder/ clean package docker:build -Pdocker -DskipTests -DdockerImageName=georchestra/datafeeder:${{ steps.version.outputs.VERSION }}
 
+    - name: "Building docker image (frontend)"
+      if: github.repository == 'georchestra/georchestra'
+      run: ./mvnw -f datafeeder-ui/ clean package docker:build -Pdocker -DskipTests -DdockerImageName=georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}
+
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/georchestra'
       uses: azure/docker-login@v1
@@ -84,21 +88,25 @@ jobs:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
-    - name: "Pushing latest to docker.io"
+    - name: "Pushing latest images to docker.io"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra'
       run: |
         docker tag georchestra/datafeeder:${{ steps.version.outputs.VERSION }} georchestra/datafeeder:latest
+        docker tag georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }} georchestra/datafeeder-frontend:latest
         docker push georchestra/datafeeder:latest
+        docker push georchestra/datafeeder-frontend:latest
 
-    - name: "Pushing release branch to docker.io"
+    - name: "Pushing release branch to docker.io (22.x series)"
       if: contains(github.ref, 'refs/heads/22.') && github.repository == 'georchestra/georchestra'
       run: |
         docker push georchestra/datafeeder:${{ steps.version.outputs.VERSION }}
+        docker push georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}
 
-    - name: "Pushing release tag to docker.io"
+    - name: "Pushing release tag to docker.io (22.x series)"
       if: contains(github.ref, 'refs/tags/22.') && github.repository == 'georchestra/georchestra'
       run: |
         docker push georchestra/datafeeder:${{ steps.version.outputs.VERSION }}
+        docker push georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}
 
     - name: "Remove SNAPSHOT jars from repository"
       run: |

--- a/datafeeder-ui/pom.xml
+++ b/datafeeder-ui/pom.xml
@@ -142,5 +142,40 @@
             </plugins>
         </build>
     </profile>
+    <profile>
+      <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/datafeeder-frontend:${project.version}</dockerImageName>
+      </properties>
+      <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>1.2.2</version>
+            <configuration>
+              <imageName>${dockerImageName}</imageName>
+              <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
+              <serverId>docker-hub</serverId>
+              <registryUrl>https://index.docker.io/v1/</registryUrl>
+              <resources>
+                <resource>
+                    <targetPath>/datafeeder-ui</targetPath>
+                    <directory>${project.build.directory}/datafeeder-ui</directory>
+                </resource>
+              </resources>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>28.2-jre</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/datafeeder-ui/src/docker/Dockerfile
+++ b/datafeeder-ui/src/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:1.16.0-alpine
+
+RUN rm -rf /usr/share/nginx/html/*
+
+COPY datafeeder-ui/dist/apps/datafeeder/ /usr/share/nginx/html
+COPY datafeeder-ui/nginx-default.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
For now, we are building the docker image for the datafeeder UI into a separate repository, and the generic war / debian package into the main (e.g.this) repository.

this PR aims to harmonize the way we build, by building the docker image at the same place.

Tests: `mvn clean package docker:build -Pdocker` into datafeeder-ui generated a docker image which is quite the same as georchestra/datafeeder-frontend:latest, having a quick look inside it.

If this PR is accepted, then the github action located into the geonetwork-ui fork (branch georchestra-datafeeder) won't be necessary anymore, and there won't be any need of setting a tag there either.

This should not change anything to the other builds (war,deb).