### PR TITLE
Adding specific email template for new OAuth2 account creation

### DIFF
--- a/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
+++ b/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
@@ -81,8 +81,12 @@ public class RabbitmqEventsListener implements MessageListener {
             try {
                 String username = jsonObj.getString("username");
                 String email = jsonObj.getString("email");
-                String provider = jsonObj.getString("provider");
-                System.out.println(this.roleDao.findByCommonName("SUPERUSER"));
+                String providerName = jsonObj.getString("providerName");
+                String providerUid = jsonObj.getString("providerUid");
+                String organization = null;
+                if (jsonObj.has("organization")) {
+                    organization = jsonObj.getString("organization");
+                }
                 List<String> superUserAdmins = this.roleDao.findByCommonName("SUPERUSER").getUserList().stream()
                         .map(user -> {
                             try {
@@ -92,8 +96,8 @@ public class RabbitmqEventsListener implements MessageListener {
                             }
                         }).collect(Collectors.toList());
 
-                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, username, email, provider,
-                        true);
+                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, username, email, providerName,
+                        providerUid, organization, true);
 
                 synReceivedMessageUid.add(uid);
                 logUtils.createOAuth2Log(email, AdminLogType.OAUTH2_USER_CREATED, null);

--- a/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
+++ b/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
@@ -79,7 +79,8 @@ public class RabbitmqEventsListener implements MessageListener {
 
         if (subject.equals("OAUTH2-ACCOUNT-CREATION") && !synReceivedMessageUid.stream().anyMatch(s -> s.equals(uid))) {
             try {
-                String username = jsonObj.getString("username");
+                String fullName = jsonObj.getString("fullName");
+                String localUid = jsonObj.getString("localUid");
                 String email = jsonObj.getString("email");
                 String providerName = jsonObj.getString("providerName");
                 String providerUid = jsonObj.getString("providerUid");
@@ -96,8 +97,8 @@ public class RabbitmqEventsListener implements MessageListener {
                             }
                         }).collect(Collectors.toList());
 
-                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, username, email, providerName,
-                        providerUid, organization, true);
+                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, fullName, localUid, email,
+                        providerName, providerUid, organization, true);
 
                 synReceivedMessageUid.add(uid);
                 logUtils.createOAuth2Log(email, AdminLogType.OAUTH2_USER_CREATED, null);

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -65,6 +65,8 @@ public class EmailFactory {
 
     private String newAccountNotificationEmailFile;
 
+    private String newOAuth2AccountNotificationEmailFile;
+
     private String newAccountNotificationEmailSubject;
 
     private String newOAuth2AccountNotificationEmailSubject;
@@ -181,34 +183,32 @@ public class EmailFactory {
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
                 this.newAccountNotificationEmailFile, servletContext, this.georConfig, this.publicUrl,
                 this.instanceName);
-
-        email.set("oauth2", "");
         email.set("name", userName);
-        email.set("uid_msg", "User ID: " + uid + "\n");
+        email.set("uid", uid);
         email.set("email", userEmail);
         if (userOrg == null) {
             userOrg = "";
         }
-        email.set("org_msg", "User Organization: " + userOrg + "\n");
-        email.set("provider_msg", "");
-        email.set("user_id", uid);
+        email.set("org", userOrg);
         email.send(reallySend);
     }
 
     public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String userName, String userEmail,
-            String provider, boolean reallySend) throws MessagingException {
+            String providerName, String providerUid, String userOrg, boolean reallySend) throws MessagingException {
 
         Email email = new Email(recipients, this.newOAuth2AccountNotificationEmailSubject, this.smtpHost, this.smtpPort,
                 this.emailHtml, userEmail, // Reply-to
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
-                this.newAccountNotificationEmailFile, null, this.georConfig, this.publicUrl, this.instanceName);
+                this.newOAuth2AccountNotificationEmailFile, null, this.georConfig, this.publicUrl, this.instanceName);
         email.set("name", userName);
         email.set("email", userEmail);
-        email.set("uid_msg", "");
-        email.set("org_msg", "");
-        email.set("provider_msg", "Provider : " + provider + "\n");
-        email.set("oauth2", "OAuth 2 ");
-        email.set("user_id", userEmail);
+        if (userOrg == null) {
+            userOrg = "";
+        }
+        email.set("org", userOrg);
+        email.set("providerName", providerName);
+        email.set("uid", providerUid);
+        email.set("userId", userEmail);
         email.send(reallySend);
     }
 
@@ -302,6 +302,10 @@ public class EmailFactory {
 
     public void setNewAccountNotificationEmailFile(String newAccountNotificationEmailFile) {
         this.newAccountNotificationEmailFile = newAccountNotificationEmailFile;
+    }
+
+    public void setNewOAuth2AccountNotificationEmailFile(String newOAuth2AccountNotificationEmailFile) {
+        this.newOAuth2AccountNotificationEmailFile = newOAuth2AccountNotificationEmailFile;
     }
 
     public void setNewAccountNotificationEmailSubject(String newAccountNotificationEmailSubject) {

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -170,22 +170,22 @@ public class EmailFactory {
         email.send(reallySend);
     }
 
-    public void sendNewAccountNotificationEmail(ServletContext servletContext, List<String> recipients, String userName,
-            String uid, String userEmail, String userOrg) throws MessagingException {
-        sendNewAccountNotificationEmail(servletContext, recipients, userName, uid, userEmail, userOrg, true);
+    public void sendNewAccountNotificationEmail(ServletContext servletContext, List<String> recipients, String fullName,
+            String uid, String emailAddress, String userOrg) throws MessagingException {
+        sendNewAccountNotificationEmail(servletContext, recipients, fullName, uid, emailAddress, userOrg, true);
     }
 
-    public void sendNewAccountNotificationEmail(ServletContext servletContext, List<String> recipients, String userName,
-            String uid, String userEmail, String userOrg, boolean reallySend) throws MessagingException {
+    public void sendNewAccountNotificationEmail(ServletContext servletContext, List<String> recipients, String fullName,
+            String uid, String emailAddress, String userOrg, boolean reallySend) throws MessagingException {
 
         Email email = new Email(recipients, this.newAccountNotificationEmailSubject, this.smtpHost, this.smtpPort,
-                this.emailHtml, userEmail, // Reply-to
+                this.emailHtml, emailAddress, // Reply-to
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
                 this.newAccountNotificationEmailFile, servletContext, this.georConfig, this.publicUrl,
                 this.instanceName);
-        email.set("name", userName);
+        email.set("name", fullName);
         email.set("uid", uid);
-        email.set("email", userEmail);
+        email.set("email", emailAddress);
         if (userOrg == null) {
             userOrg = "";
         }
@@ -193,22 +193,23 @@ public class EmailFactory {
         email.send(reallySend);
     }
 
-    public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String userName, String userEmail,
-            String providerName, String providerUid, String userOrg, boolean reallySend) throws MessagingException {
+    public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String fullName, String localUid,
+            String emailAddress, String providerName, String providerUid, String userOrg, boolean reallySend)
+            throws MessagingException {
 
         Email email = new Email(recipients, this.newOAuth2AccountNotificationEmailSubject, this.smtpHost, this.smtpPort,
-                this.emailHtml, userEmail, // Reply-to
+                this.emailHtml, emailAddress, // Reply-to
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
                 this.newOAuth2AccountNotificationEmailFile, null, this.georConfig, this.publicUrl, this.instanceName);
-        email.set("name", userName);
-        email.set("email", userEmail);
+        email.set("name", fullName);
+        email.set("uid", localUid);
+        email.set("email", emailAddress);
         if (userOrg == null) {
             userOrg = "";
         }
         email.set("org", userOrg);
         email.set("providerName", providerName);
-        email.set("uid", providerUid);
-        email.set("userId", userEmail);
+        email.set("providerUid", providerUid);
         email.send(reallySend);
     }
 

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -274,6 +274,7 @@
     <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="${subject.account.uid.renamed:[${instanceName}] New login for your account}" />
     <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>
+    <property name="newOAuth2AccountNotificationEmailFile" value="new-oauth2-account-notification-template.txt"/>
     <property name="newAccountNotificationEmailSubject" value="${subject.new.account.notification:[${instanceName}] New account created}"/>
     <property name="newOAuth2AccountNotificationEmailSubject" value="${subject.new.oauth2account.notification:[${instanceName}] New OAuth2 account created}"/>
     <property name="publicUrl" value="https://${domainName}"/>

--- a/console/src/test/resources/mail-factory-test.xml
+++ b/console/src/test/resources/mail-factory-test.xml
@@ -24,6 +24,7 @@
     <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="[georTest] New login for your account" />
     <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>
+    <property name="newOAuth2AccountNotificationEmailFile" value="new-oauth2-account-notification-template.txt"/>
     <property name="newAccountNotificationEmailSubject" value="[georTest]] New account created"/>
     <property name="publicUrl" value="https://georchestra.mydomain.org"/>
     <property name="instanceName" value="georchestra test"/>

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -263,6 +263,7 @@
     <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="${subject.account.uid.renamed:[${instanceName}] New login for your account}" />
     <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>
+    <property name="newOAuth2AccountNotificationEmailFile" value="new-oauth2-account-notification-template.txt"/>
     <property name="newAccountNotificationEmailSubject" value="${subject.new.account.notification:[${instanceName}] New account created}"/>
     <property name="publicUrl" value="https://${domainName}"/>
     <property name="instanceName" value="${instanceName}"/>


### PR DESCRIPTION
A specific email template for new OAuth2 account creation has been added to avoid use of i18n in mail templates.
Adding required code to handle new template in console.