### PR TITLE
console - make name fields not editable for OAuth2 users

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormBean.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormBean.java
@@ -35,6 +35,7 @@ public class EditUserDetailsFormBean implements java.io.Serializable {
     private String org;
     private String description;
     private String postalAddress;
+    private boolean isOAuth2;
 
     @Override
     public String toString() {
@@ -123,4 +124,11 @@ public class EditUserDetailsFormBean implements java.io.Serializable {
         this.postalAddress = postalAddress;
     }
 
+    public boolean getIsOAuth2() {
+        return isOAuth2;
+    }
+
+    public void setIsOAuth2(boolean isOAuth2) {
+        this.isOAuth2 = isOAuth2;
+    }
 }

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -162,6 +162,7 @@ public class EditUserDetailsFormController {
         if (!org.equals("")) {
             formBean.setOrg(orgsDao.findByCommonName(org).getName());
         }
+        formBean.setIsOAuth2(account.getOAuth2ProviderId() != null);
 
         return formBean;
     }

--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -77,12 +77,34 @@ var gdprAllowAccountDeletion = ${gdprAllowAccountDeletion};
 
     <fieldset>
       <legend><s:message code="editUserDetailsForm.fieldset.userDetails"/></legend>
-      <t:input path="firstName" required="${firstNameRequired}">
-        <jsp:attribute name="label"><s:message code="firstName.label"/></jsp:attribute>
-      </t:input>
-      <t:input path="surname" required="${surnameRequired}">
-        <jsp:attribute name="label"><s:message code="surname.label"/></jsp:attribute>
-      </t:input>
+      <c:choose>
+        <c:when test="${editUserDetailsFormBean.isOAuth2}">
+          <div class="form-group">
+            <label class="col-lg-4 control-label"><s:message code="firstName.label"/></label>
+            <div class="col-lg-8">
+              <p class="form-control-static">
+                  ${editUserDetailsFormBean.firstName}
+              </p>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-lg-4 control-label"><s:message code="surname.label"/></label>
+            <div class="col-lg-8">
+              <p class="form-control-static">
+                  ${editUserDetailsFormBean.surname}
+              </p>
+            </div>
+          </div>
+        </c:when>
+        <c:otherwise>
+          <t:input path="firstName" required="${firstNameRequired}">
+            <jsp:attribute name="label"><s:message code="firstName.label"/></jsp:attribute>
+          </t:input>
+          <t:input path="surname" required="${surnameRequired}">
+            <jsp:attribute name="label"><s:message code="surname.label"/></jsp:attribute>
+          </t:input>
+        </c:otherwise>
+      </c:choose>
       <div class="form-group">
         <label class="col-lg-4 control-label"><s:message code="email.label"/></label>
         <div class="col-lg-8">

--- a/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormControllerTest.java
@@ -70,6 +70,7 @@ public class EditUserDetailsFormControllerTest {
         formBean.setSurname("misterTest");
         formBean.setTitle("test engineer");
         formBean.setUid("mtester");
+        formBean.setIsOAuth2(false);
 
         // Mock mtester user
         this.mtesterAccount = AccountFactory.createBrief("mtester", "12345", "testFirst", "misterTest", "email",


### PR DESCRIPTION
As required by FranceConnect IDP, and it sounds a correct idea, First Name and Surname should not be editable for OAuth2 users.