### PR TITLE
Disabled password recovery for OAuth2 accounts

### DIFF
--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -159,19 +159,18 @@ public class EmailFactory {
         email.send(reallySend);
     }
 
-    public void sendChangePasswordOAuth2Email(ServletContext servletContext, String recipient, String userName,
-            String providerId) throws MessagingException {
-        sendChangePasswordOAuth2Email(servletContext, recipient, userName, providerId, true);
+    public void sendChangePasswordOAuth2Email(ServletContext servletContext, String recipient, String userName)
+            throws MessagingException {
+        sendChangePasswordOAuth2Email(servletContext, recipient, userName, true);
     }
 
     public void sendChangePasswordOAuth2Email(ServletContext servletContext, String recipient, String userName,
-            String providerId, boolean reallySend) throws MessagingException {
+            boolean reallySend) throws MessagingException {
         Email email = new Email(singletonList(recipient), this.changePasswordOAuth2EmailSubject, this.smtpHost,
                 this.smtpPort, this.emailHtml, this.replyTo, this.from, this.bodyEncoding, this.subjectEncoding,
                 this.templateEncoding, this.changePasswordOAuth2EmailFile, servletContext, this.georConfig,
                 this.publicUrl, this.instanceName);
         email.set("name", userName);
-        email.set("provider", providerId);
         email.send(reallySend);
     }
 

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -60,6 +60,9 @@ public class EmailFactory {
     private String changePasswordEmailFile;
     private String changePasswordEmailSubject;
 
+    private String changePasswordOAuth2EmailFile;
+    private String changePasswordOAuth2EmailSubject;
+
     private String changeEmailAddressEmailFile;
     private String changeEmailAddressEmailSubject;
 
@@ -153,6 +156,22 @@ public class EmailFactory {
         email.set("name", userName);
         email.set("uid", uid);
         email.set("url", url);
+        email.send(reallySend);
+    }
+
+    public void sendChangePasswordOAuth2Email(ServletContext servletContext, String recipient, String userName,
+            String providerId) throws MessagingException {
+        sendChangePasswordOAuth2Email(servletContext, recipient, userName, providerId, true);
+    }
+
+    public void sendChangePasswordOAuth2Email(ServletContext servletContext, String recipient, String userName,
+            String providerId, boolean reallySend) throws MessagingException {
+        Email email = new Email(singletonList(recipient), this.changePasswordOAuth2EmailSubject, this.smtpHost,
+                this.smtpPort, this.emailHtml, this.replyTo, this.from, this.bodyEncoding, this.subjectEncoding,
+                this.templateEncoding, this.changePasswordOAuth2EmailFile, servletContext, this.georConfig,
+                this.publicUrl, this.instanceName);
+        email.set("name", userName);
+        email.set("provider", providerId);
         email.send(reallySend);
     }
 
@@ -311,6 +330,14 @@ public class EmailFactory {
 
     public void setChangePasswordEmailSubject(String changePasswordEmailSubject) {
         this.changePasswordEmailSubject = changePasswordEmailSubject;
+    }
+
+    public void setChangePasswordOAuth2EmailSubject(String changePasswordOAuth2EmailSubject) {
+        this.changePasswordOAuth2EmailSubject = changePasswordOAuth2EmailSubject;
+    }
+
+    public void setChangePasswordOAuth2EmailFile(String changePasswordOAuth2EmailFile) {
+        this.changePasswordOAuth2EmailFile = changePasswordOAuth2EmailFile;
     }
 
     public void setChangeEmailAddressEmailFile(String changePasswordEmailFile) {

--- a/console/src/main/java/org/georchestra/console/ws/passwordrecovery/PasswordRecoveryFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/passwordrecovery/PasswordRecoveryFormController.java
@@ -177,7 +177,7 @@ public class PasswordRecoveryFormController {
             }
 
             ServletContext servletContext = request.getSession().getServletContext();
-            if (account.getOAuth2Provider() == null) {
+            if ((account.getOAuth2Provider() == null) && !account.getIsExternalAuth()) {
                 String token = UUID.randomUUID().toString();
 
                 // if there is a previous token it is removed
@@ -197,7 +197,7 @@ public class PasswordRecoveryFormController {
                 logUtils.createLog(account.getUid(), AdminLogType.EMAIL_RECOVERY_SENT, "");
             } else {
                 this.emailFactory.sendChangePasswordOAuth2Email(servletContext, account.getEmail(),
-                        account.getCommonName(), account.getOAuth2Provider());
+                        account.getCommonName());
             }
         } catch (DataServiceException | MessagingException e) {
             throw new IOException(e);

--- a/console/src/main/java/org/georchestra/console/ws/passwordrecovery/PasswordRecoveryFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/passwordrecovery/PasswordRecoveryFormController.java
@@ -176,32 +176,35 @@ public class PasswordRecoveryFormController {
                 throw new NameNotFoundException("User is pending");
             }
 
-            String token = UUID.randomUUID().toString();
-
-            // if there is a previous token it is removed
-            if (this.userTokenDao.exist(account.getUid())) {
-                this.userTokenDao.delete(account.getUid());
-            }
-
-            this.userTokenDao.insertToken(account.getUid(), token);
-
-            String url = makeChangePasswordURL(publicUrl, publicContextPath, token);
-
             ServletContext servletContext = request.getSession().getServletContext();
-            this.emailFactory.sendChangePasswordEmail(servletContext, account.getEmail(), account.getCommonName(),
-                    account.getUid(), url);
-            sessionStatus.setComplete();
+            if (account.getOAuth2Provider() == null) {
+                String token = UUID.randomUUID().toString();
 
-            // log role deleted
-            logUtils.createLog(account.getUid(), AdminLogType.EMAIL_RECOVERY_SENT, "");
+                // if there is a previous token it is removed
+                if (this.userTokenDao.exist(account.getUid())) {
+                    this.userTokenDao.delete(account.getUid());
+                }
 
-            return "emailWasSentForPasswordChange";
+                this.userTokenDao.insertToken(account.getUid(), token);
 
+                String url = makeChangePasswordURL(publicUrl, publicContextPath, token);
+
+                this.emailFactory.sendChangePasswordEmail(servletContext, account.getEmail(), account.getCommonName(),
+                        account.getUid(), url);
+                sessionStatus.setComplete();
+
+                // log role deleted
+                logUtils.createLog(account.getUid(), AdminLogType.EMAIL_RECOVERY_SENT, "");
+            } else {
+                this.emailFactory.sendChangePasswordOAuth2Email(servletContext, account.getEmail(),
+                        account.getCommonName(), account.getOAuth2Provider());
+            }
         } catch (DataServiceException | MessagingException e) {
             throw new IOException(e);
         } catch (NameNotFoundException e) {
-            return "emailWasSentForPasswordChange";
         }
+
+        return "emailWasSentForPasswordChange";
     }
 
     /**

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -272,6 +272,8 @@
     <property name="newAccountRequiresModerationEmailSubject" value="${subject.requires.moderation:[${instanceName}] New account waiting for validation}"/>
     <property name="changePasswordEmailFile" value="changepassword-email-template.txt"/>
     <property name="changePasswordEmailSubject" value="${subject.change.password:[${instanceName}] Update your password}"/>
+    <property name="changePasswordOAuth2EmailFile" value="changepasswordoauth2-email-template.txt"/>
+    <property name="changePasswordOAuth2EmailSubject" value="${subject.change.password-oauth2:[${instanceName}] Update your password}"/>
     <property name="changeEmailAddressEmailFile" value="changeemail-email-template.txt"/>
     <property name="changeEmailAddressEmailSubject" value="${subject.change.email:[${instanceName}] Update your e-mail address}"/>
     <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />

--- a/console/src/main/webapp/WEB-INF/templates/changepasswordoauth2-email-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/changepasswordoauth2-email-template.txt
@@ -1,0 +1,11 @@
+Dear {name},
+
+You (or someone else) asked to reset your password on {publicUrl}/.
+However, you are usually logging in using an external provider ({provider}).
+Therefore, you need to log in using this provider, or use recovery features from this provider if you no longer have access to your account.
+If you did not request any password update, just ignore this e-mail, you're safe.
+
+Caution: this e-mail is personal, don't forward it.
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/main/webapp/WEB-INF/templates/changepasswordoauth2-email-template.txt
+++ b/console/src/main/webapp/WEB-INF/templates/changepasswordoauth2-email-template.txt
@@ -1,8 +1,9 @@
 Dear {name},
 
 You (or someone else) asked to reset your password on {publicUrl}/.
-However, you are usually logging in using an external provider ({provider}).
-Therefore, you need to log in using this provider, or use recovery features from this provider if you no longer have access to your account.
+
+If you are usually logging in using an external provider you need to log in using this provider, or use recovery features from this provider if you no longer have access to your account.
+
 If you did not request any password update, just ignore this e-mail, you're safe.
 
 Caution: this e-mail is personal, don't forward it.

--- a/console/src/test/java/org/georchestra/console/ws/passwordrecovery/PasswordRecoveryFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/passwordrecovery/PasswordRecoveryFormControllerTest.java
@@ -199,8 +199,7 @@ public class PasswordRecoveryFormControllerTest {
         Mockito.when(result.hasErrors()).thenReturn(false);
         String ret = ctrl.generateToken(request, formBean, result, status);
 
-        Mockito.verify(efi).sendChangePasswordOAuth2Email(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.eq("provider"));
+        Mockito.verify(efi).sendChangePasswordOAuth2Email(Mockito.any(), Mockito.any(), Mockito.any());
         assertEquals("emailWasSentForPasswordChange", ret);
     }
 

--- a/console/src/test/resources/mail-factory-test.xml
+++ b/console/src/test/resources/mail-factory-test.xml
@@ -21,6 +21,8 @@
     <property name="newAccountRequiresModerationEmailSubject" value="[georTest]] New account waiting for validation"/>
     <property name="changePasswordEmailFile" value="changepassword-email-template.txt"/>
     <property name="changePasswordEmailSubject" value="[georTest] Update your password}"/>
+    <property name="changePasswordOAuth2EmailFile" value="changepasswordoauth2-email-template.txt"/>
+    <property name="changePasswordOAuth2EmailSubject" value="[georTest] Update your password}"/>
     <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="[georTest] New login for your account" />
     <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>

--- a/console/src/test/resources/templates/changepasswordoauth2-email-template.txt
+++ b/console/src/test/resources/templates/changepasswordoauth2-email-template.txt
@@ -1,0 +1,11 @@
+Dear {name},
+
+You (or someone else) asked to reset your password on {publicUrl}/.
+However, you are usually logging in using an external provider ({provider}).
+Therefore, you need to log in using this provider, or use recovery features from this provider if you no longer have access to your account.
+If you did not request any password update, just ignore this e-mail, you're safe.
+
+Caution: this e-mail is personal, don't forward it.
+
+---
+Sent by {instanceName} ({publicUrl}/)

--- a/console/src/test/resources/templates/changepasswordoauth2-email-template.txt
+++ b/console/src/test/resources/templates/changepasswordoauth2-email-template.txt
@@ -1,8 +1,9 @@
 Dear {name},
 
 You (or someone else) asked to reset your password on {publicUrl}/.
-However, you are usually logging in using an external provider ({provider}).
-Therefore, you need to log in using this provider, or use recovery features from this provider if you no longer have access to your account.
+
+If you are usually logging in using an external provider you need to log in using this provider, or use recovery features from this provider if you no longer have access to your account.
+
 If you did not request any password update, just ignore this e-mail, you're safe.
 
 Caution: this e-mail is personal, don't forward it.

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -261,6 +261,8 @@
     <property name="newAccountRequiresModerationEmailSubject" value="${subject.requires.moderation:[${instanceName}] New account waiting for validation}"/>
     <property name="changePasswordEmailFile" value="changepassword-email-template.txt"/>
     <property name="changePasswordEmailSubject" value="${subject.change.password:[${instanceName}] Update your password}"/>
+    <property name="changePasswordOAuth2EmailFile" value="changepasswordoauth2-email-template.txt"/>
+    <property name="changePasswordOAuth2EmailSubject" value="${subject.change.password-oauth2:[${instanceName}] Update your password}"/>
     <property name="accountUidRenamedEmailFile" value="account-uid-renamed.txt" />
     <property name="accountUidRenamedEmailSubject" value="${subject.account.uid.renamed:[${instanceName}] New login for your account}" />
     <property name="newAccountNotificationEmailFile" value="newaccount-notification-template.txt"/>


### PR DESCRIPTION
OAuth2 and externally authenticated users are not allowed to change their password, so they should also not be allowed to recover their password.