### PR TITLE
console - allow bigger organization thumbnails

### DIFF
--- a/console/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/console/src/main/webapp/WEB-INF/jetty-web.xml
@@ -5,4 +5,5 @@
   <Call name="addAliasCheck">
     <Arg><New class="org.eclipse.jetty.server.handler.AllowSymLinkAliasChecker"/></Arg>
   </Call>
+  <Set name="maxFormContentSize">5000000</Set>
 </Configure>

--- a/console/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/console/src/main/webapp/WEB-INF/jetty-web.xml
@@ -5,5 +5,5 @@
   <Call name="addAliasCheck">
     <Arg><New class="org.eclipse.jetty.server.handler.AllowSymLinkAliasChecker"/></Arg>
   </Call>
-  <Set name="maxFormContentSize">5000000</Set>
+  <Set name="maxFormContentSize">1048576</Set>
 </Configure>


### PR DESCRIPTION
this is to increase by the default (200000) value of maxFormContentSize in console