### PR TITLE
datafeeder: Allow longer text for dataset abstract and genealogy

### DIFF
--- a/datafeeder/api.yaml
+++ b/datafeeder/api.yaml
@@ -425,7 +425,8 @@ components:
           description: Metadata title for the dataset
         abstract:
           type: string
-          description: Metadata abtract text for the dataset 
+          description: Metadata abtract text for the dataset
+          maxLength: 4096
         tags:
           type: array
           description: metadata keyworkds for the dataset
@@ -444,6 +445,7 @@ components:
         creationProcessDescription:
           type: string
           description: textual description of dataset lineage
+          maxLength: 4096
 
     DatasetPublishRequest:
       type: object

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -353,6 +353,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <exclusions>
+      	<exclusion>
+      		<groupId>com.vaadin.external.google</groupId>
+      		<artifactId>android-json</artifactId>
+      	</exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/DatasetUploadState.java
@@ -56,7 +56,7 @@ public class DatasetUploadState {
     @ManyToOne(fetch = FetchType.EAGER)
     private DataUploadJob job;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 2048)
     private String absolutePath;
 
     @Column(nullable = false)

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/model/PublishSettings.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/model/PublishSettings.java
@@ -29,6 +29,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.persistence.FetchType;
+import javax.persistence.Lob;
 
 import lombok.Data;
 
@@ -59,10 +60,11 @@ public class PublishSettings {
     @Column(name = "md_record_id")
     private String metadataRecordId;
 
-    @Column(name = "md_title")
+    @Column(name = "md_title", length = 512)
     private String title;
 
     @Column(name = "md_abstract")
+    @Lob
     private String Abstract;
 
     @ElementCollection(fetch = FetchType.EAGER)
@@ -76,6 +78,7 @@ public class PublishSettings {
     private Integer scale;
 
     @Column(name = "md_creation_process_desc")
+    @Lob
     private String datasetCreationProcessDescription;
 
     @Embedded

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -61,7 +61,7 @@ datafeeder:
       baseNamespaceURI: ${publicUrl}/import
 
 feign:
-  okhttp.enabled: true
+  okhttp.enabled: false
   httpclient.enabled: false 
   client:
     config:
@@ -72,11 +72,11 @@ feign:
 
 logging:
   level:
-    root: INFO
-    feign: INFO
-    org.georchestra.datafeeder: INFO
-    org.geoserver.openapi: INFO
-    org.geoserver.restconfig: INFO
+    root: warn
+    feign: info
+    org.georchestra.datafeeder: warn
+    org.geoserver.openapi: warn
+    org.geoserver.restconfig: warn
 ---
 spring:
   profiles: georchestra
@@ -143,12 +143,12 @@ datafeeder:
     geoserver:
       api-url: http://localhost:18080/geoserver/rest
       public-url: https://georchestra.mydomain.org/geoserver
-      log-requests: true
+      log-requests: false
       baseNamespaceURI: ${publicUrl}/import
     geonetwork:
       api-url: http://localhost:28080/geonetwork
       public-url: https://georchestra.mydomain.org/geonetwork
-      log-requests: true
+      log-requests: false
     backend:
       local:
         dbtype: postgis
@@ -167,13 +167,5 @@ datafeeder:
         user: georchestra
         passwd: georchestra
 
-feign.client.config.default.loggerLevel: full # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
-
-logging:
-  level:
-    root: info
-    '[feign]': info
-    '[org.georchestra.datafeeder]': info
-    '[org.georchestra.config.security]': info
-    '[org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationFilter]': info #mute GeorchestraSecurityProxyAuthenticationFilter superclass a bit
-    '[org.geoserver.openapi]': info
+feign.client.config.default.loggerLevel: basic # one of none|basic|headers|full. Only activated if 'logging.level.feign: DEBUG'
+logging.level.org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver: error

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -82,7 +82,10 @@ spring:
   profiles: georchestra
   jpa.database-platform: org.hibernate.dialect.PostgreSQL10Dialect
   jpa.hibernate.ddl-auto: update
-  jackson.default-property-inclusion: non-null
+  jackson:
+    default-property-inclusion: non-null
+    serialization:
+      indent-output: true
   batch:
     job.enabled: false #disable automatically running configured jobs at startup time
     initialize-schema: always

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
@@ -149,7 +149,7 @@ public class GeorchestraMetadataPublicationServiceIT {
 
         final String publishedRecord = geonetwork.getRecordById(createdMdId);
         assertNotNull(publishedRecord);
-        log.info("published record returned from GN: {}", publishedRecord);
+        log.debug("published record returned from GN: {}", publishedRecord);
 
         Document dom;
         try {

--- a/datafeeder/src/test/resources/logback-test.xml
+++ b/datafeeder/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="ch.qos.logback" level="error"/>
+    <logger name="com.zaxxer.hikari.HikariConfig" level="error"/>
+    <logger name="org.georchestra.datafeeder" level="warn"/>
+</configuration>


### PR DESCRIPTION
Publish requests with dataset abstract or genealogy text longer than 255 characters were failing.

This patch sets an API limit of 4096 chars for both request attributes, and configure the JPA entity attributes as CLOBs.

No manual database schema upgrade would be needed since the embedded application.yml configuration file sets the
`spring.jpa.hibernate.ddl-auto: update` property, and hence the required db change will be applied automatically.

As a reference, the `4096` chars limit is equivalent to the following text:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eget sapien sed libero volutpat placerat.
Etiam eu sagittis ligula. In nisl lorem, ornare eu justo at, interdum rhoncus mauris. Morbi enim ex, imperdiet
id tristique sed, porttitor a purus. Vivamus est lorem, ultricies lobortis facilisis quis, cursus sit amet nibh.
Nunc ut mollis lectus, non condimentum ipsum. Sed eget eros neque. Phasellus id dolor eget nibh tristique
maximus at eget nibh. Pellentesque sed erat id mauris lacinia semper et eu metus. Duis vestibulum vel enim et
ullamcorper. Curabitur vehicula, magna ut aliquet vestibulum, odio odio tempus erat, ut euismod felis lectus non
orci. Nulla elementum velit lectus, eget dictum felis suscipit vel. Ut a risus in nibh mollis semper ut non lacus.
In hac habitasse platea dictumst. Fusce tincidunt sem nec ex accumsan luctus. Cras egestas nisi ut est luctus,
vel tincidunt ante tempus.

Aenean at odio congue, eleifend tellus vitae, lacinia augue. Vivamus mauris augue, maximus sit amet faucibus id,
hendrerit et orci. Maecenas suscipit libero sem, vitae posuere tortor imperdiet eget. Donec auctor dictum est nec
dictum. Sed ut vulputate urna, id pharetra lorem. Fusce sit amet laoreet risus, at elementum lectus. Praesent in
lacus quam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec at interdum
turpis, vitae luctus enim. Nullam sit amet sem vehicula, elementum sapien sed, consectetur ipsum. Quisque semper nec
mauris a blandit. Duis sapien ligula, pellentesque sit amet neque porta, dignissim elementum tortor. Maecenas turpis
felis, dictum nec cursus at, convallis non est. Fusce ex leo, pretium ac nulla sed, porta vehicula ligula. In eget
rutrum tellus, non tincidunt ligula. Donec pellentesque vestibulum sollicitudin.

Donec a lorem eu elit porta blandit viverra et odio. Mauris iaculis orci arcu, quis pretium libero varius ut. Phasellus
non facilisis massa. Nulla scelerisque est velit, vel porta justo euismod a. Orci varius natoque penatibus et magnis dis
parturient montes, nascetur ridiculus mus. Phasellus placerat accumsan ligula, id molestie elit varius sit amet. Nulla
lacinia mattis tristique. Mauris mollis porttitor sem, molestie sagittis enim placerat sit amet.

Nunc mollis vel ex vel interdum. Suspendisse pretium, lectus eu interdum vestibulum, leo nisl lacinia nibh, sit amet
egestas tortor dolor eget enim. Duis feugiat semper tortor eu imperdiet. Donec sodales ipsum eu sapien bibendum, ac
elementum tortor aliquet. Quisque auctor risus mollis, tincidunt nisl a, varius dolor. Ut aliquam id elit eget
tristique. Ut pretium nunc vel auctor malesuada. Nulla commodo fermentum eleifend. In ultrices tortor dui, at varius
sapien laoreet sit amet.
latea nam.
Cras odio risus, euismod non turpis dignissim, rhoncus tempus ex. Nunc fermentum lobortis libero, sed semper dolor
euismod sit amet. Aliquam erat volutpat. Vestibulum id turpis vel elit ultricies tempus sit amet in est. Duis ultricies
in enim a suscipit. Morbi vitae tincidunt mi, et cursus turpis. Mauris lacinia bibendum massa, a pellentesque orci tincidunt
sit amet. Praesent porta condimentum bibendum. Nulla ultrices ut mauris convallis elementum. Sed tellus augue, cursus vitae
neque sit amet, consectetur porttitor diam. Donec bibendum quis libero sit amet ultricies. Sed sit amet ipsum tempus,
cursus neque in, rutrum magna. Ut nisl purus, rhoncus nec elementum ac, consequat quis lectus. Nunc pretium porttitor nisl,
id faucibus erat porta at. Fusce vitae accumsan arcu.

Phasellus nec mattis sem. Nunc eu suscipit est. Nullam at lacinia erat. Etiam iaculis augue ut nisl consectetur tincidunt.
Etiam eu vulputate lorem. Nunc sed velit sed leo molestie cursus. Maecenas sed odio dapibus, fermentum enim eget, consequat
metus. Aenean in metus at enim consectetur ullamcorper. Ut leo ligula, gravida et nisl non, semper euismod felis. In
ultricies risus ultrices, porttitor velit ut, feugiat purus. Nunc interdum molestie nunc, eget volutpat ante tempus non.
Cras ac ligula in neque pellentesque finibus commodo in dui. In hac habitasse p
```