### PR TITLE
console - rename manager into referent

### DIFF
--- a/console/src/main/webapp/manager/app/assets/lang/de.json
+++ b/console/src/main/webapp/manager/app/assets/lang/de.json
@@ -48,7 +48,7 @@
   "user.postalAddress"    : "Adresse",
   "user.org"              : "Organisation",
   "user.description"      : "Beschreibung",
-  "user.manager"          : "Vorgesetzter",
+  "user.manager"          : "Referent",
   "user.expire"           : "Ablaufdatum",
   "user.reset"            : "Zurücksetzen",
   "user.password"         : "Passwort",

--- a/console/src/main/webapp/manager/app/assets/lang/en.json
+++ b/console/src/main/webapp/manager/app/assets/lang/en.json
@@ -48,7 +48,7 @@
   "user.postalAddress"    : "Address",
   "user.org"              : "Organization",
   "user.description"      : "Description",
-  "user.manager"          : "Manager",
+  "user.manager"          : "Referent",
   "user.expire"           : "Expire",
   "user.reset"            : "Reset",
   "user.password"         : "Local Password",

--- a/console/src/main/webapp/manager/app/assets/lang/es.json
+++ b/console/src/main/webapp/manager/app/assets/lang/es.json
@@ -48,7 +48,7 @@
   "user.postalAddress"    : "Dirección",
   "user.org"              : "Organización",
   "user.description"      : "Descripción",
-  "user.manager"          : "Responsable",
+  "user.manager"          : "Referente",
   "user.expire"           : "Fecha de expiración",
   "user.reset"            : "Volver a generar",
   "user.password"         : "Contraseña",

--- a/console/src/main/webapp/manager/app/assets/lang/fr.json
+++ b/console/src/main/webapp/manager/app/assets/lang/fr.json
@@ -48,7 +48,7 @@
   "user.postalAddress"    : "Adresse",
   "user.org"              : "Organisme",
   "user.description"      : "Description",
-  "user.manager"          : "Manager",
+  "user.manager"          : "Référent",
   "user.expire"           : "Date d'expiration",
   "user.reset"            : "Régénérer",
   "user.password"         : "Mot de passe local",

--- a/console/src/main/webapp/manager/app/assets/lang/nl.json
+++ b/console/src/main/webapp/manager/app/assets/lang/nl.json
@@ -48,7 +48,7 @@
   "user.postalAddress"    : "Adres",
   "user.org"              : "Organisatie",
   "user.description"      : "Beschrijving",
-  "user.manager"          : "Manager",
+  "user.manager"          : "Referent",
   "user.expire"           : "Vervaldatum",
   "user.reset"            : "Regenereren",
   "user.password"         : "Wachtwoord",


### PR DESCRIPTION
Discussed with INRAE / IRD / CIRAD : the sense of "referent" is wider than "manager", and less hierarchical.
Makes more sense to them.

WDYT ?