### PR TITLE
new passwords management policy -ldap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ docker-build-ldap:
 	docker pull debian:bullseye
 	cd ldap; \
 	docker build -t georchestra/ldap:${BTAG} .
+	
+docker-build-ldap-withrotation:
+	docker pull debian:bullseye
+	cd ldap; \
+	docker build -t georchestra/ldap:${BTAG} --build-arg PM_POLICY=rotation .
 
 docker-build-database:
 	docker pull postgres:15

--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM debian:bullseye
 
+ARG PM_POLICY=default
 ENV OPENLDAP_VERSION 2.4.57
 ENV RUN_AS_UID 101
 ENV RUN_AS_GID 101
@@ -12,6 +13,7 @@ ENV SLAPD_DOMAIN georchestra.org
 ENV SLAPD_PASSWORD secret
 ENV SLAPD_ADDITIONAL_SCHEMAS ppolicy
 ENV SLAPD_ADDITIONAL_MODULES groupofmembers,openssh,ppolicy
+ENV SLAPD_PASSWORD_MGT_POLICY ${PM_POLICY}
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/ldap/docker-root/docker-entrypoint.d/00-init
+++ b/ldap/docker-root/docker-entrypoint.d/00-init
@@ -82,6 +82,12 @@ EOF
             slapadd -n0 -F /etc/ldap/slapd.d -l "/etc/ldap/schema/${schema}.ldif"
         done
     fi
+    
+    if [ "$SLAPD_PASSWORD_MGT_POLICY" == 'rotation' ]; then
+    	cp /etc/ldap/modules/ppolicy-rotation.ldif /etc/ldap/modules/ppolicy.ldif
+    else 
+    	cp /etc/ldap/modules/ppolicy-default.ldif /etc/ldap/modules/ppolicy.ldif
+    fi
 
     if [[ -n "$SLAPD_ADDITIONAL_MODULES" ]]; then
         IFS=","; declare -a modules=($SLAPD_ADDITIONAL_MODULES); unset IFS

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -36,6 +36,11 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
     ldapadd -Y EXTERNAL -H ldapi:/// -f /georchestraSchema.ldif
     ldapadd -Y EXTERNAL -H ldapi:/// -f /memberof.ldif
     ldapadd -Y EXTERNAL -H ldapi:/// -f /lastbind.ldif
+    if [ "$SLAPD_PASSWORD_MGT_POLICY" == 'rotation' ]; then
+    	echo "Updating password management policy..."
+    	ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /rotationpolicyoverlay.ldif
+    	ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /pwd_no_expire.ldif
+    fi
     if [ "$IGNORE_DATA" = 'true' ]; then
         echo "$0: ignoring /georchestra.ldif";
     else
@@ -51,6 +56,11 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
         perl -p -i -e "s/georchestra.org/${SLAPD_DOMAIN}/"        /georchestra.ldif
         perl -p -i -e "s/dc=georchestra,dc=org/${dc_string}/"     /georchestra.ldif
         ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /georchestra.ldif
+        if [ "$SLAPD_PASSWORD_MGT_POLICY" == 'rotation' ]; then
+    	echo "Updating password management policy..."
+		ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /pwd_no_expire_users.ldif
+	fi
+    fi
     fi
     echo "Populating LDAP tree: OK"
 

--- a/ldap/docker-root/etc/ldap.dist/modules/ppolicy-default.ldif
+++ b/ldap/docker-root/etc/ldap.dist/modules/ppolicy-default.ldif
@@ -1,0 +1,13 @@
+dn: cn=module,cn=config
+objectClass: olcModuleList
+cn: module
+olcModuleLoad: ppolicy.la
+
+dn: olcOverlay=ppolicy,olcDatabase={1}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcPPolicyConfig
+olcOverlay: ppolicy
+olcPPolicyDefault: PPOLICY_DN
+olcPPolicyHashCleartext: FALSE
+olcPPolicyForwardUpdates: FALSE
+olcPPolicyUseLockout: FALSE

--- a/ldap/docker-root/etc/ldap.dist/modules/ppolicy-rotation.ldif
+++ b/ldap/docker-root/etc/ldap.dist/modules/ppolicy-rotation.ldif
@@ -1,0 +1,13 @@
+dn: cn=module,cn=config
+objectClass: olcModuleList
+cn: module
+olcModuleLoad: ppolicy.la
+
+dn: olcOverlay=ppolicy,olcDatabase={1}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcPPolicyConfig
+olcOverlay: ppolicy
+olcPPolicyDefault: cn=default,ou=pwpolicy,dc=georchestra,dc=org
+olcPPolicyHashCleartext: FALSE
+olcPPolicyForwardUpdates: FALSE
+olcPPolicyUseLockout: FALSE

--- a/ldap/docker-root/pwd_no_expire.ldif
+++ b/ldap/docker-root/pwd_no_expire.ldif
@@ -1,0 +1,10 @@
+dn: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org
+objectClass: person
+objectClass: pwdPolicyChecker
+objectClass: pwdPolicy
+cn: pwpolicy
+cn: pwd-no-expire
+sn: pwpolicy
+pwdAttribute: userPassword
+pwdMinAge: 0
+pwdMaxAge: 0

--- a/ldap/docker-root/pwd_no_expire_users.ldif
+++ b/ldap/docker-root/pwd_no_expire_users.ldif
@@ -1,0 +1,9 @@
+dn: uid=geoserver_privileged_user,ou=users,dc=georchestra,dc=org
+changetype: modify
+add: pwdPolicySubentry
+pwdPolicySubentry: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org
+
+dn: uid=idatafeeder,ou=users,dc=georchestra,dc=org
+changetype: modify
+add: pwdPolicySubentry
+pwdPolicySubentry: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org

--- a/ldap/docker-root/rotationpolicyoverlay.ldif
+++ b/ldap/docker-root/rotationpolicyoverlay.ldif
@@ -1,0 +1,16 @@
+dn: ou=pwpolicy,dc=georchestra,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: pwpolicy
+
+dn: cn=default,ou=pwpolicy,dc=georchestra,dc=org
+objectClass: person
+objectClass: pwdPolicyChecker
+objectClass: pwdPolicy
+cn: pwpolicy
+sn: pwpolicy
+pwdAttribute: userPassword
+pwdMinAge: 0
+pwdMaxAge: 31536000
+pwdGraceAuthnLimit: 0
+pwdExpireWarning: 2592000

--- a/migrations/23.0/set_rotation_policy_for_all_users.sh
+++ b/migrations/23.0/set_rotation_policy_for_all_users.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "updating password management policy for all users"
+sleep 2
+
+for i in `ldapsearch -x -b ou=users,dc=georchestra,dc=org -H ldap://localhost:389| grep uid: | cut -d: -f2 | sed 's/^\ //g'`
+do
+if [ $i != "geoserver_privileged_user" ] && [ $i != "idatafeeder" ]; then
+echo updating user $i
+ldapmodify -x -H ldap://localhost:389 -D cn=admin,dc=georchestra,dc=org -w secret  << EOF
+dn: uid=$i,ou=users,dc=georchestra,dc=org
+changetype: modify
+add: pwdPolicySubentry
+pwdPolicySubentry: cn=default,ou=pwpolicy,dc=georchestra,dc=org
+
+
+EOF
+fi
+done

--- a/migrations/master/README.md
+++ b/migrations/master/README.md
@@ -1,2 +1,66 @@
 # From 23.0 to master
 
+## cas
+From 23.0 to 23.1
+To activate password rotation policy for ldap, user need to run these commands:
+
+```
+ldapmodify -H ldap://localhost:389 -D cn=admin,dc=georchestra,dc=org -w secret
+dn: olcOverlay={0}ppolicy,olcDatabase={1}mdb,cn=config
+changetype: modify
+replace: olcPPolicyDefault
+olcPPolicyDefault: cn=default,ou=pwpolicy,dc=georchestra,dc=org
+
+```
+```
+ldapadd -H ldap://localhost:389 -D cn=admin,dc=georchestra,dc=org -w secret
+dn: ou=pwpolicy,dc=georchestra,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: pwpolicy
+
+dn: cn=default,ou=pwpolicy,dc=georchestra,dc=org
+objectClass: person
+objectClass: pwdPolicyChecker
+objectClass: pwdPolicy
+cn: pwpolicy
+sn: pwpolicy
+pwdAttribute: userPassword
+pwdMinAge: 0
+pwdMaxAge: 31536000
+pwdGraceAuthnLimit: 0
+pwdExpireWarning: 2592000
+
+dn: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org
+objectClass: person
+objectClass: pwdPolicyChecker
+objectClass: pwdPolicy
+cn: pwpolicy
+cn: pwd-no-expire
+sn: pwpolicy
+pwdAttribute: userPassword
+pwdMinAge: 0
+pwdMaxAge: 0
+
+```
+To activate rotation password policy for all users, please run script 'set_rotation_policy_for_all_users.sh' located at 'georchestra/migrations/23.0' :
+```
+sh set_rotation_policy_for_all_users.sh 
+```
+To desactivate rotation password policy for non humain users, please run :
+```
+ldapmodify -H ldap://localhost:389  -D cn=admin,dc=georchestra,dc=org -w secret
+dn: uid=geoserver_privileged_user,ou=users,dc=georchestra,dc=org
+changetype: modify
+add: pwdPolicySubentry
+pwdPolicySubentry: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org
+
+dn: uid=idatafeeder,ou=users,dc=georchestra,dc=org
+changetype: modify
+add: pwdPolicySubentry
+pwdPolicySubentry: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org
+```
+
+
+
+


### PR DESCRIPTION
A new policy management for password called rotation is implemented  at georchestra, where user has to set password periodically. rotation policy is not activated by default. to build a docker image with this new configuration run : docker-build-ldap-withrotation.