### PR TITLE
Implemention of new WebComponent header

### DIFF
--- a/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -3,7 +3,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy-url="${headerUrl}" legacy-style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;" active-app="analytics"></geor-header>
         <script src="${headerScript}"></script>
     </div>
     </c:when>

--- a/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -3,7 +3,8 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <iframe src="${headerUrl}?lang=<%= lang %>" style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;" scrolling="no" frameborder="0"></iframe>
+        <geor-header legacy_url="${headerUrl}" legacy_style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <script src="${headerScript}"></script>
     </div>
     </c:when>
 </c:choose>

--- a/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -4,7 +4,7 @@
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
         <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;" active-app="analytics"></geor-header>
-        <script src="${headerScript}"></script>
+        <script src="<c:out value="${headerScript}" />"></script>
     </div>
     </c:when>
 </c:choose>

--- a/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -3,7 +3,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy_url="${headerUrl}" legacy_style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <geor-header legacy-url="${headerUrl}" legacy-style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
         <script src="${headerScript}"></script>
     </div>
     </c:when>

--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -52,6 +52,7 @@
                 <entry key="headerUrl" value="${headerUrl}"/>
                 <entry key="headerHeight" value="${headerHeight}"/>
                 <entry key="headerScript" value="${headerScript}" />
+                <entry key="useLegacyHeader" value="${useLegacyHeader}" />
             </map>
         </property>
     </bean>

--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -51,6 +51,7 @@
                 <entry key="defaultLanguage" value="${language}"/>
                 <entry key="headerUrl" value="${headerUrl}"/>
                 <entry key="headerHeight" value="${headerHeight}"/>
+                <entry key="headerScript" value="${headerScript}" />
             </map>
         </property>
     </bean>

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
@@ -71,6 +71,7 @@ public class InfosController {
         ret.put("saslEnabled", saslEnabled);
         ret.put("saslServer", saslServer);
         ret.put("analyticsEnabled", analyticsEnabled);
+        ret.put("extractorappEnabled", extractorappEnabled);
         ret.put("useLegacyHeader", useLegacyHeader);
         ret.put("headerUrl", headerUrl);
         ret.put("headerHeight", headerHeight);

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
@@ -51,6 +51,18 @@ public class InfosController {
     @Setter
     private boolean extractorappEnabled;
 
+    @Value("${useLegacyHeader:false}")
+    private boolean useLegacyHeader;
+
+    @Value("${headerUrl:/header/}")
+    private String headerUrl;
+
+    @Value("${headerHeight:90}")
+    private String headerHeight;
+
+    @Value("${headerScript:https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js}")
+    private String headerScript;
+
     @GetMapping(value = BASE_MAPPING + "/platform/infos", produces = "application/json; charset=utf-8")
     @PreAuthorize(value = "hasRole('SUPERUSER')")
     @ResponseBody
@@ -59,7 +71,10 @@ public class InfosController {
         ret.put("saslEnabled", saslEnabled);
         ret.put("saslServer", saslServer);
         ret.put("analyticsEnabled", analyticsEnabled);
-        ret.put("extractorappEnabled", extractorappEnabled);
+        ret.put("useLegacyHeader", useLegacyHeader);
+        ret.put("headerUrl", headerUrl);
+        ret.put("headerHeight", headerHeight);
+        ret.put("headerScript", headerScript);
         return ret.toString();
     }
 }

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -58,6 +58,7 @@
       <map>
         <entry key="headerHeight" value="${headerHeight}" />
         <entry key="headerUrl" value="${headerUrl}" />
+        <entry key="headerScript" value="${headerScript}" />
         <entry key="readonlyUid" value="${readonlyUid:false}" />
         <entry key="publicContextPath" value="${publicContextPath:/console}"/>
       </map>

--- a/console/src/main/webapp/WEB-INF/views/header.jsp
+++ b/console/src/main/webapp/WEB-INF/views/header.jsp
@@ -3,7 +3,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy_url="${headerUrl}" legacy_style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <geor-header legacy-url="${headerUrl}" legacy-style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
         <script src="${headerScript}"></script>
     </div>
     </c:when>

--- a/console/src/main/webapp/WEB-INF/views/header.jsp
+++ b/console/src/main/webapp/WEB-INF/views/header.jsp
@@ -3,7 +3,8 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <iframe src="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;" scrolling="no"></iframe>
+        <geor-header legacy_url="${headerUrl}" legacy_style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <script src="${headerScript}"></script>
     </div>
     </c:when>
 </c:choose>

--- a/console/src/main/webapp/WEB-INF/views/header.jsp
+++ b/console/src/main/webapp/WEB-INF/views/header.jsp
@@ -3,9 +3,6 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <!-- Unused -->
-        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;" active-app="console"></geor-header>
-        <script src="${headerScript}"></script>
     </div>
     </c:when>
 </c:choose>

--- a/console/src/main/webapp/WEB-INF/views/header.jsp
+++ b/console/src/main/webapp/WEB-INF/views/header.jsp
@@ -3,7 +3,8 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy-url="${headerUrl}" legacy-style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <!-- Unused -->
+        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;" active-app="console"></geor-header>
         <script src="${headerScript}"></script>
     </div>
     </c:when>

--- a/console/src/main/webapp/manager/app/app.es6
+++ b/console/src/main/webapp/manager/app/app.es6
@@ -1,9 +1,9 @@
 class AppController {
   static $inject = [
-    '$scope', '$router', '$location', '$translate', 'roleAdminList', 'Profile', 'PlatformInfos'
+    '$scope', '$router', '$location', '$translate', '$sce', 'roleAdminList', 'Profile', 'PlatformInfos'
   ]
 
-  constructor ($scope, $router, $location, $translate, roleAdminList, Profile, PlatformInfos) {
+  constructor ($scope, $router, $location, $translate, $sce, roleAdminList, Profile, PlatformInfos) {
     $router.config([
       {
         path: '/',
@@ -66,6 +66,8 @@ class AppController {
         ? 'DELEGATED' : 'SUPERUSER'
     })
     $scope.platformInfos = PlatformInfos.get()
+
+    $scope.trustSrc = (src) => $sce.trustAsResourceUrl(src)
 
     $scope.isProtectedRole = role => roleAdminList().indexOf(role.cn) !== -1
     $scope.$translate = $translate

--- a/console/src/main/webapp/manager/app/assets/index.html
+++ b/console/src/main/webapp/manager/app/assets/index.html
@@ -14,12 +14,12 @@
 
 <body ng-app="manager" ng-strict-di ng-controller="AppController">
 
-  <geor-header style="width:100%;height:90px" active-app="console"></geor-header>
-  <script src="http://localhost:5500/header.js"></script>
+  <geor-header legacy-header="{{ platformInfos.useLegacyHeader }}" legacy-url="{{ platformInfos.headerUrl }}" style="width:100%;height:{{ platformInfos.headerHeight }}px;border:none;" active-app="console"></geor-header>
+  <script ng-src="{{ trustSrc(platformInfos.headerScript) }}"></script>
 
   <div flash-message="2000"></div>
 
-  <div class="container">
+  <div class="container" style="padding-top:20px">
 
     <div class="profile label label-{{(profile === 'SUPERUSER') ? 'info' : 'warning'}} pull-right" title="{{'index.' + profile + 'tip' | translate }}">
       {{ 'index.' + profile | translate}}

--- a/console/src/main/webapp/manager/app/assets/index.html
+++ b/console/src/main/webapp/manager/app/assets/index.html
@@ -14,7 +14,8 @@
 
 <body ng-app="manager" ng-strict-di ng-controller="AppController">
 
-  <iframe src="/header/?active=console" scrolling="no" frameborder="0"></iframe>
+  <geor-header style="width:100%;height:90px" active-app="console"></geor-header>
+  <script src="http://localhost:5500/header.js"></script>
 
   <div flash-message="2000"></div>
 

--- a/console/src/test/java/org/georchestra/console/integration/ws/backoffice/platform/InfosControllerIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/ws/backoffice/platform/InfosControllerIT.java
@@ -25,7 +25,11 @@ public class InfosControllerIT extends ConsoleIntegrationTest {
         // By default, analytics & extractorapp are enabled
         JSONObject ret = new JSONObject(infosController.getPlatformInfos());
 
-        assertTrue(ret.getBoolean("analyticsEnabled") == true && ret.getBoolean("extractorappEnabled") == false);
+        assertTrue(ret.getBoolean("analyticsEnabled") == true && ret.getBoolean("extractorappEnabled") == false
+                && ret.getBoolean("useLegacyHeader") == false);
+
+        assertTrue(ret.getString("headerUrl").equals("/header/") && ret.getString("headerHeight").equals("90") && ret
+                .getString("headerScript").equals("https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js"));
 
         infosController.setAnalyticsEnabled(false);
         infosController.setExtractorappEnabled(false);

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -46,6 +46,7 @@
       <map>
         <entry key="headerHeight" value="${headerHeight}" />
         <entry key="headerUrl" value="${headerUrl}" />
+        <entry key="headerScript" value="${headerScript}" />
         <entry key="readonlyUid" value="${readonlyUid:false}" />
         <entry key="publicContextPath" value="${publicContextPath:/console}"/>
       </map>

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -22,6 +22,7 @@
             <map>
                 <entry key="headerHeight" value="${headerHeight}" />
                 <entry key="headerUrl" value="${headerUrl}" />
+                <entry key="headerScript" value="${headerScript}" />
             </map>
         </property>
     </bean>

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -23,6 +23,7 @@
                 <entry key="headerHeight" value="${headerHeight}" />
                 <entry key="headerUrl" value="${headerUrl}" />
                 <entry key="headerScript" value="${headerScript}" />
+                <entry key="useLegacyHeader" value="${useLegacyHeader}" />
             </map>
         </property>
     </bean>

--- a/security-proxy/src/main/webapp/header.jsp
+++ b/security-proxy/src/main/webapp/header.jsp
@@ -4,7 +4,8 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <iframe src="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;overflow:none;" scrolling="no"></iframe>
+        <geor-header legacy_url="${headerUrl}" legacy_style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <script src="${headerScript}"></script>
     </div>
     </c:when>
 </c:choose>

--- a/security-proxy/src/main/webapp/header.jsp
+++ b/security-proxy/src/main/webapp/header.jsp
@@ -4,7 +4,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy_url="${headerUrl}" legacy_style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <geor-header legacy-url="${headerUrl}" legacy-style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
         <script src="${headerScript}"></script>
     </div>
     </c:when>

--- a/security-proxy/src/main/webapp/header.jsp
+++ b/security-proxy/src/main/webapp/header.jsp
@@ -5,7 +5,7 @@
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
         <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;"></geor-header>
-        <script src="${headerScript}"></script>
+        <script src="<c:out value="${headerScript}" />"></script>
     </div>
     </c:when>
 </c:choose>

--- a/security-proxy/src/main/webapp/header.jsp
+++ b/security-proxy/src/main/webapp/header.jsp
@@ -4,7 +4,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy-url="${headerUrl}" legacy-style="width:100%;height:${headerHeight}px;border:none;overflow:hidden;"></geor-header>
+        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;"></geor-header>
         <script src="${headerScript}"></script>
     </div>
     </c:when>


### PR DESCRIPTION
# New geOrchestra header

The goal of this PR is to integrate the [new web component header](https://github.com/georchestra/header/) into georchestra.

This new header have the capability to display the original `iframe` with the `legacy-header` attribute (See How-to section below).

## Implementations

Following apps/repos have to be modified to be able to use it :
- [x] analytics: wc header shows up, needs white background,
- [x] console: wc does not show up yet => why?
- [x] security-proxy: where should this one show up?
- [x] datahub: todo: pass `headerUrl` from default.properties to add-header-webcomponent.sh script
- [x] datafeeder: pass `headerUrl` from default.properties to add-header-webcomponent.sh script

Submodules/other repos:
- [x] geonetwork: js error from other dep `lib.js` => moving wc script behind it does not help
- [x] geoserver
- [x] mapstore
- [x] cas
- [x] gateway (also do not forget password rotation message implemented in legacy header for MEL, but this is project specific)
- [x] home header

## TODO
### Validate PRs :


- New Header https://github.com/georchestra/header/pull/11
- Geoserver https://github.com/georchestra/geoserver/pull/32
- Geonetwork https://github.com/georchestra/geonetwork/pull/257
- Mapstore https://github.com/georchestra/mapstore2-georchestra/pull/663
- CAS https://github.com/georchestra/georchestra-cas-server/pull/15
- Georchestra https://github.com/georchestra/georchestra/pull/4065
- Datafeeder https://github.com/georchestra/georchestra/issues/4065 | Needs validation of another PR (See #4030, PR https://github.com/georchestra/georchestra/pull/4083)

Docker : 
- HtDocs https://github.com/georchestra/htdocs/pull/3
- Datadir https://github.com/georchestra/datadir/pull/350
- Docker https://github.com/georchestra/docker/pull/242

### Other issues:
- [x] error in analytics js when using header.js from [mobile](https://github.com/georchestra/header/pull/11) branch (includes white background for analytics)
- [ ] Documentation

### Issues Done

- [x] new admin header is higher (108px) than non-admin (80px), mobile even shorter (64px) => unify height?
- [x] `headerUrl` needs to be defined in `default.properties`: empty for new header, `/header/` for legacy => acceptable?
- [x] handle highlighted active tabs to work on new and legacy
- [x] Handle i18n
- [x] Handle font-size (mostly avoid using rem unit) 
- [x] Implement custom script at startup in datafeeder to be able to add new header 

## How-to

Iframe can still be set with defining `legacy-url` attribute, style can also be set with `legacy-style` attribute :
  ```html
  <geor-header legacy-url="myheader.com" legacy-style="width: 100%"></geor-header>
   <script src="https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js"></script>
  ```

Attributes available :

| Attribute     | Description                                                                                          | Example                                                                     | For host | For legacy |
|---------------|------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|----------|------------|
| lang          | Used to force header language (default value : en)                                                   | `<geor-header lang='de'>`                                                   | v        |            |
| active-app    | Use this attribute to set the active class in menu                                                   | `<geor-header active-app='console'>`                                        | v        | v          |
| logo-url      | Use this attribute to set the logo for the new header (not legacy one).                              | `<geor-header logo-url='https://linktomylogo.com'>`                         | v        |            |
| legacy-header | Use this attribute to enable the legacy header `iframe` tag. Needs `legacy-url`.                     | `<geor-header legacy-header='true' legacy-url="/header/">`                  |          | v          |
| legacy-url    | Legacy URL: if set, activates iframe with src attribute pointing to this URL. Needs `legacy-header`. | `<geor-header legacy-header='true' legacy-url="/header/"></geor-header>`    |          | v          |
| style         | adds this style to iframe or host tag (if legacy url is not used)                                    | `<geor-header legacy-url="myheader.com" style="width: 100%"></geor-header>` | v        | v          |