### PR TITLE
console - block org description to 255 chars

### DIFF
--- a/console/src/main/webapp/manager/app/assets/lang/de.json
+++ b/console/src/main/webapp/manager/app/assets/lang/de.json
@@ -115,6 +115,7 @@
   "org.note"              : "Aufzeichnungen",
   "org.cities"            : "Bereich",
   "org.orgType"           : "Organisationstyp",
+  "org.maxdesc"           : "255 Zeichen max",
   "imageinput.label"      : "Logo laden",
   "roles.title_plural"    : "Rollen",
   "roles.title_one"       : "Rolle",

--- a/console/src/main/webapp/manager/app/assets/lang/en.json
+++ b/console/src/main/webapp/manager/app/assets/lang/en.json
@@ -115,6 +115,7 @@
   "org.note"              : "Internal Notes",
   "org.cities"            : "Area",
   "org.orgType"           : "Organisation type",
+  "org.maxdesc"           : "255 chars max",
   "imageinput.label"      : "Upload logo",
   "roles.title_plural"    : "roles",
   "roles.title_one"       : "role",

--- a/console/src/main/webapp/manager/app/assets/lang/es.json
+++ b/console/src/main/webapp/manager/app/assets/lang/es.json
@@ -115,6 +115,7 @@
   "org.note"              : "Interno Notas",
   "org.cities"            : "Zona",
   "org.orgType"           : "Organisation type",
+  "org.maxdesc"           : "255 caracteres max",
   "imageinput.label"      : "Subir un logo",
   "roles.title_plural"    : "roles",
   "roles.title_one"       : "role",

--- a/console/src/main/webapp/manager/app/assets/lang/fr.json
+++ b/console/src/main/webapp/manager/app/assets/lang/fr.json
@@ -115,6 +115,7 @@
   "org.note"              : "Notes Internes",
   "org.cities"            : "Aire de compétence",
   "org.orgType"           : "Type d'organisme",
+  "org.maxdesc"           : "255 caractères max",
   "imageinput.label"      : "Charger un logo",
   "roles.title_plural"    : "rôles",
   "roles.title_one"       : "rôle",

--- a/console/src/main/webapp/manager/app/assets/lang/nl.json
+++ b/console/src/main/webapp/manager/app/assets/lang/nl.json
@@ -115,6 +115,7 @@
   "org.note"              : "Internal Notes",
   "org.cities"            : "Area",
   "org.orgType"           : "Organisation type",
+  "org.maxdesc"           : "255 tekens max",
   "imageinput.label"      : "Upload logo",
   "roles.title_plural"    : "rollen",
   "roles.title_one"       : "rol",

--- a/console/src/main/webapp/manager/app/templates/orgForm.tpl.html
+++ b/console/src/main/webapp/manager/app/templates/orgForm.tpl.html
@@ -42,10 +42,13 @@
       </div>
 
       <div class="form-group form-group-sm" ng-class="{required: required.description}">
-        <label class="col-sm-4" for="address" translate>org.description</label>
+        <label class="col-sm-4" for="address">
+          <span translate>org.description</span><br>
+          <small class="text-muted" style="font-weight: normal" translate>org.maxdesc</small>
+        </label>
         <div class="col-sm-8">
-          <textarea ng-model="model.description" class="form-control" id="description"
-                    placeholder="" ng-required="required.description"></textarea>
+          <textarea ng-model="model.description" class="form-control" id="description" maxlength="255"
+                    placeholder="{{ 'org.maxdesc' | translate }}" ng-required="required.description"></textarea>
         </div>
       </div>
 


### PR DESCRIPTION
Used to avoid `Caused by: java.sql.BatchUpdateException: Batch entry 0 insert into Groups`in Geonetwork (GN limited to 255 chars)