### PR TITLE
GS - making sure gs-gwc-rest dependencies are included in the webapp

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -117,6 +117,11 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc-rest</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
       <artifactId>gs-rest</artifactId>
       <version>${gs.version}</version>
     </dependency>


### PR DESCRIPTION
Same as #4073 for the 23.0.x line.
