### PR TITLE
[20.1] update to geoserver 2.18.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 [submodule "geoserver/geoserver-submodule"]
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
-	branch = 2.18.6-georchestra
+	branch = 2.18.7-georchestra

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -13,8 +13,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.18.6</gs.version>
-    <gt.version>24.6</gt.version>
+    <gs.version>2.18.7</gs.version>
+    <gt.version>24.7</gt.version>
     <geofence.version>3.5.0</geofence.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <marlin.version>0.9.3</marlin.version>


### PR DESCRIPTION
fixes https://github.com/geoserver/geoserver/security/advisories/GHSA-7g5f-wrx8-5ccf

backport of #3901 to branch 20.1.x. Master branch should get updated to 2.22.2.