### PR TITLE
Ldap logo to gn

### DIFF
--- a/commons/src/main/java/org/georchestra/security/api/OrganizationsApi.java
+++ b/commons/src/main/java/org/georchestra/security/api/OrganizationsApi.java
@@ -30,4 +30,6 @@ public interface OrganizationsApi {
     Optional<Organization> findById(String id);
 
     Optional<Organization> findByShortName(String shortName);
+
+    Optional<byte[]> getLogo(String id);
 }

--- a/commons/src/main/java/org/georchestra/security/model/GeorchestraUserHasher.java
+++ b/commons/src/main/java/org/georchestra/security/model/GeorchestraUserHasher.java
@@ -51,9 +51,9 @@ public class GeorchestraUserHasher {
         return hexHash;
     }
 
-    public static String createHash(Organization organization) {
+    public static String createHash(Organization organization, int logoSize) {
         Hasher hasher = Hashing.sha256().newHasher();
-        hashOrg(organization, hasher);
+        hashOrg(organization, logoSize, hasher);
         String hexHash = hasher.hash().toString();
         return hexHash;
     }
@@ -68,7 +68,7 @@ public class GeorchestraUserHasher {
         return hexHash;
     }
 
-    private static void hashOrg(Organization org, Hasher hasher) {
+    private static void hashOrg(Organization org, int logoSize, Hasher hasher) {
         hasher.putUnencodedChars("org");
         if (null != org) {
             hasher.putUnencodedChars(nonNull(org.getId()));
@@ -79,6 +79,7 @@ public class GeorchestraUserHasher {
             hasher.putUnencodedChars(nonNull(org.getDescription()));
             hasher.putUnencodedChars(nonNull(org.getLinkage()));
             hasher.putUnencodedChars(nonNull(org.getNotes()));
+            hasher.putUnencodedChars(logoSize > 0 ? Integer.toString(logoSize) : "");
             hashList(org.getMembers(), hasher);
         }
     }

--- a/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
@@ -137,7 +137,6 @@ public class SecurityApiController {
         if (found.isPresent()) {
             return ResponseEntity.ok(found.get());
         }
-        return ResponseEntity.notFound().build();
-
+        return ResponseEntity.ok().build();
     }
 }

--- a/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
@@ -107,6 +107,11 @@ public class SecurityApiController {
         return toEntityOrNotFound(this.orgs.findByShortName(name));
     }
 
+    @GetMapping(value = "/organizations/id/{id}/logo", produces = "application/octet-stream")
+    public ResponseEntity<byte[]> getOrganizationLogo(@PathVariable("id") String id) {
+        return toEntityOrNotFound(this.orgs.getLogo(id));
+    }
+
     /**
      * Return a list of available roles as a json array
      * <p>

--- a/console/src/test/java/org/georchestra/console/integration/OrgsIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/OrgsIT.java
@@ -31,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -45,6 +46,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @RunWith(SpringRunner.class)
@@ -140,7 +142,13 @@ public class OrgsIT extends ConsoleIntegrationTest {
 
         create(orgName);
 
-        support.perform(get("/private/orgs/" + orgName)).andExpect(jsonPath("$.logo").value(""));
+        StringCaptor uuidCaptor = new StringCaptor();
+        support.perform(get("/private/orgs/" + orgName)).andExpect(jsonPath("$.logo").value(""))
+                .andExpect(jsonPath("$.uuid").value(uuidCaptor));
+        support.perform(get("/internal/organizations/id/" + uuidCaptor.getValue() + "/logo")).andExpect(status().isOk())
+                .andExpect(result -> result.getResponse().getContentAsString().isEmpty());
+        support.perform(get("/internal/organizations/id/" + UUID.randomUUID() + "/logo")).andExpect(status().isOk())
+                .andExpect(result -> result.getResponse().getContentAsString().isEmpty());
     }
 
     @WithMockUser(username = "admin", roles = "SUPERUSER")

--- a/console/src/test/java/org/georchestra/console/integration/OrgsIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/OrgsIT.java
@@ -118,21 +118,15 @@ public class OrgsIT extends ConsoleIntegrationTest {
 
         create(orgName, "/testData/createOrgWithMoreFieldsPayload.json");
 
-        final String[] uuidCaptor = new String[1];
+        StringCaptor uuidCaptor = new StringCaptor();
         support.perform(get("/private/orgs/" + orgName))
                 .andExpect(jsonPath("$.logo").value(stringContainsInOrder(
                         Arrays.asList("/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBQgMFBofBgYHCg0dHhwHBwgMFB0jHAcJCw8aLCgf",
                                 "cH35r5o8W/EvV9Xc/bLp4bfP7jT4jhY1/wCmg7n3P4YrlhjtXfDCfzz+R2wwv88j7TtL+2nXNldW",
                                 "BRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAA/9k="))))
-                .andExpect(jsonPath("$.uuid").value(new CustomMatcher<Object>("") {
-                    @Override
-                    public boolean matches(Object o) {
-                        uuidCaptor[0] = o.toString();
-                        return true;
-                    }
-                }));
+                .andExpect(jsonPath("$.uuid").value(uuidCaptor));
 
-        byte[] logo = support.perform(get("/internal/organizations/id/" + uuidCaptor[0] + "/logo")).andReturn()
+        byte[] logo = support.perform(get("/internal/organizations/id/" + uuidCaptor.getValue() + "/logo")).andReturn()
                 .getResponse().getContentAsByteArray();
         byte[] md5 = MessageDigest.getInstance("MD5").digest(logo);
         assertArrayEquals(new byte[] { -81, 25, 73, -126, -100, -125, 2, 34, 45, -47, 60, -40, -123, -105, 107, 61 },
@@ -197,4 +191,22 @@ public class OrgsIT extends ConsoleIntegrationTest {
                 .content(support.readResourceToString(payloadResourcePath).replace("{shortName}", name)));
     }
 
+    private static class StringCaptor extends CustomMatcher {
+
+        private String value;
+
+        public StringCaptor() {
+            super("");
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            value = o.toString();
+            return true;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
 }

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/OrganizationMapper.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/OrganizationMapper.java
@@ -54,7 +54,7 @@ public interface OrganizationMapper {
 
     @AfterMapping
     default void addLastUpdated(Org source, @MappingTarget Organization target) {
-        String hash = GeorchestraUserHasher.createHash(target);
+        String hash = GeorchestraUserHasher.createHash(target, source.getLogo().length());
         target.setLastUpdated(hash);
     }
 

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/OrganizationsApiImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/OrganizationsApiImpl.java
@@ -20,6 +20,8 @@ package org.georchestra.ds.security;
 
 import static com.google.common.base.Predicates.not;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -62,6 +64,16 @@ public class OrganizationsApiImpl implements OrganizationsApi {
         return Optional.ofNullable(orgsDao.findByCommonName(shortName))//
                 .filter(not(Org::isPending))//
                 .map(orgMapper::map);
+    }
+
+    @Override
+    public Optional<byte[]> getLogo(String id) {
+        UUID uuid = UUID.fromString(id);
+        byte[] base64encoded = orgsDao.findById(uuid).getLogo().getBytes(StandardCharsets.UTF_8);
+        if (base64encoded.length == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(Base64.getMimeDecoder().decode(base64encoded));
     }
 
 }

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/OrganizationsApiImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/OrganizationsApiImpl.java
@@ -69,7 +69,11 @@ public class OrganizationsApiImpl implements OrganizationsApi {
     @Override
     public Optional<byte[]> getLogo(String id) {
         UUID uuid = UUID.fromString(id);
-        byte[] base64encoded = orgsDao.findById(uuid).getLogo().getBytes(StandardCharsets.UTF_8);
+        Org org = orgsDao.findById(uuid);
+        if (org == null) {
+            return Optional.empty();
+        }
+        byte[] base64encoded = org.getLogo().getBytes(StandardCharsets.UTF_8);
         if (base64encoded.length == 0) {
             return Optional.empty();
         }

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -92,12 +92,12 @@ public class InternalSecurityApiImplIT {
         return Collections.unmodifiableList(readValues);
     }
 
-    public @Test void testUsersApi_FindAll() throws Exception {
+    public @Test void testUsersApi_FindAll() {
         Map<String, GeorchestraUser> actual = toMap(users.findAll(), GeorchestraUser::getId);
         assertEquals(expectedUsers, actual);
     }
 
-    public @Test void testUsersApi_FindById() throws Exception {
+    public @Test void testUsersApi_FindById() {
         expectedUsers.values().forEach(user -> {
             Optional<GeorchestraUser> found = users.findById(user.getId());
             assertTrue(found.isPresent());
@@ -105,7 +105,7 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testUsersApi_FindByUsername() throws Exception {
+    public @Test void testUsersApi_FindByUsername() {
         expectedUsers.values().forEach(expected -> {
             Optional<GeorchestraUser> found = users.findByUsername(expected.getUsername());
             assertTrue(found.isPresent());
@@ -113,12 +113,12 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testOrganizationsApi_FindAll() throws Exception {
+    public @Test void testOrganizationsApi_FindAll() {
         Map<String, Organization> actual = toMap(orgs.findAll(), Organization::getId);
         assertEquals(expectedOrganizations, actual);
     }
 
-    public @Test void testOrganizationsApi_FindById() throws Exception {
+    public @Test void testOrganizationsApi_FindById() {
         expectedOrganizations.values().forEach(expected -> {
             Optional<Organization> found = orgs.findById(expected.getId());
             assertTrue(found.isPresent());
@@ -126,7 +126,7 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testOrganizationsApi_FindByShortName() throws Exception {
+    public @Test void testOrganizationsApi_FindByShortName() {
         expectedOrganizations.values().forEach(expected -> {
             Optional<Organization> found = orgs.findByShortName(expected.getShortName());
             assertTrue(found.isPresent());
@@ -134,12 +134,12 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testRolesApi_FindAll() throws Exception {
+    public @Test void testRolesApi_FindAll() {
         Map<String, Role> actual = toMap(roles.findAll(), Role::getId);
         assertEquals(expectedRoles, actual);
     }
 
-    public @Test void testRolesApi_FindByName() throws Exception {
+    public @Test void testRolesApi_FindByName() {
         expectedRoles.values().forEach(role -> {
             Optional<Role> found = roles.findByName(role.getName());
             assertTrue(found.isPresent());

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -92,12 +92,12 @@ public class InternalSecurityApiImplIT {
         return Collections.unmodifiableList(readValues);
     }
 
-    public @Test void testUsersApi_FindAll() {
+    public @Test void usersApi_FindAll() {
         Map<String, GeorchestraUser> actual = toMap(users.findAll(), GeorchestraUser::getId);
         assertEquals(expectedUsers, actual);
     }
 
-    public @Test void testUsersApi_FindById() {
+    public @Test void usersApi_FindById() {
         expectedUsers.values().forEach(user -> {
             Optional<GeorchestraUser> found = users.findById(user.getId());
             assertTrue(found.isPresent());
@@ -105,7 +105,7 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testUsersApi_FindByUsername() {
+    public @Test void usersApi_FindByUsername() {
         expectedUsers.values().forEach(expected -> {
             Optional<GeorchestraUser> found = users.findByUsername(expected.getUsername());
             assertTrue(found.isPresent());
@@ -113,12 +113,12 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testOrganizationsApi_FindAll() {
+    public @Test void organizationsApi_FindAll() {
         Map<String, Organization> actual = toMap(orgs.findAll(), Organization::getId);
         assertEquals(expectedOrganizations, actual);
     }
 
-    public @Test void testOrganizationsApi_FindById() {
+    public @Test void organizationsApi_FindById() {
         expectedOrganizations.values().forEach(expected -> {
             Optional<Organization> found = orgs.findById(expected.getId());
             assertTrue(found.isPresent());
@@ -126,7 +126,7 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testOrganizationsApi_FindByShortName() {
+    public @Test void organizationsApi_FindByShortName() {
         expectedOrganizations.values().forEach(expected -> {
             Optional<Organization> found = orgs.findByShortName(expected.getShortName());
             assertTrue(found.isPresent());
@@ -134,12 +134,12 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void testRolesApi_FindAll() {
+    public @Test void rolesApi_FindAll() {
         Map<String, Role> actual = toMap(roles.findAll(), Role::getId);
         assertEquals(expectedRoles, actual);
     }
 
-    public @Test void testRolesApi_FindByName() {
+    public @Test void rolesApi_FindByName() {
         expectedRoles.values().forEach(role -> {
             Optional<Role> found = roles.findByName(role.getName());
             assertTrue(found.isPresent());

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -96,12 +96,12 @@ public class InternalSecurityApiImplIT {
         return Collections.unmodifiableList(readValues);
     }
 
-    public @Test void usersApi_FindAll() {
+    public @Test void usersApiFindAll() {
         Map<String, GeorchestraUser> actual = toMap(users.findAll(), GeorchestraUser::getId);
         assertEquals(expectedUsers, actual);
     }
 
-    public @Test void usersApi_FindById() {
+    public @Test void usersApiFindById() {
         expectedUsers.values().forEach(user -> {
             Optional<GeorchestraUser> found = users.findById(user.getId());
             assertTrue(found.isPresent());
@@ -109,7 +109,7 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void usersApi_FindByUsername() {
+    public @Test void usersApiFindByUsername() {
         expectedUsers.values().forEach(expected -> {
             Optional<GeorchestraUser> found = users.findByUsername(expected.getUsername());
             assertTrue(found.isPresent());
@@ -117,12 +117,12 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void organizationsApi_FindAll() {
+    public @Test void organizationsApiFindAll() {
         Map<String, Organization> actual = toMap(orgs.findAll(), Organization::getId);
         assertEquals(expectedOrganizations, actual);
     }
 
-    public @Test void organizationsApi_FindById() {
+    public @Test void organizationsApiFindById() {
         expectedOrganizations.values().forEach(expected -> {
             Optional<Organization> found = orgs.findById(expected.getId());
             assertTrue(found.isPresent());
@@ -130,7 +130,7 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void organizationsApi_FindByShortName() {
+    public @Test void organizationsApiFindByShortName() {
         expectedOrganizations.values().forEach(expected -> {
             Optional<Organization> found = orgs.findByShortName(expected.getShortName());
             assertTrue(found.isPresent());
@@ -138,23 +138,23 @@ public class InternalSecurityApiImplIT {
         });
     }
 
-    public @Test void organizationsApi_GetLogo() throws NoSuchAlgorithmException {
+    public @Test void organizationsApiGetLogo() throws NoSuchAlgorithmException {
         byte[] logo = orgs.getLogo("bddf474d-125d-4b18-92bd-bd8ebb6699a9").get();
         byte[] md5 = MessageDigest.getInstance("MD5").digest(logo);
         assertArrayEquals(new byte[] { -81, 25, 73, -126, -100, -125, 2, 34, 45, -47, 60, -40, -123, -105, 107, 61 },
                 md5);
     }
 
-    public @Test void organizationsApi_GetLogoNoLogo() {
+    public @Test void organizationsApiGetLogoNoLogo() {
         assertFalse(orgs.getLogo("8c1ef87a-73fc-4d79-80cb-ba4ff7102cca").isPresent());
     }
 
-    public @Test void rolesApi_FindAll() {
+    public @Test void rolesApiFindAll() {
         Map<String, Role> actual = toMap(roles.findAll(), Role::getId);
         assertEquals(expectedRoles, actual);
     }
 
-    public @Test void rolesApi_FindByName() {
+    public @Test void rolesApiFindByName() {
         expectedRoles.values().forEach(role -> {
             Optional<Role> found = roles.findByName(role.getName());
             assertTrue(found.isPresent());

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -141,7 +141,8 @@ public class InternalSecurityApiImplIT {
     public @Test void organizationsApi_GetLogo() throws NoSuchAlgorithmException {
         byte[] logo = orgs.getLogo("bddf474d-125d-4b18-92bd-bd8ebb6699a9").get();
         byte[] md5 = MessageDigest.getInstance("MD5").digest(logo);
-        assertArrayEquals(new byte[] {-81, 25, 73, -126, -100, -125, 2, 34, 45, -47, 60, -40, -123, -105, 107, 61}, md5);
+        assertArrayEquals(new byte[] { -81, 25, 73, -126, -100, -125, 2, 34, 45, -47, 60, -40, -123, -105, 107, 61 },
+                md5);
     }
 
     public @Test void organizationsApi_GetLogoNoLogo() {

--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -18,11 +18,15 @@
  */
 package org.georchestra.ds.security;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -132,6 +136,16 @@ public class InternalSecurityApiImplIT {
             assertTrue(found.isPresent());
             assertEquals(found.get(), expected);
         });
+    }
+
+    public @Test void organizationsApi_GetLogo() throws NoSuchAlgorithmException {
+        byte[] logo = orgs.getLogo("bddf474d-125d-4b18-92bd-bd8ebb6699a9").get();
+        byte[] md5 = MessageDigest.getInstance("MD5").digest(logo);
+        assertArrayEquals(new byte[] {-81, 25, 73, -126, -100, -125, 2, 34, 45, -47, 60, -40, -123, -105, 107, 61}, md5);
+    }
+
+    public @Test void organizationsApi_GetLogoNoLogo() {
+        assertFalse(orgs.getLogo("8c1ef87a-73fc-4d79-80cb-ba4ff7102cca").isPresent());
     }
 
     public @Test void rolesApi_FindAll() {

--- a/ldap-account-management/src/test/resources/defaultOrganizations.json
+++ b/ldap-account-management/src/test/resources/defaultOrganizations.json
@@ -8,7 +8,7 @@
 		"category": "Association",
 		"description": "Association PSC geOrchestra",
 		"notes": "Internal CRM notes on PSC",
-		"lastUpdated": "2200a6051fcef499884e1cfa8b6625766e76df75d18ce2316c23b421db99e147",
+		"lastUpdated": "b9142a69098fecfb1b639d6a8e9ac091284a23f6cc103dc3f5ca71688e42d9c3",
 		"members": [
 			"testadmin",
 			"testuser"

--- a/security-proxy-spring-integration/src/main/java/org/georchestra/security/client/console/GeorchestraConsoleOrganizationsApiImpl.java
+++ b/security-proxy-spring-integration/src/main/java/org/georchestra/security/client/console/GeorchestraConsoleOrganizationsApiImpl.java
@@ -54,4 +54,9 @@ public class GeorchestraConsoleOrganizationsApiImpl implements OrganizationsApi 
         return client.get("/console/internal/organizations/shortname/{name}", Organization.class, shortName);
     }
 
+    @Override
+    public Optional<byte[]> getLogo(String id) {
+        return client.get("/console/internal/organizations/id/{id}/logo", byte[].class, id);
+    }
+
 }


### PR DESCRIPTION
bring an entry point at console / security side so to retrieve an organisation logo, given its uuid, canonical, org lastUpdated hash taking into account logo updates.

logo can be retrieved from org uuid, but do not travel with common module organisation dto over network.

linked with https://github.com/georchestra/geonetwork/pull/218.



