### PR TITLE
add sasl2-bin debian package in georchestra-ldap image

### DIFF
--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -16,7 +16,7 @@ ENV SLAPD_PASSWORD_MGT_POLICY ${PM_POLICY}
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        slapd=${OPENLDAP_VERSION}* ldap-utils procps && \
+        slapd=${OPENLDAP_VERSION}* ldap-utils procps sasl2-bin && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR adds the debian package `sasl2-bin` to the georchestra-ldap docker image