### PR TITLE
Alter workspace name created by datafeeder when schema is fixed

### DIFF
--- a/datafeeder/docker-compose.yml
+++ b/datafeeder/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
 
   database:
-    image: georchestra/database:latest
+    image: georchestra/database:23.0.x
     environment:
       - POSTGRES_USER=georchestra
       - POSTGRES_PASSWORD=georchestra
@@ -31,7 +31,7 @@ services:
         - SLAPD_LOG_LEVEL=32768 # See https://www.openldap.org/doc/admin24/slapdconfig.html#loglevel%20%3Clevel%3E
 
   console:
-    image: georchestra/console:latest
+    image: georchestra/console:23.0.x
     depends_on:
       - ldap
       - database
@@ -45,7 +45,7 @@ services:
       - "38080:8080"
 
   geoserver:
-    image: georchestra/geoserver:latest
+    image: georchestra/geoserver:23.0.x
     healthcheck:
       test: [ "CMD-SHELL", "curl -s -f http://localhost:8080/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities >/dev/null || exit 1" ]
       interval: 30s

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/autoconf/GeorchestraNameNormalizer.java
@@ -23,6 +23,7 @@ import java.text.Normalizer.Form;
 import java.util.regex.Pattern;
 
 import lombok.NonNull;
+import org.springframework.util.StringUtils;
 
 public class GeorchestraNameNormalizer {
 
@@ -59,8 +60,9 @@ public class GeorchestraNameNormalizer {
      * first data store with a given name even if it's not the one that belongs to
      * the requested workspace.
      */
-    public String resolveDataStoreName(String workspaceName) {
-        return String.format("datafeeder_%s", workspaceName);
+    public String resolveDataStoreName(String workspaceName, String storeNameConfig) {
+        return !StringUtils.isEmpty(storeNameConfig) && !storeNameConfig.equals("<storename>") ? storeNameConfig
+                : String.format("datafeeder_%s", workspaceName);
     }
 
     /**

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -61,6 +61,7 @@ import org.springframework.http.MediaType;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link OWSPublicationService} relying on {@link GeoServerRemoteService} to
@@ -102,8 +103,9 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         requireNonNull(publishing.getImportedName(),
                 "importedName is required to resolve the native feature type name");
 
-        final String workspaceName = resolveWorkspace(user);
-        final String dataStoreName = nameResolver.resolveDataStoreName(workspaceName);
+        final Map<String, String> geoserverConfig = this.configProperties.getPublishing().getBackend().getGeoserver();
+        final String workspaceName = resolveWorkspace(user, geoserverConfig.get("workspacename"));
+        final String dataStoreName = nameResolver.resolveDataStoreName(workspaceName, geoserverConfig.get("storename"));
         final String publishedLayerName = resolveUniqueLayerName(workspaceName, publishing.getPublishedName());
 
         Optional<DataStoreResponse> dataStore = geoserver.findDataStore(workspaceName, dataStoreName);
@@ -152,7 +154,8 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         requireNonNull(publishing);
 
         final String workspace = publishing.getPublishedWorkspace();
-        final String dataStore = nameResolver.resolveDataStoreName(workspace);
+        final String dataStore = nameResolver.resolveDataStoreName(workspace,
+                this.configProperties.getPublishing().getBackend().getGeoserver().get("storename"));
         final String layerName = publishing.getPublishedName();
         final String metadataRecordId = publishing.getMetadataRecordId();
 
@@ -294,9 +297,11 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
         return layerName;
     }
 
-    private String resolveWorkspace(@NonNull UserInfo user) {
+    private String resolveWorkspace(@NonNull UserInfo user, String workspaceNameConfig) {
         final @NonNull String orgName = user.getOrganization().getShortName();
-        final String workspaceName = nameResolver.resolveWorkspaceName(orgName);
+        final String workspaceName = !StringUtils.isEmpty(workspaceNameConfig)
+                && !workspaceNameConfig.equals("<workspacename>") ? workspaceNameConfig
+                        : nameResolver.resolveWorkspaceName(orgName);
         String baseNamespaceURI = this.configProperties.getPublishing().getGeoserver().getBaseNamespaceURI();
         String namespaceURI = URI.create(baseNamespaceURI + "/" + workspaceName).normalize().toString();
         WorkspaceInfo ws = geoserver.getOrCreateWorkspace(workspaceName, namespaceURI);

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraOwsPublicationServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraOwsPublicationServiceIT.java
@@ -116,7 +116,7 @@ public class GeorchestraOwsPublicationServiceIT {
     public @Before void setup() {
         user = authSupport.buildUser();
         expectedWorksapce = nameResolver.resolveWorkspaceName(user.getOrganization().getShortName());
-        expectedDataStore = nameResolver.resolveDataStoreName(expectedWorksapce);
+        expectedDataStore = nameResolver.resolveDataStoreName(expectedWorksapce, "<storename>");
         geoServerClient.setDebugRequests(true);
 
         deleteWorkspace(expectedWorksapce);

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -95,6 +95,8 @@ datafeeder.publishing.backend.geoserver.preparedStatements=true
 datafeeder.publishing.backend.geoserver.testFromDatafeederPropertiesFile=true
 #<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
 datafeeder.publishing.backend.geoserver.schema=<schema>
+datafeeder.publishing.backend.geoserver.workspacename=<workspacename>
+datafeeder.publishing.backend.geoserver.storename=<storename>
 #datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
 #if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
 datafeeder.publishing.backend.geoserver.host=database


### PR DESCRIPTION
# Datafeeder workspaces and stores names

Allow to edit workspace name and storeName for geoserver indenpendantly of schema with `datafeeder.properties`.

Implement two variables : 
```
datafeeder.publishing.backend.geoserver.workspacename=<workspacename>
datafeeder.publishing.backend.geoserver.storename=<storename>
```
![image](https://github.com/georchestra/georchestra/assets/39771412/ad03fe90-321d-4c30-8cc4-1ff780ce4b50)

## How to

Replace `<workspacename>` and `<storename>` with desired workspace name and store name.
