### PR TITLE
console - fix aera of competence removal (#3468)

### DIFF
--- a/ldap-account-management/src/main/java/org/georchestra/ds/orgs/OrgsDaoImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/orgs/OrgsDaoImpl.java
@@ -24,15 +24,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -165,12 +157,20 @@ public class OrgsDaoImpl implements OrgsDao {
                 List<String> descriptions = new ArrayList<>();
                 int maxFieldSize = 1000;
 
-                for (String city : org.getCities()) {
-                    if (buffer.length() > maxFieldSize) {
-                        descriptions.add(buffer.substring(1));
-                        buffer = new StringBuilder();
+                // special case where cities is empty
+                if (org.getCities().size() == 0) {
+                    Object[] values = context.getObjectAttributes("description");
+                    if (values != null) {
+                        Arrays.asList(values).stream().forEach(v -> context.removeAttributeValue("description", v));
                     }
-                    buffer.append("," + city);
+                } else {
+                    for (String city : org.getCities()) {
+                        if (buffer.length() > maxFieldSize) {
+                            descriptions.add(buffer.substring(1));
+                            buffer = new StringBuilder();
+                        }
+                        buffer.append("," + city);
+                    }
                 }
                 if (buffer.length() > 0)
                     descriptions.add(buffer.substring(1));

--- a/ldap-account-management/src/test/java/org/georchestra/ds/orgs/OrgsDaoImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/orgs/OrgsDaoImplIT.java
@@ -1,21 +1,6 @@
 package org.georchestra.ds.orgs;
 
-import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.BasicAttribute;
-import javax.naming.directory.BasicAttributes;
-
+import com.google.common.collect.Lists;
 import org.georchestra.ds.users.Account;
 import org.georchestra.ds.users.AccountDao;
 import org.georchestra.ds.users.AccountImpl;
@@ -32,7 +17,17 @@ import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.google.common.collect.Lists;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.junit.Assert.*;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(locations = { "classpath:testApplicationContext.xml" })

--- a/ldap-account-management/src/test/java/org/georchestra/ds/orgs/OrgsDaoImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/orgs/OrgsDaoImplIT.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -217,5 +218,24 @@ public class OrgsDaoImplIT {
 
         Org org = toTest.mapFromAttributes(orgToDeserialize);
         assertTrue("Expected 6 cities", org.getCities().size() == 6);
+    }
+
+    @Test
+    public void testOrgAttributeMapperRemovingAllCities() {
+        Org ncOrg = new Org();
+        ncOrg.setId("ncorg");
+        ncOrg.setName("ncorg");
+        ncOrg.setShortName("no cities org");
+        ncOrg.setCities(Lists.newArrayList("Paris"));
+        ncOrg.setOrgType("Non Profit");
+        dao.insert(ncOrg);
+        ncOrg = dao.findByCommonName(ncOrg.getId());
+        ncOrg.setCities(List.of());
+
+        dao.update(ncOrg);
+
+        Org updated = dao.findByCommonName(ncOrg.getId());
+        assertEquals(ncOrg, updated);
+        assertEquals(0, updated.getCities().size());
     }
 }


### PR DESCRIPTION
When removing all the aeras of competence from an organization, the 'description' attribute of the OrgExt has to be removed from the LDAP object. Without this modification, it is kept intact.

Tests:

* IT added
* runtime tested

Thanks @cmangeat for the help / pair programming.
