### PR TITLE
console - handle case when no `sec-external-authentication` http header is sent

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/changepassword/ChangePasswordFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/changepassword/ChangePasswordFormController.java
@@ -42,6 +42,7 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.georchestra.commons.security.SecurityHeaders.SEC_EXTERNAL_AUTHENTICATION;
@@ -93,8 +94,8 @@ public class ChangePasswordFormController {
             throws DataServiceException {
         Optional<String> uid = getUsername();
         if (uid.isPresent()) {
-            boolean isExternalAuth = Boolean
-                    .parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
+            boolean isExternalAuth = !Objects.isNull(request.getHeader(SEC_EXTERNAL_AUTHENTICATION))
+                    && Boolean.parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
             if (isUserAuthenticatedBySASL(uid.get()) || isExternalAuth) {
                 return "userManagedBySASL";
             }

--- a/console/src/main/java/org/georchestra/console/ws/changepassword/ChangePasswordFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/changepassword/ChangePasswordFormController.java
@@ -94,7 +94,7 @@ public class ChangePasswordFormController {
             throws DataServiceException {
         Optional<String> uid = getUsername();
         if (uid.isPresent()) {
-            boolean isExternalAuth = !Objects.isNull(request.getHeader(SEC_EXTERNAL_AUTHENTICATION))
+            boolean isExternalAuth = Objects.nonNull(request.getHeader(SEC_EXTERNAL_AUTHENTICATION))
                     && Boolean.parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
             if (isUserAuthenticatedBySASL(uid.get()) || isExternalAuth) {
                 return "userManagedBySASL";

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -115,7 +115,7 @@ public class EditUserDetailsFormController {
     public String setupForm(HttpServletRequest request, HttpServletResponse response, Model model) throws IOException {
         try {
             String username = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
-            boolean isExternalAuth = !Objects.isNull(request.getHeader(SEC_EXTERNAL_AUTHENTICATION))
+            boolean isExternalAuth = Objects.nonNull(request.getHeader(SEC_EXTERNAL_AUTHENTICATION))
                     && Boolean.parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
             Account userAccount = this.accountDao.findByUID(username);
             userAccount.setIsExternalAuth(isExternalAuth);

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -24,6 +24,7 @@ import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -114,8 +115,8 @@ public class EditUserDetailsFormController {
     public String setupForm(HttpServletRequest request, HttpServletResponse response, Model model) throws IOException {
         try {
             String username = SecurityHeaders.decode(request.getHeader(SEC_USERNAME));
-            boolean isExternalAuth = Boolean
-                    .parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
+            boolean isExternalAuth = !Objects.isNull(request.getHeader(SEC_EXTERNAL_AUTHENTICATION))
+                    && Boolean.parseBoolean(SecurityHeaders.decode(request.getHeader(SEC_EXTERNAL_AUTHENTICATION)));
             Account userAccount = this.accountDao.findByUID(username);
             userAccount.setIsExternalAuth(isExternalAuth);
             model.addAttribute(createForm(userAccount));


### PR DESCRIPTION
Following PR remark on the georchestra-gateway here:
https://github.com/georchestra/georchestra-gateway/pull/101#discussion_r1517732378

There is a possibility that the header is not sent to the proxified webapps when this is not relevant, hence the modifications introduced by PR: https://github.com/georchestra/georchestra/pull/4183 could lead to an NPE.


Adding an extra check to avoid it.
