### PR TITLE
df-ui - attempt to fix js build (#3932)

### DIFF
--- a/datafeeder-ui/pom.xml
+++ b/datafeeder-ui/pom.xml
@@ -91,17 +91,17 @@
                       </configuration>
                   </execution>
                   <execution>
-                      <id>npm run build</id>
+                      <id>build</id>
                       <goals>
-                          <goal>npm</goal>
+                          <goal>npx</goal>
                       </goals>
                       <configuration>
-                          <arguments>run build datafeeder -- --base-href=/import/</arguments>
+                          <arguments>nx build datafeeder -- --base-href=/import/</arguments>
                       </configuration>
                   </execution>
               </executions>
               <configuration>
-                  <nodeVersion>v12.22.1</nodeVersion>
+                  <nodeVersion>v18.15.0</nodeVersion>
                   <workingDirectory>${project.build.directory}/datafeeder-ui</workingDirectory>
               </configuration>
           </plugin>


### PR DESCRIPTION
* upgrading node version in the maven plugin
* adapting build commands to what is documented in the upstream README.md

Tests: checked a georchestra/datafeeder-ui:latest against a locally generated one, and the documentroot on both sides were taking the same size.

Note: as the same repository is used in the 22.0.x, this might require a backport.
