### PR TITLE
[CONSOLE] Allow activation of  competence areas in console

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/platform/InfosController.java
@@ -51,6 +51,11 @@ public class InfosController {
     @Setter
     private boolean extractorappEnabled;
 
+    @Value("${competenceAreaEnabled:false}")
+    @Getter
+    @Setter
+    private boolean competenceAreaEnabled;
+
     @Value("${useLegacyHeader:false}")
     private boolean useLegacyHeader;
 
@@ -78,6 +83,7 @@ public class InfosController {
         ret.put("saslServer", saslServer);
         ret.put("analyticsEnabled", analyticsEnabled);
         ret.put("extractorappEnabled", extractorappEnabled);
+        ret.put("competenceAreaEnabled", competenceAreaEnabled);
         ret.put("useLegacyHeader", useLegacyHeader);
         ret.put("headerUrl", headerUrl);
         ret.put("headerHeight", headerHeight);

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -61,6 +61,7 @@
         <entry key="headerScript" value="${headerScript}" />
         <entry key="logoUrl" value="${logoUrl}" />
         <entry key="georchestraStylesheet" value="${georchestraStylesheet:}" />
+        <entry key="competenceAreaEnabled" value="${competenceAreaEnabled:false}" />
         <entry key="readonlyUid" value="${readonlyUid:false}" />
         <entry key="publicContextPath" value="${publicContextPath:/console}"/>
       </map>

--- a/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
@@ -166,7 +166,9 @@
 
                     <div ng-app="manager" ng-strict-di ng-controller="StandaloneController">
                       <imageinput target="'#orgLogo'" class="form-group"></imageinput>
-                      <areas item="org"></areas>
+                        <c:if test="${competenceAreaEnabled}">
+                            <areas item="org"></areas>
+                        </c:if>
                     </div>
 
                 </div>

--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -239,9 +239,11 @@ var gdprAllowAccountDeletion = ${gdprAllowAccountDeletion};
         </li>
       </ul>
 
-      <h4><s:message code="editUserDetailsForm.areaOfCompetence"/></h4>
-      <areas item="org" readonly="'true'"></areas>
-      <br>
+      <c:if test="${competenceAreaEnabled}">
+        <h4><s:message code="editUserDetailsForm.areaOfCompetence"/></h4>
+        <areas item="org" readonly="'true'"></areas>
+        <br>
+      </c:if>
 
       <h4><s:message code="editUserDetailsForm.members"/> <span
           class="badge">{{ users.length }}</span></h4>

--- a/console/src/main/webapp/manager/app/components/org/org.es6
+++ b/console/src/main/webapp/manager/app/components/org/org.es6
@@ -12,7 +12,10 @@ class OrgController {
 
     this.q = ''
 
-    this.tabs = ['infos', 'area', 'users', 'manage']
+    $injector.get('PlatformInfos').get().$promise.then((platformInfos) => {
+      this.tabs = platformInfos.competenceAreaEnabled ? ['infos', 'area', 'users', 'manage'] : ['infos', 'users', 'manage']
+    })
+
     this.tab = $routeParams.tab
 
     this.itemsPerPage = 15

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -49,6 +49,7 @@
         <entry key="headerScript" value="${headerScript}" />
         <entry key="logoUrl" value="${logoUrl}" />
         <entry key="georchestraStylesheet" value="${georchestraStylesheet:}" />
+        <entry key="competenceAreaEnabled" value="${competenceAreaEnabled:false}" />
         <entry key="readonlyUid" value="${readonlyUid:false}" />
         <entry key="publicContextPath" value="${publicContextPath:/console}"/>
       </map>


### PR DESCRIPTION
This PR allows admins to enable/disable are of competences in console. 

Datadir's PR : 
- https://github.com/georchestra/datadir/pull/391

*User page*
![image](https://github.com/georchestra/georchestra/assets/39771412/35ef43b7-e6b2-4a4e-bf31-ea17fd0c8ad1)

*Organization page*
![image](https://github.com/georchestra/georchestra/assets/39771412/20955089-c09c-4897-93d2-9dad4ebb8bfb)


## HOW-TO
 
In `console.properties` enable it with : 
```
competenceAreaEnabled=true
```


