### PR TITLE
fix: hide jumbotron when analytics is disabled

### DIFF
--- a/console/src/main/webapp/manager/app/components/home/home.tpl.html
+++ b/console/src/main/webapp/manager/app/components/home/home.tpl.html
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <div class="jumbotron">
+    <div class="jumbotron" ng-if="platformInfos.analyticsEnabled">
       <h1 ng-if="home.connected && home.connected.results.length > 0" ng-cloack>{{::home.connected.results.length}}</h1>
       <p><ng-pluralize count="home.connected.results.length"
                        when="{'0': '{{ &quot;home.connected_users_none&quot; | translate }}',


### PR DESCRIPTION
https://github.com/georchestra/georchestra/pull/4080