### PR TITLE
geoserver docker - fix font inclusion

### DIFF
--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -11,7 +11,7 @@ USER root
 RUN apt-get update \
     && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && apt-get install -y ttf-mscorefonts-installer \
-    && apt-get install -y gsfonts \
+    && apt-get install -y gsfonts fonts-deva fonts-font-awesome fonts-freefont-ttf fonts-material-design-icons-iconfont fonts-materialdesignicons-webfont fonts-roboto\
     && apt-get install -y wget \
     && apt-get clean \
     && apt-get autoremove -y \

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -11,6 +11,7 @@ USER root
 RUN apt-get update \
     && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && apt-get install -y ttf-mscorefonts-installer \
+    && apt-get install -y gsfonts \
     && apt-get install -y wget \
     && apt-get clean \
     && apt-get autoremove -y \

--- a/geoserver/webapp/src/docker/Dockerfile
+++ b/geoserver/webapp/src/docker/Dockerfile
@@ -9,6 +9,7 @@ COPY --chown=jetty:jetty . /
 USER root
 
 RUN apt-get update \
+    && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && apt-get install -y ttf-mscorefonts-installer \
     && apt-get install -y wget \
     && apt-get clean \


### PR DESCRIPTION
by accepting eula, see #3948 for the discussion

Also including the [gsfonts](https://packages.debian.org/buster/gsfonts) package, which are free variants of the Adobe PostScript fonts.