### PR TITLE
Update to geoserver 2.25.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "geoserver/geoserver-submodule"]
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
-	branch = 2.24.2-georchestra-24.0.x
+	branch = 2.25.x-georchestra

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,8 +8,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.25.0</gs.version>
-    <gt.version>31.0</gt.version>
+    <gs.version>2.25.1</gs.version>
+    <gt.version>31.1</gt.version>
     <geofence.version>3.5.1</geofence.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <marlin.version>0.9.3</marlin.version>
@@ -17,7 +17,7 @@
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.3.32</spring.version>
+    <spring.version>5.3.34</spring.version>
     <spring.security.version>5.7.12</spring.security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,17 +8,17 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.24.2</gs.version>
-    <gt.version>30.2</gt.version>
+    <gs.version>2.25.0</gs.version>
+    <gt.version>31.0</gt.version>
     <geofence.version>3.5.1</geofence.version>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.52.v20230823</jetty.version>
     <marlin.version>0.9.3</marlin.version>
     <jackson2.version>2.15.2</jackson2.version>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.3.27</spring.version>
-    <spring-security.version>5.7.10</spring-security.version>
+    <spring.version>5.3.32</spring.version>
+    <spring.security.version>5.7.12</spring.security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--
     <commons-beanutils.version>1.8.0</commons-beanutils.version>


### PR DESCRIPTION
once all extensions are locally built, this builds, packages & starts fine.

at runtime trying to go to the openlayers preview of a layer barfs on the SLD parsing:
```
Caused by: org.xml.sax.SAXException: Entity resolution disallowed for null
        at org.geoserver.util.AllowListEntityResolver.resolveEntity(AllowListEntityResolver.java:176)
        at org.geoserver.util.AllowListEntityResolver.getExternalSubset(AllowListEntityResolver.java:119)
        at org.apache.xerces.util.EntityResolver2Wrapper.getExternalSubset(Unknown Source)
        at org.apache.xerces.impl.XMLDocumentScannerImpl$ContentDispatcher.resolveExternalSubsetAndRead(Unknown Source)
        at org.apache.xerces.impl.XMLNSDocumentScannerImpl$NSContentDispatcher.scanRootElementHook(Unknown Source)
        at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl$FragmentContentDispatcher.dispatch(Unknown Source)
        at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
        at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
        at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
        at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
        at org.apache.xerces.parsers.DOMParser.parse(Unknown Source)
        at org.apache.xerces.jaxp.DocumentBuilderImpl.parse(Unknown Source)
        at org.geotools.xml.styling.SLDParser.parseSLD(SLDParser.java:469)
```
i suppose that's related to the new entity resolving checks, but even if globally disabling the url checker it fails. Will have to check if existing SLDs have to be tweaked/modified..

discussed with @f-necas and we think once #4205 is merged to `master`, and georchestra 24.0 branch is created we should aim to update to gs 2.25 in `master`