### PR TITLE
Raise RestClient read timeout to 60s 

### DIFF
--- a/security-proxy-spring-integration/src/main/java/org/georchestra/security/client/console/RestClient.java
+++ b/security-proxy-spring-integration/src/main/java/org/georchestra/security/client/console/RestClient.java
@@ -28,7 +28,7 @@ public class RestClient {
         HttpComponentsClientHttpRequestFactory httpRequestFactory = new HttpComponentsClientHttpRequestFactory();
         httpRequestFactory.setConnectionRequestTimeout(3000);
         httpRequestFactory.setConnectTimeout(3000);
-        httpRequestFactory.setReadTimeout(6000);
+        httpRequestFactory.setReadTimeout(60000);
 
         this.restTemplate = new RestTemplate(httpRequestFactory);
         log.info("Created geOrchestra console app REST client for " + baseUri);


### PR DESCRIPTION
As discussed in #3779 this allows the GN4<->LDAP sync to work with ~1k users. To be debated: change the defaults in the datadir repo. And backport to 22.0.