### PR TITLE
upgrade geoserver to 2.22.5

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,16 +8,16 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.22.2</gs.version>
-    <gt.version>28.2</gt.version>
+    <gs.version>2.22.5</gs.version>
+    <gt.version>28.5</gt.version>
     <geofence.version>3.5.1</geofence.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <marlin.version>0.9.3</marlin.version>
-    <jackson.version>2.13.2</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.2.22.RELEASE</spring.version>
+    <spring.version>5.2.24.RELEASE</spring.version>
     <spring-security.version>5.1.13.RELEASE</spring-security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -1034,6 +1034,11 @@
             <artifactId>gs-dds</artifactId>
             <version>${gs.version}</version>
           </dependency>
+          <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-wps-longitudinal-profile</artifactId>
+            <version>${gs.version}</version>
+          </dependency>
       </dependencies>
     </profile>
     <profile>


### PR DESCRIPTION
i know #4076 targets a more recent branch but:
- updating to the latest of 2.22 was doable for me, and we get the latest bugfixes from a stable branch:
  - https://geoserver.org/announcements/2023/05/05/geoserver-2-22-3-released.html
  - https://geoserver.org/announcements/2023/06/19/geoserver-2-22-4-released.html
  - https://geoserver.org/announcements/2023/08/30/geoserver-2-22-5-released.html
- and most interesting, allows to enable the `gs-wps-longitudinal-profile` extension in the mapstore profile (ec78737c) which allows to use the profile tool in mapstore 2023.02 (cf https://docs.mapstore.geosolutionsgroup.com/en/v2023.02.00/user-guide/longitudinal-profile/) - this extension was added to 2.24 and backported to 2.22.5.

the https://github.com/georchestra/geoserver/tree/2.22.5-georchestra branch was generated with the following sequence:
- make a new branch off `2.22.2-georchestra`
```
georchestra/geoserver/geoserver-submodule $git checkout 2.22.2-georchestra
georchestra/geoserver/geoserver-submodule $git checkout -b 2.22.5-georchestra
```
rebase of our branch on top of the 2.22.5 tag, only dropping https://github.com/georchestra/geoserver/commit/35519594a4
```
georchestra/geoserver/geoserver-submodule $git rebase -i 2.22.5
  1 drop 35519594a4 updating version numbers and release notes for 2.22.2                                                                                                                                                                                                         
  2 pick 2d3c2d8ae9 customizations applied on top of geoserver 2.22.2 for geOrchestra                                                                                                                                                                                             
  3 pick 7ab7f4a6a3 comment out CORS config for jetty, only one of tomcat or jetty should be enabled (georchestra/georchestra#3358)                                                                                                                                               
  4 pick 4f6946630e fixing lost customization in GeoServerBasePage class                                                                                                                                                                                                          
  5 pick 8d627dc150 header url - fixed missing active parameter                                                                                                                                                                                                                   
  6 pick 16d26f8e8e georchestra integration - reintegrating the header                                                                                                                                                                                                            
  7 pick 1b9c5efb50 fixing testsuite                                                                                                                                                                                                                                              
  8 pick ceab958ab7 web.xml - Request logging filter removed from the classpath upstream                                                                                                                                                                                          
  9 pick 9b98b81bfe GS - deactivating test                                                                                                                                                                                                                                        
 10 pick fa3cc42b14 feat: implement new header                                                                                                                                                                                                                                    
 11 pick 525d50c47d feat: rename georchestra iframe to webcomponent                                                                                                                                                                                                               
 12 pick 4afa74d846 feat: set favicon to root                                                                                                                                                                                                                                     
 13 pick 6b16605423 feat: implement themable header                                                                                                                                                                                                                               
 14 pick 450850776b fix: double href                                                                                                                                                                                                                                              
 15 pick 6d4f7f3cc3 [GEOS-11235] preauthentication filters - session reuse even after having logout      
Successfully rebased and updated refs/heads/2.22.5-georchestra.
```
bumping the version in the custom modules:
```
georchestra/geoserver/geoserver-submodule $sed -i -e 's/2.22.2-georchestra/2.22.5-georchestra/' src/gwc/pom.xml src/main/pom.xml src/restconfig/pom.xml src/web/core/pom.xml
georchestra/geoserver/geoserver-submodule $git commit -m 'bump version to 2.22.5-georchestra' src/{gwc,main,restconfig,web/core}/pom.xml
[2.22.5-georchestra 032c9302a2] bump version to 2.22.5-georchestra
 4 files changed, 4 insertions(+), 4 deletions(-)
```
and then, changing the versions in `geoserver/pom.xml` cf 816f4804

testing:
- built-tested via `make war-build-georchestra; make deb-build-georchestra`
- runtime-tested with the same operations backported on top of 23.0, i have an instance running in development here which shows `2.22.5-georchestra` in the version, and with a working WPS longitudinal profile process.

more testing much welcome.