### PR TITLE
console - delegation - uid containing dots fix

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/delegations/DelegationController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/delegations/DelegationController.java
@@ -90,7 +90,7 @@ public class DelegationController {
     }
 
     @RequestMapping(value = REQUEST_MAPPING
-            + "/{uid}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+            + "/{uid:.*}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     @ResponseBody
     public String findByUid(@PathVariable String uid) throws JSONException {
 
@@ -100,7 +100,7 @@ public class DelegationController {
     }
 
     @RequestMapping(value = REQUEST_MAPPING
-            + "/{uid}", method = RequestMethod.POST, produces = "application/json; charset=utf-8")
+            + "/{uid:.*}", method = RequestMethod.POST, produces = "application/json; charset=utf-8")
     @ResponseBody
     public String add(HttpServletRequest request, @PathVariable String uid)
             throws JSONException, IOException, DataServiceException {
@@ -129,7 +129,7 @@ public class DelegationController {
     }
 
     @RequestMapping(value = REQUEST_MAPPING
-            + "/{uid}", method = RequestMethod.DELETE, produces = "application/json; charset=utf-8")
+            + "/{uid:.*}", method = RequestMethod.DELETE, produces = "application/json; charset=utf-8")
     @ResponseBody
     public String delete(HttpServletRequest request, @PathVariable String uid)
             throws JSONException, IOException, DataServiceException {

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/delegations/DelegationControllerIT.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/delegations/DelegationControllerIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.console.ws.backoffice.delegations;
+
+import org.georchestra.console.integration.ConsoleIntegrationTest;
+import org.georchestra.console.integration.IntegrationTestSupport;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@EnableWebMvc
+@ContextConfiguration(locations = { "classpath:/webmvc-config-test.xml" })
+@PropertySource("classpath:console-it.properties")
+@WebAppConfiguration
+public class DelegationControllerIT extends ConsoleIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    public @Rule @Autowired IntegrationTestSupport support;
+
+    @WithMockUser(roles = { "SUPERUSER" })
+    public @Test void testDelegationControllersUidWithDots() throws Exception {
+        String payload = "{\"uid\":\"flup.top@georchestra.com\",\"roles\":[\"GN_ADMIN\"],\"orgs\":[\"psc\"]}";
+
+        support.createUser("flup.top@georchestra.com");
+        support.perform(post("/private/delegation/flup.top@georchestra.com").content(payload))
+                .andExpect(status().isOk());
+
+        support.perform(get("/private/delegation/flup.top@georchestra.com")).andExpect(content().string(payload));
+    }
+
+}


### PR DESCRIPTION
When the user identifier contains a dot, spring will truncate the path variable, leading the code not being able to resolve the concerned user.

This is basically the same fix as 466244b1, but on the `DelegationController`.

Tests: added an IT, `mvn clean verify -Pit` OK locally