### PR TITLE
point at the right geoserver branch for 2.22.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "geoserver/geoserver-submodule"]
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
-	branch = 2.22.2-georchestra
+	branch = 2.22.5-georchestra


### PR DESCRIPTION
was forgotten in #4171, which got reverted by dependabot in #4176