### PR TITLE
[CONSOLE] Symbolic links vendor error - saveSvgAsPng

### DIFF
--- a/console/src/main/webapp/manager/vendor/promise.min.js
+++ b/console/src/main/webapp/manager/vendor/promise.min.js
@@ -1,1 +1,0 @@
-./../node_modules/promise-polyfill/dist/promise.min.js

--- a/console/src/main/webapp/manager/vendor/saveSvgAsPng.js
+++ b/console/src/main/webapp/manager/vendor/saveSvgAsPng.js
@@ -1,1 +1,1 @@
-../node_modules/save-svg-as-png/saveSvgAsPng.js
+../node_modules/save-svg-as-png/lib/saveSvgAsPng.js


### PR DESCRIPTION
saveSvgAsPng method couldn't be found as symbolic link was invalid.

Fix button below graph on console's dashboard

No need for Promise anymore.