### PR TITLE
console - account creation - improve the error message if e-mail already in use

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -61,6 +61,7 @@ import org.georchestra.ds.users.AccountFactory;
 import org.georchestra.ds.users.DuplicatedEmailException;
 import org.georchestra.ds.users.DuplicatedUidException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -123,6 +124,9 @@ public final class NewAccountFormController {
     protected Clock clock;
 
     private Validation validation;
+
+    @Value("${publicContextPath:/console}")
+    private String publicContextPath;
 
     @Autowired
     public NewAccountFormController(ReCaptchaParameters reCaptchaParameters, Validation validation) {
@@ -320,7 +324,9 @@ public final class NewAccountFormController {
 
         } catch (DuplicatedEmailException e) {
 
-            result.rejectValue("email", "email.error.exist", "there is a user with this e-mail");
+            result.rejectValue("email", "email.error.exist",
+                    new String[] { String.format("%s%s", publicContextPath, "/account/passwordRecovery") },
+                    "there is a user with this e-mail");
             return "createAccountForm";
 
         } catch (DuplicatedUidException e) {

--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -86,7 +86,7 @@ email.label=E-mail
 email.placeholder=E-mail
 email.error.required=Required
 email.error.invalidFormat=Invalid format
-email.error.exist=This e-mail is already in use
+email.error.exist=This e-mail is already in use, you can try to <a href="/console/account/passwordRecovery">reset your password</a>.
 email.error.notFound=No user is registered with this email.
 error.required=Required
 error.badUrl=malformed url

--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -86,7 +86,7 @@ email.label=E-mail
 email.placeholder=E-mail
 email.error.required=Required
 email.error.invalidFormat=Invalid format
-email.error.exist=This e-mail is already in use, you can try to <a href="/console/account/passwordRecovery">reset your password</a>.
+email.error.exist=This e-mail is already in use, you can try to <a href="{0}">reset your password</a>.
 email.error.notFound=No user is registered with this email.
 error.required=Required
 error.badUrl=malformed url

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -86,7 +86,7 @@ email.label=E-Mail
 email.placeholder=E-Mail
 email.error.required=Notwendig
 email.error.invalidFormat=Ungültiges Format
-email.error.exist=Es existiert bereits ein Account mit dieser E-Mail Adresse.
+email.error.exist=Diese E-Mail Adresse ist bereits in Benutzung, Sie können ihr <a href="/console/account/passwordRecovery">Passwort zurücksetzen</a>.
 email.error.notFound=Kein Benutzer ist mit dieser E-Mail registriert.
 error.required=Notwendig
 error.badUrl=malformed url

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -86,7 +86,7 @@ email.label=E-Mail
 email.placeholder=E-Mail
 email.error.required=Notwendig
 email.error.invalidFormat=Ungültiges Format
-email.error.exist=Diese E-Mail Adresse ist bereits in Benutzung, Sie können ihr <a href="/console/account/passwordRecovery">Passwort zurücksetzen</a>.
+email.error.exist=Diese E-Mail Adresse ist bereits in Benutzung, Sie können ihr <a href="{0}">Passwort zurücksetzen</a>.
 email.error.notFound=Kein Benutzer ist mit dieser E-Mail registriert.
 error.required=Notwendig
 error.badUrl=malformed url

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -86,7 +86,7 @@ email.label=Courriel
 email.placeholder=Courriel
 email.error.required=Requis
 email.error.invalidFormat=Format invalide
-email.error.exist=Ce courriel est déjà utilisé
+email.error.exist=Ce courriel est déjà utilisé, vous pouvez tenter de <a href="/console/account/passwordRecovery">réinitialiser votre mot de passe</a>.
 email.error.notFound=Aucun utilisateur n'est enregistré avec ce courriel.
 error.required=Requis
 error.badUrl=Format d'url invalide

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -86,7 +86,7 @@ email.label=Courriel
 email.placeholder=Courriel
 email.error.required=Requis
 email.error.invalidFormat=Format invalide
-email.error.exist=Ce courriel est déjà utilisé, vous pouvez tenter de <a href="/console/account/passwordRecovery">réinitialiser votre mot de passe</a>.
+email.error.exist=Ce courriel est déjà utilisé, vous pouvez tenter de <a href="{0}">réinitialiser votre mot de passe</a>.
 email.error.notFound=Aucun utilisateur n'est enregistré avec ce courriel.
 error.required=Requis
 error.badUrl=Format d'url invalide


### PR DESCRIPTION
For now, when trying to create an account with a mail address which is already used by another account, the console just displays an error message. This PR provides the URL to the password recovery onto the message, to improve the user experience.

Notes:
* This has already been applied on the console from DataGrandEst.
* I am not really happy with hardcoding the `/console/` endpoint, but we don't have much templating capabilities from here ...
* I have no clue for translating this for the `es` and `nl` translations (poke @groldan || José Macchi).


