### PR TITLE
maven - generalizing source / test-sources jar generation

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -154,6 +154,10 @@
         </systemProperties>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -49,15 +49,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -386,7 +386,7 @@
 	  <groupId>com.vladmihalcea</groupId>
 	  <artifactId>hibernate-types-52</artifactId>
 	  <version>2.10.3</version>
-	</dependency>    
+	</dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
@@ -592,7 +592,11 @@
           <forkCount>2</forkCount>
           <reuseForks>false</reuseForks>
         </configuration>
-      </plugin>          
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -548,6 +548,27 @@
           <generatedSourcesDirectory>${project.build.directory}/generated-sources/mapstruct</generatedSourcesDirectory>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/header/pom.xml
+++ b/header/pom.xml
@@ -93,6 +93,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/ldap-account-management/pom.xml
+++ b/ldap-account-management/pom.xml
@@ -140,6 +140,10 @@
           <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/ogc-server-statistics/pom.xml
+++ b/ogc-server-statistics/pom.xml
@@ -29,7 +29,11 @@
                 <encoding>${project.build.sourceEncoding}</encoding>
               </configuration>
             </plugin>
-		</plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-source-plugin</artifactId>
+						</plugin>
+				</plugins>
 	</build>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -640,7 +640,7 @@
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
           <version>${formatter-maven-plugin.version}</version>
-	  <inherited>true</inherited>
+	        <inherited>true</inherited>
           <executions>
             <execution>
               <goals>
@@ -731,6 +731,27 @@
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
           <version>0.28.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.0</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>attach-test-sources</id>
+              <phase>package</phase>
+              <goals>
+                <goal>test-jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/security-proxy-spring-integration/pom.xml
+++ b/security-proxy-spring-integration/pom.xml
@@ -99,15 +99,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/security-proxy/pom.xml
+++ b/security-proxy/pom.xml
@@ -206,6 +206,10 @@
           </systemProperties>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -35,16 +35,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Some geOrchestra modules already provide source-jar & test-source-jar packages, but not all. This PR aims to generalize their generation across modules.

This is not necessary per se, but makes IDE (e.g. intellij) life easier when it tries to download the sources and resolve them, else requiring an extra configuration step from the user to manually provide a source tree for some of the geOrchestra components being reused (testcontainers, ldap-acct-mgmt, commons ...).