### PR TITLE
console - make sure properties file from the datadir are sourced when configuring rabbitMq

### DIFF
--- a/console/src/main/java/org/georchestra/console/autoconfiguration/IsRabbitMqEnabled.java
+++ b/console/src/main/java/org/georchestra/console/autoconfiguration/IsRabbitMqEnabled.java
@@ -2,12 +2,18 @@ package org.georchestra.console.autoconfiguration;
 
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-public class IsRabbitMqEnabled implements Condition {
+public class IsRabbitMqEnabled implements ConfigurationCondition {
 
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         return Boolean.parseBoolean(context.getEnvironment().getProperty("enableRabbitmqEvents"));
+    }
+
+    @Override
+    public ConfigurationPhase getConfigurationPhase() {
+        return ConfigurationPhase.REGISTER_BEAN;
     }
 }

--- a/console/src/main/java/org/georchestra/console/autoconfiguration/IsRabbitMqEnabled.java
+++ b/console/src/main/java/org/georchestra/console/autoconfiguration/IsRabbitMqEnabled.java
@@ -1,6 +1,5 @@
 package org.georchestra.console.autoconfiguration;
 
-import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.core.type.AnnotatedTypeMetadata;

--- a/console/src/main/java/org/georchestra/console/autoconfiguration/RabbitAutoConfiguration.java
+++ b/console/src/main/java/org/georchestra/console/autoconfiguration/RabbitAutoConfiguration.java
@@ -7,5 +7,6 @@ import org.springframework.context.annotation.*;
         "file:${georchestra.datadir}/console/console.properties}" }, ignoreResourceNotFound = true)
 @Conditional(IsRabbitMqEnabled.class)
 @ImportResource({ "classpath:/spring/rabbit-listener-context.xml", "classpath:/spring/rabbit-sender-context.xml" })
+
 public class RabbitAutoConfiguration {
 }

--- a/console/src/main/java/org/georchestra/console/autoconfiguration/RabbitAutoConfiguration.java
+++ b/console/src/main/java/org/georchestra/console/autoconfiguration/RabbitAutoConfiguration.java
@@ -3,6 +3,8 @@ package org.georchestra.console.autoconfiguration;
 import org.springframework.context.annotation.*;
 
 @Configuration
+@PropertySource(value = { "file:${georchestra.datadir}/default.properties",
+        "file:${georchestra.datadir}/console/console.properties}" }, ignoreResourceNotFound = true)
 @Conditional(IsRabbitMqEnabled.class)
 @ImportResource({ "classpath:/spring/rabbit-listener-context.xml", "classpath:/spring/rabbit-sender-context.xml" })
 public class RabbitAutoConfiguration {

--- a/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
+++ b/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
@@ -1,5 +1,6 @@
 package org.georchestra.console.events;
 
+import lombok.Setter;
 import org.georchestra.console.mailservice.EmailFactory;
 import org.georchestra.console.ws.utils.LogUtils;
 import org.georchestra.ds.DataServiceException;
@@ -9,6 +10,7 @@ import org.json.JSONObject;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.georchestra.console.model.AdminLogType;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.mail.MessagingException;
 import java.util.Collections;
@@ -19,55 +21,15 @@ import java.util.stream.Collectors;
 
 public class RabbitmqEventsListener implements MessageListener {
 
-    private LogUtils logUtils;
+    private @Autowired @Setter LogUtils logUtils;
 
-    private RoleDao roleDao;
+    private @Autowired @Setter RoleDao roleDao;
 
-    private AccountDao accountDao;
+    private @Autowired @Setter AccountDao accountDao;
 
-    private EmailFactory emailFactory;
+    private @Autowired @Setter EmailFactory emailFactory;
 
-    private RabbitmqEventsSender rabbitmqEventsSender;
-
-    public void setLogUtils(LogUtils logUtils) {
-        this.logUtils = logUtils;
-    }
-
-    public LogUtils getLogUtils() {
-        return this.logUtils;
-    }
-
-    public void setRoleDao(RoleDao roleDao) {
-        this.roleDao = roleDao;
-    }
-
-    public RoleDao getRoleDao() {
-        return this.roleDao;
-    }
-
-    public void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
-    }
-
-    public AccountDao getAccountDao() {
-        return this.accountDao;
-    }
-
-    public void setEmailFactory(EmailFactory emailFactory) {
-        this.emailFactory = emailFactory;
-    }
-
-    public EmailFactory getEmailFactory() {
-        return this.emailFactory;
-    }
-
-    public void setRabbitmqEventsSender(RabbitmqEventsSender rabbitmqEventsSender) {
-        this.rabbitmqEventsSender = rabbitmqEventsSender;
-    }
-
-    public RabbitmqEventsSender getRabbitmqEventsSender() {
-        return this.rabbitmqEventsSender;
-    }
+    private @Autowired @Setter RabbitmqEventsSender rabbitmqEventsSender;
 
     private static Set<String> synReceivedMessageUid = Collections.synchronizedSet(new HashSet<String>());
 

--- a/console/src/main/resources/spring/rabbit-listener-context.xml
+++ b/console/src/main/resources/spring/rabbit-listener-context.xml
@@ -6,7 +6,8 @@
             http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="file:${georchestra.datadir}/default.properties,
-     file:${georchestra.datadir}/console/console.properties, file:${georchestra.datadir}/console/protectedroles.properties" ignore-resource-not-found="true" ignore-unresolvable="true" />
+     file:${georchestra.datadir}/console/console.properties,
+     file:${georchestra.datadir}/console/protectedroles.properties" ignore-resource-not-found="true" ignore-unresolvable="true" />
 
     <rabbit:connection-factory id="connectionFactory" host="${rabbitmqHost}" port="${rabbitmqPort}" username="${rabbitmqUser}" password="${rabbitmqPassword}" />
     <rabbit:admin connection-factory="connectionFactory" />
@@ -19,14 +20,10 @@
         </rabbit:bindings>
     </rabbit:topic-exchange>
     <!-- instantiate eventsListener -->
-    <bean id="eventsListener" class="org.georchestra.console.events.RabbitmqEventsListener" depends-on="logUtils">
-        <property name="logUtils" ref="logUtils"/>
-        <property name="roleDao" ref="roleDao"/>
-        <property name="accountDao" ref="accountDao"/>
-        <property name="emailFactory" ref="emailFactory"/>
-        <property name="rabbitmqEventsSender" ref="rabbitmqEventsSender"/>
-    </bean>
+    <bean id="eventsListener" class="org.georchestra.console.events.RabbitmqEventsListener" />
+
     <!-- glue the listener and OAuth2Queue to the container-->
     <rabbit:listener-container id="EventListenerContainer" connection-factory="connectionFactory">
-        <rabbit:listener ref="eventsListener" queues="OAuth2Queue" /></rabbit:listener-container>
+        <rabbit:listener ref="eventsListener" queues="OAuth2Queue" />
+    </rabbit:listener-container>
 </beans>

--- a/console/src/main/webapp/WEB-INF/console-servlet.xml
+++ b/console/src/main/webapp/WEB-INF/console-servlet.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- see the other xml files defined in the web.xml's contextConfigLocation variable -->
+</beans>

--- a/console/src/main/webapp/WEB-INF/web.xml
+++ b/console/src/main/webapp/WEB-INF/web.xml
@@ -6,8 +6,9 @@
     <context-param>
         <param-name>contextConfigLocation</param-name>
         <param-value>
-        classpath*:META-INF/spring/applicationContext*.xml
-        WEB-INF/spring/applicationContext*.xml
+            classpath*:META-INF/spring/applicationContext*.xml
+            WEB-INF/spring/applicationContext*.xml
+            WEB-INF/spring/webmvc-config.xml
         </param-value>
     </context-param>
     <context-param>
@@ -25,10 +26,6 @@
     <servlet>
         <servlet-name>console</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
-        <init-param>
-            <param-name>contextConfigLocation</param-name>
-            <param-value>WEB-INF/spring/webmvc-config.xml</param-value>
-        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
     <!-- url mapping -->

--- a/console/src/test/java/org/georchestra/console/integration/autoconfiguration/RabbitMqAutoconfigurationIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/autoconfiguration/RabbitMqAutoconfigurationIT.java
@@ -30,6 +30,8 @@ public class RabbitMqAutoconfigurationIT extends ConsoleIntegrationTest {
         assertNotNull("expected the RabbitMq eventsSender bean",
                 context.getBean(org.georchestra.console.events.RabbitmqEventsSender.class));
 
+        assertNotNull("expected the LogUtils bean", context.getBean(org.georchestra.console.ws.utils.LogUtils.class));
+
         CachingConnectionFactory rabbitFactory = (CachingConnectionFactory) context.getBean("connectionFactory");
         assertEquals(rabbitFactory.getHost(), "my-rabbit");
         assertEquals(rabbitFactory.getPort(), 1234);


### PR DESCRIPTION
This is following PR #4229, which was not completely loading the full context when checking if rabbitMQ was enabled, the intended behaviour was true only if rabbitmq related properties were also defined as environment variables (or Java properties), and did not take into account properties file from the datadir.

Tests: mainly runtime, as it is transparent from the integration test (we define the expected properties via a TestPropertySource annotation).