### PR TITLE
datafeeder - remove useless WWW:DOWNLOAD link

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -112,7 +112,6 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
 
         m.getOnlineResources().add(wmsOnlineResource(d));
         m.getOnlineResources().add(wfsOnlineResource(d));
-        m.getOnlineResources().add(downloadOnlineResource(d));
 
         URI uniqueResourceIdentifier = geonetwork.buildMetadataRecordIdentifier(metadataId);
         m.setDataIdentifier(uniqueResourceIdentifier);
@@ -287,14 +286,6 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
         String queryString = "";
         String layerName = fullyQualifiedLayerName(d.getPublishing());
         return onlineResource(d, layerName, protocol, description, queryString);
-    }
-
-    private OnlineResource downloadOnlineResource(DatasetUploadState d) {
-        String protocol = "WWW:DOWNLOAD-1.0-http--download";
-        String description = d.getPublishing().getTitle() + " - WWW";
-        String layer = d.getPublishing().getPublishedName();
-        String queryString = String.format("SERVICE=WFS&REQUEST=GetFeature&typename=%s&outputformat=shape-zip", layer);
-        return onlineResource(d, layer, protocol, description, queryString);
     }
 
     private OnlineResource onlineResource(DatasetUploadState d, String publishedName, String protocol,

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
@@ -184,7 +184,6 @@ public class GeorchestraMetadataPublicationServiceIT {
         final String title = publishing.getTitle();
         assertOnlineResource(dom, "OGC:WMS", PULISHED_LAYERNAME, title + " - WMS");
         assertOnlineResource(dom, "OGC:WFS", PULISHED_LAYERNAME, title + " - WFS");
-        assertOnlineResource(dom, "WWW:DOWNLOAD-1.0-http--download", PULISHED_LAYERNAME, title + " - WWW");
 
         URL publicUrl = configProperties.getPublishing().getGeonetwork().getPublicUrl();
         final String uniqueResourceIdentifier = URI.create(publicUrl + "?uuid=" + createdMdId).normalize().toString();


### PR DESCRIPTION
Given the fact that both GeoNetwork and datahub are able to provide such a download link via the WFS API, it does not make sense to favor the old SHP format (which appears as "unknown format" at the bottom of the list).

![image](https://github.com/georchestra/georchestra/assets/265319/85689fac-9349-46a2-a575-5e7c94208e97)
