### PR TITLE
Prevent preflight requests interception

### DIFF
--- a/security-proxy/src/main/java/org/georchestra/security/RemovePreflightHandlerMapping.java
+++ b/security-proxy/src/main/java/org/georchestra/security/RemovePreflightHandlerMapping.java
@@ -1,0 +1,18 @@
+package org.georchestra.security;
+
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Prevent preflight requests interception.
+ */
+public class RemovePreflightHandlerMapping extends DefaultAnnotationHandlerMapping {
+    @Override
+    protected HandlerExecutionChain getCorsHandlerExecutionChain(HttpServletRequest request,
+            HandlerExecutionChain chain, CorsConfiguration config) {
+        return chain; // Return the same chain it uses for everything else.
+    }
+}

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -13,6 +13,8 @@
 
     <context:annotation-config/>
 
+    <bean class="org.georchestra.security.RemovePreflightHandlerMapping" />
+
     <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
         <property name="prefix" value="/"/>
         <property name="suffix" value=".jsp"/>


### PR DESCRIPTION
In CORS scenario, proxy handle preflight (OPTIONS) requests it-self and returns 403 Invalid CORS request.

This change prevent proxy from interfering with requests OPTIONS, it will transfert the request to the services (geoserver, geonetwork) as for other requests.

See: https://jira.camptocamp.com/browse/GEO-5997

Testable with:
```
curl 'http://localhost:8080/geonetwork/srv/eng/csw' \
  -X 'OPTIONS' \
  -H 'Accept: */*' \
  -H 'Accept-Language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7' \
  -H 'Access-Control-Request-Headers: accept-language,content-type' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Connection: keep-alive' \
  -H 'Origin: https://dynafor.toulouse.inrae.fr' \
  -H 'Referer: https://dynafor.toulouse.inrae.fr/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: cross-site' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36' \
  --compressed
```