### PR TITLE
Fix expired role route and add tests

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/roles/RolesController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/roles/RolesController.java
@@ -187,6 +187,8 @@ public class RolesController {
         Role res;
         if (cn.equals(RolesController.VIRTUAL_TEMPORARY_ROLE_NAME))
             res = this.generateVirtualRoles().getLeft();
+        else if (cn.equals(RolesController.VIRTUAL_EXPIRED_ROLE_NAME))
+            res = this.generateVirtualRoles().getRight();
         else
             res = this.roleDao.findByCommonName(cn);
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/console/src/test/java/org/georchestra/console/ws/backoffice/roles/RolesControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/backoffice/roles/RolesControllerTest.java
@@ -142,6 +142,22 @@ public class RolesControllerTest {
     }
 
     @Test
+    public void testFindByCNTemp() throws Exception {
+        Role retTemp = RoleFactory.create("TEMPORARY", "Virtual role that contains all temporary users", false);
+        when(roleDao.findByCommonName(eq("TEMPORARY"))).thenReturn(retTemp);
+        Role res = roleCtrl.findByCN("TEMPORARY");
+        assertEquals(res, retTemp);
+    }
+
+    @Test
+    public void testFindByCNExpired() throws Exception {
+        Role retExpired = RoleFactory.create("EXPIRED", "Virtual role that contains all expired users", false);
+        when(roleDao.findByCommonName(eq("EXPIRED"))).thenReturn(retExpired);
+        Role res = roleCtrl.findByCN("EXPIRED");
+        assertEquals(res, retExpired);
+    }
+
+    @Test
     public void testCreateDuplicateRole() throws Exception {
         Role myRole = RoleFactory.create("MYROLE", "test role", false);
         when(roleDao.findByCommonName(eq("MYROLE"))).thenReturn(myRole);


### PR DESCRIPTION
This PR fixes the route `console/private/roles/EXPIRED` which hit a 404.

In console, it now displays the role correctly : 
![image](https://github.com/georchestra/georchestra/assets/39771412/90fc8d75-6041-4a8f-a009-ce22edef1e45)
