### PR TITLE
commons, console - add a isExternal flag & hide password update forms for users authenticated externally

### DIFF
--- a/commons/src/main/java/org/georchestra/commons/security/SecurityHeaders.java
+++ b/commons/src/main/java/org/georchestra/commons/security/SecurityHeaders.java
@@ -58,13 +58,17 @@ public class SecurityHeaders {
     public static final String SEC_LASTNAME = "sec-lastname";
     public static final String SEC_EMAIL = "sec-email";
     public static final String SEC_TEL = "sec-tel";
-
+    public static final String SEC_ADDRESS = "sec-address";
+    public static final String SEC_TITLE = "sec-title";
+    public static final String SEC_NOTES = "sec-notes";
     public static final String SEC_ORG = "sec-org";
     public static final String SEC_ORGID = "sec-orgid";
     public static final String SEC_ORGNAME = "sec-orgname";
     public static final String SEC_ORG_LASTUPDATED = "sec-org-lastupdated";
     public static final String IMP_ROLES = "imp-roles";
     public static final String IMP_USERNAME = "imp-username";
+    public static final String SEC_LDAP_REMAINING_DAYS = "sec-ldap-remaining-days";
+    public static final String SEC_EXTERNAL_AUTHENTICATION = "sec-external-authentication";
 
     /**
      * @return the decoded header value, if it contains multiple values separated by

--- a/commons/src/main/java/org/georchestra/security/model/GeorchestraUser.java
+++ b/commons/src/main/java/org/georchestra/security/model/GeorchestraUser.java
@@ -92,6 +92,9 @@ public class GeorchestraUser implements Serializable {
     /** Maps to Account.getOAuth2Uid */
     private String oAuth2Uid;
 
+    /** Provided by request header {@code sec-external-authentication} */
+    private Boolean isExternalAuth = false;
+
     public void setRoles(List<String> roles) {
         this.roles = roles == null ? new ArrayList<>() : roles;
     }

--- a/console/src/main/java/org/georchestra/console/ws/changepassword/ChangePasswordFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/changepassword/ChangePasswordFormController.java
@@ -19,6 +19,7 @@
 
 package org.georchestra.console.ws.changepassword;
 
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.model.AdminLogType;
 import org.georchestra.console.ws.utils.LogUtils;
 import org.georchestra.console.ws.utils.PasswordUtils;
@@ -39,7 +40,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.SessionAttributes;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
+
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EXTERNAL_AUTHENTICATION;
 
 /**
  * This controller is responsible of manage the user interactions required for
@@ -84,11 +89,13 @@ public class ChangePasswordFormController {
      * @throws DataServiceException
      */
     @RequestMapping(value = "/account/changePassword", method = RequestMethod.GET)
-    public String setupForm(Model model) throws DataServiceException {
+    public String setupForm(HttpServletRequest request, HttpServletResponse response, Model model)
+            throws DataServiceException {
         Optional<String> uid = getUsername();
         if (uid.isPresent()) {
-
-            if (isUserAuthenticatedBySASL(uid.get())) {
+            boolean isExternalAuth = Boolean
+                    .parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
+            if (isUserAuthenticatedBySASL(uid.get()) || isExternalAuth) {
                 return "userManagedBySASL";
             }
 

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormBean.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormBean.java
@@ -36,6 +36,7 @@ public class EditUserDetailsFormBean implements java.io.Serializable {
     private String description;
     private String postalAddress;
     private boolean isOAuth2;
+    private boolean isExternalAuth;
 
     @Override
     public String toString() {
@@ -131,4 +132,13 @@ public class EditUserDetailsFormBean implements java.io.Serializable {
     public void setIsOAuth2(boolean isOAuth2) {
         this.isOAuth2 = isOAuth2;
     }
+
+    public boolean getIsExternalAuth() {
+        return isExternalAuth;
+    }
+
+    public void setIsExternalAuth(boolean isExternalAuth) {
+        this.isExternalAuth = isExternalAuth;
+    }
+
 }

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -19,6 +19,7 @@
 
 package org.georchestra.console.ws.edituserdetails;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EXTERNAL_AUTHENTICATION;
 import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 
 import java.io.IOException;
@@ -113,7 +114,10 @@ public class EditUserDetailsFormController {
     public String setupForm(HttpServletRequest request, HttpServletResponse response, Model model) throws IOException {
         try {
             String username = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
+            boolean isExternalAuth = Boolean
+                    .parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
             Account userAccount = this.accountDao.findByUID(username);
+            userAccount.setIsExternalAuth(isExternalAuth);
             model.addAttribute(createForm(userAccount));
             Org org = orgsDao.findByUser(userAccount);
             model.addAttribute("org", orgToJson(org));
@@ -158,6 +162,7 @@ public class EditUserDetailsFormController {
         formBean.setFacsimile(account.getFacsimile());
         formBean.setDescription(account.getDescription());
         formBean.setPostalAddress(account.getPostalAddress());
+        formBean.setIsExternalAuth(account.getIsExternalAuth());
         String org = account.getOrg();
         if (!org.equals("")) {
             formBean.setOrg(orgsDao.findByCommonName(org).getName());

--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -147,7 +147,7 @@ var gdprAllowAccountDeletion = ${gdprAllowAccountDeletion};
       </t:textarea>
     </fieldset>
 
-    <c:if test="${!editUserDetailsFormBean.isOAuth2}">
+    <c:if test="${!editUserDetailsFormBean.isOAuth2 && !editUserDetailsFormBean.isExternalAuth}">
       <fieldset>
         <legend><s:message code="editUserDetailsForm.fieldset.credentials"/></legend>
         <div class="form-group">

--- a/console/src/test/java/org/georchestra/console/ws/changepassword/ChangePasswordControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/changepassword/ChangePasswordControllerTest.java
@@ -1,5 +1,6 @@
 package org.georchestra.console.ws.changepassword;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EXTERNAL_AUTHENTICATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -28,6 +29,8 @@ import org.mockito.Mockito;
 import org.springframework.ldap.core.ContextMapper;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -39,6 +42,8 @@ import org.springframework.web.bind.WebDataBinder;
 
 public class ChangePasswordControllerTest {
 
+    private MockHttpServletRequest request = new MockHttpServletRequest();
+    private MockHttpServletResponse response = new MockHttpServletResponse();
     private ChangePasswordFormController ctrlToTest;
     private LdapTemplate ldapTemplate;
     private Model model;
@@ -86,8 +91,19 @@ public class ChangePasswordControllerTest {
     @Test
     public void setupForm() throws Exception {
         userIsSpringSecurityAuthenticatedAndExistInLdap("me");
-        String ret = ctrlToTest.setupForm(model);
+        request.addHeader(SEC_EXTERNAL_AUTHENTICATION, "false");
+
+        String ret = ctrlToTest.setupForm(request, response, model);
         assertEquals("changePasswordForm", ret);
+    }
+
+    @Test
+    public void setupFormWithExternalAuth() throws Exception {
+        userIsSpringSecurityAuthenticatedAndExistInLdap("me");
+        request.addHeader(SEC_EXTERNAL_AUTHENTICATION, "true");
+
+        String ret = ctrlToTest.setupForm(request, response, model);
+        assertEquals("userManagedBySASL", ret);
     }
 
     @Test

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/UserMapper.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/UserMapper.java
@@ -55,6 +55,7 @@ public abstract class UserMapper {
     @Mapping(target = "lastUpdated", ignore = true)
     @Mapping(target = "ldapWarn", ignore = true)
     @Mapping(target = "ldapRemainingDays", ignore = true)
+    @Mapping(target = "isExternalAuth", ignore = true)
     protected abstract GeorchestraUser map(Account account);
 
     String map(UUID value) {

--- a/ldap-account-management/src/main/java/org/georchestra/ds/users/Account.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/users/Account.java
@@ -188,4 +188,8 @@ public interface Account extends Comparable<Account> {
     String getOAuth2Uid();
 
     void setOAuth2Uid(String oAuth2Uid);
+
+    boolean getIsExternalAuth();
+
+    void setIsExternalAuth(boolean isExternalAuth);
 }

--- a/ldap-account-management/src/main/java/org/georchestra/ds/users/AccountImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/users/AccountImpl.java
@@ -166,6 +166,7 @@ public class AccountImpl implements Serializable, Account {
     // Json export is defined on the getter getOrg()
     private String org;
     private boolean pending;
+    private boolean isExternalAuth;
 
     @Override
     public String toString() {
@@ -618,5 +619,15 @@ public class AccountImpl implements Serializable, Account {
     @Override
     public void setOAuth2Uid(String oAuth2Uid) {
         this.oAuth2Uid = oAuth2Uid;
+    }
+
+    @Override
+    public boolean getIsExternalAuth() {
+        return this.isExternalAuth;
+    }
+
+    @Override
+    public void setIsExternalAuth(boolean isExternalAuth) {
+        this.isExternalAuth = isExternalAuth;
     }
 }


### PR DESCRIPTION
In preauth mode, no need to manage user password, a code refactor is done to handle this case.