### PR TITLE
[Console] Allow ordering of orgTypes in console/account/new

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -413,9 +413,13 @@ public final class NewAccountFormController {
         model.addAttribute("orgTypes", getOrgTypes());
     }
 
+    /**
+     * Create a linked Map of organization types, same order as it is in the String
+     * array orgDao.getOrgTypeValues()
+     */
     private Map<String, String> getOrgTypes() {
         return Arrays.stream(orgDao.getOrgTypeValues())
-                .collect(Collectors.toMap(Function.identity(), Function.identity()));
+                .collect(Collectors.toMap(Function.identity(), Function.identity(), (x, y) -> x, LinkedHashMap::new));
     }
 
     /**


### PR DESCRIPTION
Now match the order defined in the `console.properties` file. 
