### PR TITLE
[22.0] update to geoserver 2.18.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 [submodule "geoserver/geoserver-submodule"]
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
-	branch = 2.18.6-georchestra
+	branch = 2.18.7-georchestra

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,8 +8,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.18.6</gs.version>
-    <gt.version>24.6</gt.version>
+    <gs.version>2.18.7</gs.version>
+    <gt.version>24.7</gt.version>
     <geofence.version>3.5.0</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>


### PR DESCRIPTION
fixes https://github.com/geoserver/geoserver/security/advisories/GHSA-7g5f-wrx8-5ccf

for the record, `2.18.7-georchestra` branch done with the following steps under `geoserver/geoserver-submodule`:
```
git checkout 2.18.6-georchestra
git checkout -b 2.18.7-georchestra
git rebase upstream/2.18.x
git grep -l '<version>2.18.6' src/ |xargs sed -i -e 's/version>2.18.6/version>2.18.7/'
sed -i -e 's/gt.version>24.6/gt.version>24.7/' src/pom.xml
git commit
```
the last command ends up with georchestra/geoserver@251d1931ce which matches geoserver/geoserver@eae3b636d9c18da2b5740743201bff186ebceeec which corresponds to the upstream git tag https://github.com/geoserver/geoserver/releases/tag/2.18.7

tested by a local build with `make deb-build-geoserver`, the resulting war/deb only contains the fixed geotools 24.7, and at runtime the about page of geoserver correctly states this:
```
Version
2.18.7-georchestra
Version de GeoTools
24.7 (rev 39a268ed0974c7a89040d1fd72c269965fd391c1) 
```