### PR TITLE
pwd policy - doc overhauled / extra fi removed

### DIFF
--- a/ldap/README.md
+++ b/ldap/README.md
@@ -181,11 +181,17 @@ EOF
 ```
 
 
-**pwdExpireWarning** is the number of seconds printing "change your password" message. It calculated with :  pwdExpireWarning = pwdMaxAge - TimeWithoutWaring
+**pwdExpireWarning** is the number of seconds before the password expires. Users are kindly remembered to change password. 
+
+To sum up: pwdExpireWarning + "time without warning" = pwdMaxAge.
 
 The default value is `2592000`, which corresponds to 30 days.
 
-So for default value the password will be valid for 365 jours (pwdMaxAge), but from 30 days (pwdExpireWarning) before the expiration it will print the warning, so from the day 335.
+geOrchestra's default password policy will:
+
+* warn users 335 days after their last password change
+* prevent users from logging in 365 days after their last password change
+
 
 You can update it with the following command:
 

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -161,7 +161,7 @@ These three files are:
 The `rotationpolicyoverlay.ldif` file has two key variables which define the password policy.
 
 
-**pwdMaxAge** - when this delay is expired, geOrchestra will print a "change your password" message.
+**pwdMaxAge** - when this delay is expired, geOrchestra will disable the account. This field describe the total time (in seconds) of validity for a user password. 
 
 
 The default value is `31536000`, which corresponds to 365 days.
@@ -169,34 +169,34 @@ The default value is `31536000`, which corresponds to 365 days.
 It can be updated with the following command:
 
 ```
-ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<!
+ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<EOF
 dn: cn=default,ou=pwpolicy,dc=georchestra,dc=org
 changetype: modify
 delete: pwdMaxAge
 -
 add: pwdMaxAge
-pwdMaxAge: 63072000
+pwdMaxAge: 18396000
 -
-!
-
+EOF
 ```
 
 
-**pwdExpireWarning** is the number of seconds granted to modify an expired password. Past this delay, the account will be blocked.
+**pwdExpireWarning** is the number of seconds printing "change your password" message. It calculated with :  pwdExpireWarning = pwdMaxAge - TimeWithoutWaring
 
 The default value is `2592000`, which corresponds to 30 days.
+
+So for default value the password will be valid for 365 jours (pwdMaxAge), but from 30 days (pwdExpireWarning) before the expiration it will print the warning, so from the day 335.
 
 You can update it with the following command:
 
 ```
-ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<!
+ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<EOF
 dn: cn=default,ou=pwpolicy,dc=georchestra,dc=org
 changetype: modify
 delete: pwdExpireWarning
 -
 add: pwdExpireWarning
-pwdExpireWarning: 648000
+pwdExpireWarning: 2628000
 -
-!
-
+EOF
 ```

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -148,33 +148,25 @@ ldapsearch -x -LLL \
    -w "secret"
 ```
 
-## Update password policy
-Rotation password policy to gateway (georchestra sub-module) to show alert and force password change for user periodically.
+## About the password policy
 
-**pwdExpireWarning** : Number of seconds without alert message, if delay it will print a message
+If the `SLAPD_PASSWORD_MGT_POLICY` env var is set to "rotation" when starting the initial LDAP container startup (on an empty configuration volume), three LDIF files are loaded, which enforce password rotation.
 
-with the value 31536000 ( 31536000 / ( 60 * 60 * 24) ) = 365 days
+These three files are:
+ * rotationpolicyoverlay.ldif - sets up the `pwpolicy` password policy for regular users
+ * pwd_no_expire.ldif - sets up a `a pwd-no-expire` policy
+ * pwd_no_expire_users.ldif - sets a `pwd-no-expire` management policy to internal users
 
-You can update it with the following command : 
 
-```
-ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<!
-dn: cn=default,ou=pwpolicy,dc=georchestra,dc=org
-changetype: modify
-delete: pwdExpireWarning
--
-add: pwdExpireWarning
-pwdExpireWarning: 31536000
--
-!
+The `rotationpolicyoverlay.ldif` file has two key variables which define the password policy.
 
-```
 
-**pwdMaxAge** : number of second to modify our password after it expired, if deplayed the account will be blocked
+**pwdMaxAge** - when this delay is expired, geOrchestra will print a "change your password" message.
 
-with the value 2592000 ( 2592000 / ( 60 * 60 * 24 ) ) = 30 days
 
-You can update it with the following command :
+The default value is `31536000`, which corresponds to 365 days.
+
+It can be updated with the following command:
 
 ```
 ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<!
@@ -183,7 +175,27 @@ changetype: modify
 delete: pwdMaxAge
 -
 add: pwdMaxAge
-pwdMaxAge: 2592000
+pwdMaxAge: 63072000
+-
+!
+
+```
+
+
+**pwdExpireWarning** is the number of seconds granted to modify an expired password. Past this delay, the account will be blocked.
+
+The default value is `2592000`, which corresponds to 30 days.
+
+You can update it with the following command:
+
+```
+ldapmodify -x -H "ldap://ldap:389" -D "cn=admin,dc=georchestra,dc=org" -w "secret" <<!
+dn: cn=default,ou=pwpolicy,dc=georchestra,dc=org
+changetype: modify
+delete: pwdExpireWarning
+-
+add: pwdExpireWarning
+pwdExpireWarning: 648000
 -
 !
 

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -161,7 +161,7 @@ These three files are:
 The `rotationpolicyoverlay.ldif` file has two key variables which define the password policy.
 
 
-**pwdMaxAge** - when this delay is expired, geOrchestra will disable the account. This field describe the total time (in seconds) of validity for a user password. 
+**pwdMaxAge** - Password validity time (expressed in seconds) - when this delay is expired, user will not be able to login anymore. 
 
 
 The default value is `31536000`, which corresponds to 365 days.

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -56,11 +56,11 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
         perl -p -i -e "s/georchestra.org/${SLAPD_DOMAIN}/"        /georchestra.ldif
         perl -p -i -e "s/dc=georchestra,dc=org/${dc_string}/"     /georchestra.ldif
         ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /georchestra.ldif
+
         if [ "$SLAPD_PASSWORD_MGT_POLICY" == 'rotation' ]; then
-    	echo "Updating password management policy..."
-		ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /pwd_no_expire_users.ldif
-	fi
-    fi
+            echo "Setting a pwd-no-expire management policy to internal users"
+            ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /pwd_no_expire_users.ldif
+        fi
     fi
     echo "Populating LDAP tree: OK"
 


### PR DESCRIPTION
Please double check the extra `fi` in the 01-populate script - I've had no time to test it.

Also, I think the documentation inverted the meaning of the pwdMaxAge and pwdExpireWarning config options.
To be double checked.