### PR TITLE
ldap-account-mgmt - fix test fixtures

### DIFF
--- a/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
+++ b/ldap-account-management/src/test/java/org/georchestra/ds/security/InternalSecurityApiImplIT.java
@@ -75,7 +75,7 @@ public class InternalSecurityApiImplIT {
         List<Role> defaultRoles = loadJson("/defaultRoles.json", Role.class);
         assertEquals(6, defaultUsers.size());
         assertEquals(2, defaultOrganizations.size());
-        assertEquals(10, defaultRoles.size());
+        assertEquals(11, defaultRoles.size());
 
         expectedUsers = toMap(defaultUsers, GeorchestraUser::getId);
         expectedOrganizations = toMap(defaultOrganizations, Organization::getId);

--- a/ldap-account-management/src/test/resources/defaultRoles.json
+++ b/ldap-account-management/src/test/resources/defaultRoles.json
@@ -56,6 +56,17 @@
 		]
 	},
 	{
+		"id": "2a6fb334-5b93-4b4b-9f48-f39b6a04376c",
+		"name": "IMPORT",
+		"description": "This role allows users to publish data with the importer application.",
+		"lastUpdated": "71fc44b07ffd0f98806894ac6d38e780e81c4c4c2831e896d63f8ac04d03f0a4",
+		"members": [
+			"testadmin",
+			"testuser",
+			"idatafeeder"
+		]
+	},
+	{
 		"id": "67148edb-ac2a-4959-a42c-8361fcb057bd",
 		"name": "ORGADMIN",
 		"description": "This role is automatically granted to all users holding an admin delegation",

--- a/ldap-account-management/src/test/resources/defaultUsers.json
+++ b/ldap-account-management/src/test/resources/defaultUsers.json
@@ -2,11 +2,12 @@
 	{
 		"username": "testuser",
 		"roles": [
-			"USER"
+			"USER",
+			"IMPORT"
 		],
 		"organization": "PSC",
 		"id": "048b2f38-6ee7-4eec-9bed-349cc6eb13c3",
-		"lastUpdated": "f30686969d96a5a7962aec9521a97f3493e042b79302f24c15771d90b8b99c56",
+		"lastUpdated": "cda8f14b4203ceadbc246193005aebbb87959349cbbfe9ee3d409118669816e5",
 		"firstName": "Test",
 		"lastName": "USER",
 		"email": "psc+testuser@georchestra.org",
@@ -57,11 +58,12 @@
 			"GN_ADMIN",
 			"USER",
 			"MAPSTORE_ADMIN",
-			"EMAILPROXY"
+			"EMAILPROXY",
+			"IMPORT"
 		],
 		"organization": "PSC",
 		"id": "0c6bb556-4ee8-46f2-892d-6116e262b489",
-		"lastUpdated": "035cabcdc6fdd76c5d8670dbc534e6123a5d04f2a7a80dd5cad138c6eb40a895",
+		"lastUpdated": "9942b5348c83d8607de857f7d75ef7dfcbff699d7929d38674eb90a0bfc10ce7",
 		"firstName": "Test",
 		"lastName": "ADMIN",
 		"email": "psc+testadmin@georchestra.org",
@@ -73,11 +75,12 @@
 	{
 		"username": "idatafeeder",
 		"roles": [
-			"GN_ADMIN"
+			"GN_ADMIN",
+			"IMPORT"
 		],
 		"organization": null,
 		"id": "ab18b654-b281-4b6d-b09c-a2a4a690216d",
-		"lastUpdated": "dac700ed4f2eb2185a4bc875ebdabdcdb422ffad20e29fdccabfde4589864d2e",
+		"lastUpdated": "c560896a13a6d9ce7b8d46eb0a7c0460e6679aefdd220442f90d68a41ce9557f",
 		"firstName": "Datafeeder",
 		"lastName": "Import",
 		"email": "psc+idatafeeder@georchestra.org",


### PR DESCRIPTION
See #4222 for the context. This commit does not fix the issue, but at least fixes the integration tests for said module, following the insertion of the `IMPORT` role some weeks ago.

Tests:
mvn clean verify into the module