### PR TITLE
Adding i18n to email template for new account creation

### DIFF
--- a/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
+++ b/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
@@ -81,7 +81,9 @@ public class RabbitmqEventsListener implements MessageListener {
             try {
                 String username = jsonObj.getString("username");
                 String email = jsonObj.getString("email");
-                String provider = jsonObj.getString("provider");
+                String organization = jsonObj.getString("organization");
+                String providerName = jsonObj.getString("providerName");
+                String providerUid = jsonObj.getString("providerUid");
                 System.out.println(this.roleDao.findByCommonName("SUPERUSER"));
                 List<String> superUserAdmins = this.roleDao.findByCommonName("SUPERUSER").getUserList().stream()
                         .map(user -> {
@@ -92,8 +94,8 @@ public class RabbitmqEventsListener implements MessageListener {
                             }
                         }).collect(Collectors.toList());
 
-                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, username, email, provider,
-                        true);
+                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, username, email, organization,
+                        providerName, providerUid,true);
 
                 synReceivedMessageUid.add(uid);
                 logUtils.createOAuth2Log(email, AdminLogType.OAUTH2_USER_CREATED, null);

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -22,6 +22,7 @@ package org.georchestra.console.mailservice;
 import static java.util.Collections.singletonList;
 
 import java.util.List;
+import java.util.Locale;
 
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -30,12 +31,15 @@ import javax.servlet.ServletContext;
 
 import org.georchestra.commons.configuration.GeorchestraConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.util.StringUtils;
 
 /**
  * Manage e-mails required for this application
  */
 public class EmailFactory {
 
+    private String language;
     private String smtpHost;
     private int smtpPort;
     private boolean emailHtml;
@@ -47,6 +51,9 @@ public class EmailFactory {
 
     @Autowired
     private GeorchestraConfiguration georConfig;
+
+    @Autowired
+    ReloadableResourceBundleMessageSource messageSource;
 
     private String accountWasCreatedEmailFile;
     private String accountWasCreatedEmailSubject;
@@ -181,17 +188,27 @@ public class EmailFactory {
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
                 this.newAccountNotificationEmailFile, servletContext, this.georConfig, this.publicUrl,
                 this.instanceName);
-
         email.set("oauth2", "");
-        email.set("name", userName);
-        email.set("uid_msg", "User ID: " + uid + "\n");
-        email.set("email", userEmail);
-        if (userOrg == null) {
-            userOrg = "";
+        email.set("welcome_msg", messageSource.getMessage("email.welcome.message", null, new Locale(language)) + "\n");
+        email.set("start_msg_part1",
+                messageSource.getMessage("email.start.message.part1", null, new Locale(language)) + " ");
+        email.set("start_msg_part2", messageSource.getMessage("email.start.message.part2", null, new Locale(language)));
+        email.set("name_msg",
+                messageSource.getMessage("email.user.name", null, new Locale(language)) + ": " + userName + "\n");
+        email.set("email_msg",
+                messageSource.getMessage("email.user.email", null, new Locale(language)) + ": " + userEmail + "\n");
+        email.set("uid_msg", messageSource.getMessage("email.user.id", null, new Locale(language)) + ": " + uid + "\n");
+        if (!StringUtils.isEmpty(userOrg)) {
+            email.set("org_msg",
+                    messageSource.getMessage("email.user.org", null, new Locale(language)) + ": " + userOrg + "\n");
+        } else {
+            email.set("org_msg", "");
         }
-        email.set("org_msg", "User Organization: " + userOrg + "\n");
         email.set("provider_msg", "");
-        email.set("user_id", uid);
+        email.set("manage_msg", messageSource.getMessage("email.manage.message", null, new Locale(language)));
+        email.set("sent_msg_part1", messageSource.getMessage("email.sent.message.part1", null, new Locale(language)));
+        email.set("sent_msg_part2",
+                messageSource.getMessage("email.sent.message.part2", null, new Locale(language)) + "\n");
         email.send(reallySend);
     }
 
@@ -202,13 +219,23 @@ public class EmailFactory {
                 this.emailHtml, userEmail, // Reply-to
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
                 this.newAccountNotificationEmailFile, null, this.georConfig, this.publicUrl, this.instanceName);
-        email.set("name", userName);
-        email.set("email", userEmail);
+        email.set("welcome_msg", messageSource.getMessage("email.welcome.message", null, new Locale(language)) + "\n");
+        email.set("start_msg_part1",
+                messageSource.getMessage("email.start.message.part1", null, new Locale(language)) + " ");
+        email.set("start_msg_part2", messageSource.getMessage("email.start.message.part2", null, new Locale(language)));
+        email.set("name_msg",
+                messageSource.getMessage("email.user.name", null, new Locale(language)) + ": " + userName + "\n");
+        email.set("email_msg",
+                messageSource.getMessage("email.user.email", null, new Locale(language)) + ": " + userEmail + "\n");
         email.set("uid_msg", "");
         email.set("org_msg", "");
-        email.set("provider_msg", "Provider : " + provider + "\n");
+        email.set("provider_msg",
+                messageSource.getMessage("email.user.provider", null, new Locale(language)) + ": " + provider + "\n");
+        email.set("manage_msg", messageSource.getMessage("email.manage.message", null, new Locale(language)));
+        email.set("sent_msg_part1", messageSource.getMessage("email.sent.message.part1", null, new Locale(language)));
+        email.set("sent_msg_part2",
+                messageSource.getMessage("email.sent.message.part2", null, new Locale(language)) + "\n");
         email.set("oauth2", "OAuth 2 ");
-        email.set("user_id", userEmail);
         email.send(reallySend);
     }
 
@@ -258,6 +285,10 @@ public class EmailFactory {
 
     public void setGeorConfig(GeorchestraConfiguration georConfig) {
         this.georConfig = georConfig;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
     }
 
     public void setAccountWasCreatedEmailFile(String accountWasCreatedEmailFile) {

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -209,6 +209,7 @@ public class EmailFactory {
         email.set("sent_msg_part1", messageSource.getMessage("email.sent.message.part1", null, new Locale(language)));
         email.set("sent_msg_part2",
                 messageSource.getMessage("email.sent.message.part2", null, new Locale(language)) + "\n");
+        email.set("user_id", uid);
         email.send(reallySend);
     }
 
@@ -236,6 +237,7 @@ public class EmailFactory {
         email.set("sent_msg_part2",
                 messageSource.getMessage("email.sent.message.part2", null, new Locale(language)) + "\n");
         email.set("oauth2", "OAuth 2 ");
+        email.set("user_id", userEmail);
         email.send(reallySend);
     }
 

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -213,8 +213,8 @@ public class EmailFactory {
         email.send(reallySend);
     }
 
-    public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String userName, String userEmail,
-            String provider, boolean reallySend) throws MessagingException {
+    public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String userName, String userEmail, String userOrg,
+            String providerName, String providerUid, boolean reallySend) throws MessagingException {
 
         Email email = new Email(recipients, this.newOAuth2AccountNotificationEmailSubject, this.smtpHost, this.smtpPort,
                 this.emailHtml, userEmail, // Reply-to
@@ -228,10 +228,15 @@ public class EmailFactory {
                 messageSource.getMessage("email.user.name", null, new Locale(language)) + ": " + userName + "\n");
         email.set("email_msg",
                 messageSource.getMessage("email.user.email", null, new Locale(language)) + ": " + userEmail + "\n");
-        email.set("uid_msg", "");
-        email.set("org_msg", "");
+        email.set("uid_msg", messageSource.getMessage("email.user.id", null, new Locale(language)) + ": " + providerUid + "\n");
+        if (!StringUtils.isEmpty(userOrg)) {
+            email.set("org_msg",
+                    messageSource.getMessage("email.user.org", null, new Locale(language)) + ": " + userOrg + "\n");
+        } else {
+            email.set("org_msg", "");
+        }
         email.set("provider_msg",
-                messageSource.getMessage("email.user.provider", null, new Locale(language)) + ": " + provider + "\n");
+                messageSource.getMessage("email.user.provider", null, new Locale(language)) + ": " + providerName + "\n");
         email.set("manage_msg", messageSource.getMessage("email.manage.message", null, new Locale(language)));
         email.set("sent_msg_part1", messageSource.getMessage("email.sent.message.part1", null, new Locale(language)));
         email.set("sent_msg_part2",

--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -154,3 +154,17 @@ shortName.label=Short name
 name.label=Name
 address.label=Address
 orgType.label=Organization Type
+
+### Email Template fields properties
+
+email.welcome.message=Dear admin,
+email.start.message.part1=A new
+email.start.message.part2=user signed up on
+email.user.name=User name
+email.user.email=User email
+email.user.id=User ID
+email.user.org=User Organization
+email.user.provider=Identity Provider
+email.manage.message=Manage account on
+email.sent.message.part1=Sent by
+email.sent.message.part2=automatically, please do not respond.

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -152,3 +152,16 @@ shortName.label=Kurzname
 name.label=Name
 address.label=Adresse
 orgType.label=Organisationstyp
+
+### Email Template fields properties
+
+email.welcome.message=Sehr geehrter Administrator,
+email.start.message.part1=Ein neuer
+email.start.message.part2=Benutzer hat sich angemeldet
+email.user.name=Name
+email.user.email=Email
+email.user.id=Benutzerkennung
+email.user.org=Benutzerorganisation
+email.user.provider=Identitätsanbieter
+email.sent.message.part1=Gesendet von
+email.sent.message.part2=automatisch, bitte antworten Sie nicht.

--- a/console/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -153,3 +153,17 @@ shortName.label=Nombre corto
 name.label=Nombre
 address.label=DirecciÃ³n
 orgType.label=Tipo de organizaciÃ³n
+
+### Email Template fields properties
+
+email.welcome.message=Sehr geehrter Administrator,
+email.start.message.part1=¡Una nueva usuario de 
+email.start.message.part2=usuario registrado en
+email.user.name=apellido
+email.user.email=Correo electrónico
+email.user.id=ID de usuario
+email.user.org=Organización de usuarios
+email.user.provider=Proveedor de identidad
+email.manage.message=Administrar cuenta en
+email.sent.message.part1=Enviado por
+email.sent.message.part2=automáticamente, por favor no responda.

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -152,3 +152,17 @@ shortName.label=Nom court
 name.label=Nom
 address.label=Adresse
 orgType.label=Type d'organisme
+
+### Email Template fields properties
+
+email.welcome.message=Cher administrateur,
+email.start.message.part1=Un nouvel utilisateur
+email.start.message.part2=s'est inscrit sur
+email.user.name=Nom
+email.user.email=Courriel
+email.user.id=Identifiant
+email.user.org=Organization
+email.user.provider=Fournisseur d'identité
+email.manage.message=Gérez ce compte sur
+email.sent.message.part1=Ce message a été envoyé par
+email.sent.message.part2=de manière automatique, merci de ne pas y répondre.

--- a/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
@@ -152,3 +152,17 @@ name.label=Name
 address.label=Address
 orgType.label=Organization Type
 mail.label=Mail
+
+### Email Template fields properties
+
+email.welcome.message=Sehr geehrter Administrator,
+email.start.message.part1=Een nieuwe
+email.start.message.part2=gebruiker heeft zich aangemeld
+email.user.name=Naam
+email.user.email=E-mail
+email.user.id=gebruikersnaam
+email.user.org=Gebruikersorganisatie
+email.user.provider=Identiteitsprovider
+email.manage.message=Beheer account aan
+email.sent.message.part1=Verzonden door
+email.sent.message.part2=automatisch, reageer a.u.b. niet.

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -255,6 +255,7 @@
 
   <!-- Email Factory configuration -->
   <bean id="emailFactory" class="org.georchestra.console.mailservice.EmailFactory" >
+    <property name="language" value="${language:en}"/>
     <property name="smtpHost" value="${smtpHost}"/>
     <property name="smtpPort" value="${smtpPort}"/>
     <property name="emailHtml" value="${emailHtml:false}"/>


### PR DESCRIPTION
On this PR, we  make use of I18n messages  while building email text template to be sent when a new account is created (OAuth2 or not)