### PR TITLE
console - ensures we remove empty strings from the SUPERUSER recipients

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -38,6 +38,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.validator.routines.EmailValidator;
@@ -144,6 +146,10 @@ public final class NewAccountFormController {
 
     public void setEmailFactory(EmailFactory emailFactory) {
         this.emailFactory = emailFactory;
+    }
+
+    public void setPasswordUtils(PasswordUtils passwordUtils) {
+        this.passwordUtils = passwordUtils;
     }
 
     public void setAdvancedDelegationDao(AdvancedDelegationDao advancedDelegationDao) {
@@ -285,8 +291,7 @@ public final class NewAccountFormController {
             final ServletContext servletContext = request.getSession().getServletContext();
 
             // List of recipients for notification email
-            List<String> recipients = accountDao.findByRole("SUPERUSER").stream().map(Account::getEmail)
-                    .collect(Collectors.toCollection(LinkedList::new));
+            List<String> recipients = getSuperUserEmailAddresses();
 
             // Retrieve emails of delegated admin if org is specified
             if (!formBean.getOrg().equals("-")) {
@@ -339,6 +344,11 @@ public final class NewAccountFormController {
 
             throw new IOException(e);
         }
+    }
+
+    public @VisibleForTesting List<String> getSuperUserEmailAddresses() throws DataServiceException {
+        return accountDao.findByRole("SUPERUSER").stream().map(Account::getEmail).filter(StringUtils::isNotEmpty)
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     private void validateFields(@ModelAttribute AccountFormBean formBean, BindingResult result) {


### PR DESCRIPTION
if some members of the `SUPERUSER` role don't have an e-mail address (or an empty string) defined in their LDAP entry, then the account creation will fail at notifying them by mail, returning a JSON error to the user trying to create an account. 

tests: Added a UT, `mvn clean verify -Pit` OK.

Same as https://github.com/georchestra/georchestra/pull/4102 for `23.0.x`.
