### PR TITLE
Themable Webcomponent header

### DIFF
--- a/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/analytics/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -3,7 +3,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;" active-app="analytics"></geor-header>
+        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;" logo-url="${logoUrl}" stylesheet="${georchestraStylesheet}"  active-app="analytics"></geor-header>
         <script src="<c:out value="${headerScript}" />"></script>
     </div>
     </c:when>

--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -54,7 +54,7 @@
                 <entry key="headerScript" value="${headerScript}" />
                 <entry key="useLegacyHeader" value="${useLegacyHeader}" />
                 <entry key="logoUrl" value="${logoUrl}" />
-                <entry key="stylesheet" value="${georchestraStylesheet}" />
+                <entry key="georchestraStylesheet" value="${georchestraStylesheet}" />
             </map>
         </property>
     </bean>

--- a/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
+++ b/analytics/src/main/webapp/WEB-INF/ws-servlet.xml
@@ -53,6 +53,8 @@
                 <entry key="headerHeight" value="${headerHeight}"/>
                 <entry key="headerScript" value="${headerScript}" />
                 <entry key="useLegacyHeader" value="${useLegacyHeader}" />
+                <entry key="logoUrl" value="${logoUrl}" />
+                <entry key="stylesheet" value="${georchestraStylesheet}" />
             </map>
         </property>
     </bean>

--- a/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
@@ -63,8 +63,14 @@ public class InfosController {
     @Value("${headerScript:https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js}")
     private String headerScript;
 
+    @Value("${logoUrl:https://www.georchestra.org/public/georchestra-logo.svg}")
+    private String logoUrl;
+
+    @Value("${georchestraStylesheet:}")
+    private String georchestraStylesheet;
+
     @GetMapping(value = BASE_MAPPING + "/platform/infos", produces = "application/json; charset=utf-8")
-    @PreAuthorize(value = "hasRole('SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('SUPERUSER', 'ORGADMIN')")
     @ResponseBody
     public String getPlatformInfos() {
         JSONObject ret = new JSONObject();
@@ -76,6 +82,8 @@ public class InfosController {
         ret.put("headerUrl", headerUrl);
         ret.put("headerHeight", headerHeight);
         ret.put("headerScript", headerScript);
+        ret.put("logoUrl", logoUrl);
+        ret.put("georchestraStylesheet", georchestraStylesheet);
         return ret.toString();
     }
 }

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -59,6 +59,8 @@
         <entry key="headerHeight" value="${headerHeight}" />
         <entry key="headerUrl" value="${headerUrl}" />
         <entry key="headerScript" value="${headerScript}" />
+        <entry key="logoUrl" value="${logoUrl}" />
+        <entry key="georchestraStylesheet" value="${georchestraStylesheet}" />
         <entry key="readonlyUid" value="${readonlyUid:false}" />
         <entry key="publicContextPath" value="${publicContextPath:/console}"/>
       </map>

--- a/console/src/main/webapp/manager/app/assets/index.html
+++ b/console/src/main/webapp/manager/app/assets/index.html
@@ -14,7 +14,7 @@
 
 <body ng-app="manager" ng-strict-di ng-controller="AppController">
 
-  <geor-header legacy-header="{{ platformInfos.useLegacyHeader }}" legacy-url="{{ platformInfos.headerUrl }}" style="width:100%;height:{{ platformInfos.headerHeight }}px;border:none;" active-app="console"></geor-header>
+  <geor-header legacy-header="{{ platformInfos.useLegacyHeader }}" legacy-url="{{ platformInfos.headerUrl }}" style="width:100%;height:{{ platformInfos.headerHeight }}px;border:none;"  logo-url="{{ trustSrc(platformInfos.logoUrl) }}" stylesheet="{{ trustSrc(platformInfos.georchestraStylesheet) }}" active-app="console"></geor-header>
   <script ng-src="{{ trustSrc(platformInfos.headerScript) }}"></script>
 
   <div flash-message="2000"></div>
@@ -41,7 +41,7 @@
       <li role="presentation" ng-class="{'active': isActive(['delegations'])}" ng-if="profile === 'SUPERUSER'">
         <a ng-link="delegations({})" translate>nav.delegations</a>
       </li>
-      <li role="presentation" ng-class="{'active': isActive(['analytics'])}" ng-if="platformInfos.analyticsEnabled">
+      <li role="presentation" ng-class="{'active': isActive(['analytics'])}" ng-if="platformInfos.analyticsEnabled || false">
         <a ng-link="analytics({'role': 'all'})" translate>nav.analytics</a>
       </li>
       <li role="presentation" ng-class="{'active': isActive(['logs'])}">

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -47,6 +47,8 @@
         <entry key="headerHeight" value="${headerHeight}" />
         <entry key="headerUrl" value="${headerUrl}" />
         <entry key="headerScript" value="${headerScript}" />
+        <entry key="logoUrl" value="${logoUrl}" />
+        <entry key="georchestraStylesheet" value="${georchestraStylesheet}" />
         <entry key="readonlyUid" value="${readonlyUid:false}" />
         <entry key="publicContextPath" value="${publicContextPath:/console}"/>
       </map>

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -24,6 +24,8 @@
                 <entry key="headerUrl" value="${headerUrl}" />
                 <entry key="headerScript" value="${headerScript}" />
                 <entry key="useLegacyHeader" value="${useLegacyHeader}" />
+                <entry key="logoUrl" value="${logoUrl}" />
+                <entry key="georchestraStylesheet" value="${georchestraStylesheet}" />
             </map>
         </property>
     </bean>

--- a/security-proxy/src/main/webapp/header.jsp
+++ b/security-proxy/src/main/webapp/header.jsp
@@ -4,7 +4,7 @@
 <c:choose>
     <c:when test='<%= request.getParameter("noheader") == null %>'>
     <div id="go_head">
-        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;"></geor-header>
+        <geor-header legacy-header="${useLegacyHeader}" legacy-url="${headerUrl}" style="width:100%;height:${headerHeight}px;border:none;"  logo-url="${logoUrl}" stylesheet="${georchestraStylesheet}"></geor-header>
         <script src="<c:out value="${headerScript}" />"></script>
     </div>
     </c:when>


### PR DESCRIPTION
# Themable Webcomponent header

Extends PR : 
- https://github.com/georchestra/georchestra/pull/4065

This PR adds missing 'logo-url' attribute and new 'stylesheet' attribute
| Attribute     | Description                                                                                          | Example                                                                     | For host | For legacy |
|---------------|------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|----------|------------|
| logo-url      | Use this attribute to set the logo for the new header (not legacy one).                              | `<geor-header logo-url='https://linktomylogo.com'>`                         | v        |            |
| stylesheet         | adds this stylesheet to webcomponent to allow color overriding and more                                   | `<geor-header stylesheet="my-stylesheet.css"></geor-header>` | v        |           |

## PRs

- [x] https://github.com/georchestra/header/pull/16/

### Header

### Implementations
- [x] Analytics, console & security proxy
	- [ ] *This PR*
- [x] Geoserver 
	- [x] https://github.com/georchestra/geoserver/pull/35
- [x] Geonetwork
	- [x] https://github.com/georchestra/geonetwork/pull/271
- [x] Mapstore 
	- [x] https://github.com/georchestra/mapstore2-georchestra/pull/684
- [x] CAS 
	- [x] https://github.com/georchestra/georchestra-cas-server/pull/23
- [x] Datadir 
	- [x] https://github.com/georchestra/datadir/pull/372
