### PR TITLE
Copy custom jetty env if file is found

### DIFF
--- a/geoserver/webapp/src/docker/docker-entrypoint.d/01-copy-jetty-env-if-found
+++ b/geoserver/webapp/src/docker/docker-entrypoint.d/01-copy-jetty-env-if-found
@@ -1,0 +1,8 @@
+#!/bin/sh
+FILE=/etc/georchestra/geoserver/jetty-env.xml
+if [ -f "$FILE" ]; then
+    echo "Copying jetty-env.xml"
+    cp $FILE /var/lib/jetty/webapps/geoserver/WEB-INF/jetty-env.xml
+else
+    echo "jetty-env.xml not found, ignoring."
+fi


### PR DESCRIPTION
This custom file is necessary for having geoserver JNDI working properly.

Instead of built-in the copy of the file through the docker composition or the helm chart.

I propose to have this copy directly in the container.

Probably to be backported in 23. Won't hurt the actual fonctionality of geoserver.