### PR TITLE
[22.0] Fix datafeeder-ui build

### DIFF
--- a/datafeeder-ui/pom.xml
+++ b/datafeeder-ui/pom.xml
@@ -54,7 +54,7 @@
               <configuration>
                   <checkoutDirectory>${project.build.directory}/datafeeder-ui</checkoutDirectory>
                   <connectionUrl>scm:git:https://github.com/georchestra/geonetwork-ui.git</connectionUrl>
-                  <scmVersion>georchestra-datafeeder</scmVersion>
+                  <scmVersion>georchestra-datafeeder-22.0.x</scmVersion>
                   <scmVersionType>branch</scmVersionType>
                   <pushChanges>false</pushChanges>
               </configuration>


### PR DESCRIPTION
Followup of #3933 

For the 22.0.x branch I think it makes sense to keep pointing at [the previous state of the georchestra/geonetwork-ui fork](https://github.com/georchestra/geonetwork-ui/tree/georchestra-datafeeder-22.0.x) instead of taking the risk to introduce bugs by using a more recent version of gn-ui.