### PR TITLE
unbreak users with a . in their login (#3802)

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
@@ -70,7 +70,7 @@ public class SecurityApiController {
      * <p>
      * This is the server-side counterpart of {@link UsersApi#findByUsername}
      */
-    @GetMapping(value = "/users/username/{name}")
+    @GetMapping(value = "/users/username/{name:.+}")
     public ResponseEntity<GeorchestraUser> findUserByUsername(@PathVariable("name") String name) {
         return toEntityOrNotFound(users.findByUsername(name));
     }


### PR DESCRIPTION
per https://www.baeldung.com/spring-mvc-pathvariable-dot spring's @PathVariable annotation strips what's after a dot, thinking its a file extension