### PR TITLE
Add a consent checkbox for a new account

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/newaccount/AccountFormBean.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/AccountFormBean.java
@@ -34,191 +34,69 @@ public class AccountFormBean implements Serializable {
 
     private static final long serialVersionUID = 6955470190631684934L;
 
+    @Getter
+    @Setter
     private String uid;
+    @Getter
+    @Setter
     private String firstName;
+    @Getter
+    @Setter
     private String surname;
 
+    @Getter
+    @Setter
     private String org;
+    @Getter
+    @Setter
     private String title;
+    @Getter
+    @Setter
     private String email;
+    @Getter
+    @Setter
     private String phone;
+    @Getter
+    @Setter
     private String description;
+    @Getter
+    @Setter
     private String password;
+    @Getter
+    @Setter
     private String confirmPassword;
+    @Setter
     private boolean privacyPolicyAgreed;
+    @Setter
+    private boolean consentAgreed;
 
+    @Getter
+    @Setter
     private String recaptcha_response_field;
 
     // Org creation fields
+    @Setter
     private boolean createOrg;
-    private String orgName;
-    private String orgShortName;
-    private String orgAddress;
-    private String orgType;
-    private String orgDescription;
-    private String orgUrl;
-    private String orgLogo;
+    private @Getter @Setter String orgName;
+    private @Getter @Setter String orgShortName;
+    private @Getter @Setter String orgAddress;
+    private @Getter @Setter String orgType;
+    private @Getter @Setter String orgDescription;
+    private @Getter @Setter String orgUrl;
+    private @Getter @Setter String orgLogo;
 
     private @Getter @Setter String orgMail;
 
-    public String getRecaptcha_response_field() {
-        return recaptcha_response_field;
-    }
-
-    public void setRecaptcha_response_field(String recaptcha_response_field) {
-        this.recaptcha_response_field = recaptcha_response_field;
-    }
-
-    public String getUid() {
-        return uid;
-    }
-
-    public void setUid(String uid) {
-        this.uid = uid;
-    }
-
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public void setFirstName(String name) {
-        this.firstName = name;
-    }
-
-    public String getOrg() {
-        return org;
-    }
-
-    public void setOrg(String org) {
-        this.org = org;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPhone() {
-        return phone;
-    }
-
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getConfirmPassword() {
-        return confirmPassword;
-    }
-
-    public void setConfirmPassword(String confirmPassword) {
-        this.confirmPassword = confirmPassword;
-    }
-
     public boolean getPrivacyPolicyAgreed() {
         return privacyPolicyAgreed;
-    }
-
-    public void setPrivacyPolicyAgreed(boolean privacyPolicyAgreed) {
-        this.privacyPolicyAgreed = privacyPolicyAgreed;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public void setSurname(String sn) {
-        this.surname = sn;
     }
 
     public boolean getCreateOrg() {
         return createOrg;
     }
 
-    public void setCreateOrg(boolean createOrg) {
-        this.createOrg = createOrg;
-    }
-
-    public String getOrgName() {
-        return orgName;
-    }
-
-    public void setOrgName(String orgName) {
-        this.orgName = orgName;
-    }
-
-    public String getOrgShortName() {
-        return orgShortName;
-    }
-
-    public void setOrgShortName(String orgShortName) {
-        this.orgShortName = orgShortName;
-    }
-
-    public String getOrgAddress() {
-        return orgAddress;
-    }
-
-    public void setOrgAddress(String orgAddress) {
-        this.orgAddress = orgAddress;
-    }
-
-    public String getOrgType() {
-        return orgType;
-    }
-
-    public void setOrgType(String orgType) {
-        this.orgType = orgType;
-    }
-
-    public String getOrgDescription() {
-        return orgDescription;
-    }
-
-    public void setOrgDescription(String orgDescription) {
-        this.orgDescription = orgDescription;
-    }
-
-    public String getOrgUrl() {
-        return orgUrl;
-    }
-
-    public void setOrgUrl(String orgUrl) {
-        this.orgUrl = orgUrl;
-    }
-
-    public String getOrgLogo() {
-        return orgLogo;
-    }
-
-    public void setOrgLogo(String orgLogo) {
-        this.orgLogo = orgLogo;
+    public boolean getConsentAgreed() {
+        return consentAgreed;
     }
 
     @Override
@@ -226,7 +104,8 @@ public class AccountFormBean implements Serializable {
         return "AccountFormBean [uid=" + uid + ", firstName=" + firstName + ", surname=" + surname + ", org=" + org
                 + ", title=" + title + ", email=" + email + ", phone=" + phone + ", description=" + description
                 + ", password=" + password + ", confirmPassword=" + confirmPassword + ", privacyPolicyAgreed="
-                + privacyPolicyAgreed + ", recaptcha_response_field=" + recaptcha_response_field + "]";
+                + privacyPolicyAgreed + ", consentAgreed=" + consentAgreed + ", recaptcha_response_field="
+                + recaptcha_response_field + "]";
     }
 
 }

--- a/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/newaccount/NewAccountFormController.java
@@ -120,6 +120,12 @@ public final class NewAccountFormController {
     protected String privacyPolicyAgreementUrl;
 
     @Autowired
+    protected boolean consentAgreementActivated;
+
+    @Autowired
+    protected String consentAgreementUrl;
+
+    @Autowired
     protected LogUtils logUtils;
 
     @Autowired
@@ -172,8 +178,8 @@ public final class NewAccountFormController {
     @InitBinder
     public void initForm(WebDataBinder dataBinder) {
         dataBinder.setAllowedFields("firstName", "surname", "email", "phone", "org", "title", "description", "uid",
-                "password", "confirmPassword", "privacyPolicyAgreed", "createOrg", "orgName", "orgShortName",
-                "orgAddress", "orgType", "orgCities", "orgDescription", "orgUrl", "orgMail", "orgLogo",
+                "password", "confirmPassword", "privacyPolicyAgreed", "consentAgreed", "createOrg", "orgName",
+                "orgShortName", "orgAddress", "orgType", "orgCities", "orgDescription", "orgUrl", "orgMail", "orgLogo",
                 "recaptcha_response_field");
     }
 
@@ -186,6 +192,9 @@ public final class NewAccountFormController {
 
         model.addAttribute("privacyPolicyAgreementActivated", this.privacyPolicyAgreementActivated);
         model.addAttribute("privacyPolicyAgreementUrl", this.privacyPolicyAgreementUrl);
+
+        model.addAttribute("consentAgreementActivated", this.consentAgreementActivated);
+        model.addAttribute("consentAgreementUrl", this.consentAgreementUrl);
 
         model.addAttribute("recaptchaActivated", this.reCaptchaActivated);
         model.addAttribute("pwdUtils", passwordUtils);
@@ -388,7 +397,11 @@ public final class NewAccountFormController {
 
         // Check if the user has agreed to the privacy policy
         if (privacyPolicyAgreementActivated) {
-            validation.validatePrivacyPolicyAgreedField(formBean.getPrivacyPolicyAgreed(), result);
+            validation.validateAgreedField(formBean.getPrivacyPolicyAgreed(), result, "privacyPolicyAgreed");
+        }
+
+        if (consentAgreementActivated) {
+            validation.validateAgreedField(formBean.getConsentAgreed(), result, "consentAgreed");
         }
 
         // Validate remaining fields

--- a/console/src/main/java/org/georchestra/console/ws/utils/Validation.java
+++ b/console/src/main/java/org/georchestra/console/ws/utils/Validation.java
@@ -149,9 +149,9 @@ public class Validation {
         return !this.isUserFieldRequired(field) || StringUtils.hasLength(value);
     }
 
-    public void validatePrivacyPolicyAgreedField(boolean value, Errors errors) {
+    public void validateAgreedField(boolean value, Errors errors, String rejectValue) {
         if (!value)
-            errors.rejectValue("privacyPolicyAgreed", "error.required", "required");
+            errors.rejectValue(rejectValue, "error.required", "required");
     }
 
     public boolean validateOrgField(String field, JSONObject json) {

--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -143,7 +143,7 @@ privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
 consentAgreed.label=Consent
-consentAgreed.checkboxLabel=I consent to my personal information being processed in order to access the platform's services. <a href="{0}" target="_blank">More informations.</a>
+consentAgreed.checkboxLabel=I consent to my personal information being processed in order to access the platform''s services. <a href="{0}" target="_blank">More informations.</a>
 consentAgreed.error.notChecked=Consent is required, in order to create the account
 recaptcha_response_field.error.required=Required
 recaptcha.incorrect=Incorrect, please try again

--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -22,6 +22,7 @@ createAccountForm.description=An email will be sent to the above address to conf
 createAccountForm.fieldset.userDetails=User details
 createAccountForm.fieldset.credentials=Credentials
 createAccountForm.fieldset.privacyPolicyAgreement=Terms and conditions
+createAccountForm.fieldset.consentAgreement=Consent
 editUserDetailsForm.title=User details.
 editUserDetailsForm.subtitle=Update your account.
 editUserDetailsForm.description=In this page you can manage your account informations and modify your password.
@@ -141,6 +142,9 @@ phone.error.nonNumeric=The phone number should only contain digits
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
+consentAgreed.label=Consent
+consentAgreed.checkboxLabel=I consent to my personal information being processed in order to access the platform's services. <a href="{0}" target="_blank">More informations.</a>
+consentAgreed.error.notChecked=Consent is required, in order to create the account
 recaptcha_response_field.error.required=Required
 recaptcha.incorrect=Incorrect, please try again
 surname.label=Surname

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -141,8 +141,8 @@ privacyPolicyAgreed.label=Bedingungen
 privacyPolicyAgreed.checkboxLabel=Ich habe die <a href="{0}" target="_blank">Bedingungen</a> gelesen und akzeptiert
 privacyPolicyAgreed.error.notChecked=Bitte akzeptieren Sie die Bedingungen, um das Konto zu erstellen
 consentAgreed.label=Einwilligung
-consentAgreed.checkboxLabel=Ich stimme der Verarbeitung meiner personenbezogenen Daten zu. <a href="{0}" target="_blank">Mehr erfahren</a>
-consentAgreed.error.notChecked=Bitte stimmen Sie der Verarbeitung Ihrer personenbezogenen Daten zu
+consentAgreed.checkboxLabel=Ich bin damit einverstanden, dass meine personenbezogenen Daten verarbeitet werden, um auf die Dienste der Plattform zuzugreifen. <a href="{0}" target="_blank">Mehr Informationen</a>
+consentAgreed.error.notChecked=Für die Erstellung des Kontos ist eine Einwilligung erforderlich
 recaptcha_response_field.error.required=Notwendig
 recaptcha.incorrect=Falsch, bitte versuchen es noch einmal
 surname.label=Name

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -22,6 +22,7 @@ createAccountForm.description=Eine E-Mail wird an die Adresse geschickt, um die 
 createAccountForm.fieldset.userDetails=Benutzerdetails
 createAccountForm.fieldset.credentials=Referenzen
 createAccountForm.fieldset.privacyPolicyAgreement=Geschäftsbedingungen
+createAccountForm.fieldset.consentAgreement=Einwilligung
 editUserDetailsForm.title=Benutzerdetails.
 editUserDetailsForm.subtitle=Aktualisieren Sie Ihr Konto.
 editUserDetailsForm.description=Auf dieser Seite können Sie Ihre Kontoinformationen verwalten und Ihr Passwort ändern.
@@ -139,6 +140,9 @@ phone.error.nonNumeric=Die Telefonnummer sollte nur Ziffern enthalten
 privacyPolicyAgreed.label=Bedingungen
 privacyPolicyAgreed.checkboxLabel=Ich habe die <a href="{0}" target="_blank">Bedingungen</a> gelesen und akzeptiert
 privacyPolicyAgreed.error.notChecked=Bitte akzeptieren Sie die Bedingungen, um das Konto zu erstellen
+consentAgreed.label=Einwilligung
+consentAgreed.checkboxLabel=Ich stimme der Verarbeitung meiner personenbezogenen Daten zu. <a href="{0}" target="_blank">Mehr erfahren</a>
+consentAgreed.error.notChecked=Bitte stimmen Sie der Verarbeitung Ihrer personenbezogenen Daten zu
 recaptcha_response_field.error.required=Notwendig
 recaptcha.incorrect=Falsch, bitte versuchen es noch einmal
 surname.label=Name

--- a/console/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -22,6 +22,7 @@ createAccountForm.description=Un correo de confirmación será mandado a la dire
 createAccountForm.fieldset.userDetails=Detalles del usuario
 createAccountForm.fieldset.credentials=Credenciales
 createAccountForm.fieldset.privacyPolicyAgreement=Condiciones de uso
+createAccountForm.fieldset.consentAgreement=Consentimiento
 editUserDetailsForm.title=Detalles de la cuenta.
 editUserDetailsForm.subtitle=Actualice sus informaciones.
 editUserDetailsForm.description=En esta página, puede manejar las informaciones de su cuenta y modificar su contraseña.
@@ -138,8 +139,9 @@ phone.error.nonNumeric=El número de teléfono solo puede contener dígitos
 privacyPolicyAgreed.label=Condiciones
 privacyPolicyAgreed.checkboxLabel=Leí y acepto las <a href="{0}" target="_blank">condiciones</a>
 privacyPolicyAgreed.error.notChecked=Por favor, aceptar las condiciones para crear la cuenta
-postalAddress.label=Dirección postal
-postalAddress.placeholder=Dirección postal
+consentAgreed.label=Consentimiento
+consentAgreed.checkboxLabel=Leí y acepto el <a href="{0}" target="_blank">consentimiento</a>
+consentAgreed.error.notChecked=Por favor, aceptar el consentimiento para crear la cuenta
 recaptcha_response_field.error.required=Requerido
 recaptcha.incorrect=Incorrecto, por favor pruebe de nuevo
 surname.label=Apellido

--- a/console/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -140,8 +140,8 @@ privacyPolicyAgreed.label=Condiciones
 privacyPolicyAgreed.checkboxLabel=Leí y acepto las <a href="{0}" target="_blank">condiciones</a>
 privacyPolicyAgreed.error.notChecked=Por favor, aceptar las condiciones para crear la cuenta
 consentAgreed.label=Consentimiento
-consentAgreed.checkboxLabel=Leí y acepto el <a href="{0}" target="_blank">consentimiento</a>
-consentAgreed.error.notChecked=Por favor, aceptar el consentimiento para crear la cuenta
+consentAgreed.checkboxLabel=Doy mi consentimiento para que mi información personal sea procesada para poder acceder a los servicios de la plataforma. <a href="{0}" target="_blank">Más información</a>
+consentAgreed.error.notChecked=Se requiere consentimiento para crear la cuenta
 recaptcha_response_field.error.required=Requerido
 recaptcha.incorrect=Incorrecto, por favor pruebe de nuevo
 surname.label=Apellido

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -141,7 +141,7 @@ privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=J''ai lu et j''accepte les <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Veuillez accepter les conditions afin de créer le compte
 consentAgreed.label=Consentement
-consentAgreed.checkboxLabel=Je consens à  ce que mes informations personnelles soient traitéees afin d'avoir accès aux services de la plateforme. <a href="{0}" target="_blank">Plus d''informations.</a>
+consentAgreed.checkboxLabel=Je consens à ce que mes informations personnelles soient traitées afin d''avoir accès aux services de la plateforme. <a href="{0}" target="_blank">Plus d''informations</a>
 consentAgreed.error.notChecked=Veuillez accepter le consentement afin de créeer le compte
 recaptcha_response_field.error.required=Cochez la case
 recaptcha.incorrect=Erreur. Réessayez

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -22,6 +22,7 @@ createAccountForm.description=Un courriel de confirmation sera envoyé à l'adre
 createAccountForm.fieldset.userDetails=Détails du compte
 createAccountForm.fieldset.credentials=Identification
 createAccountForm.fieldset.privacyPolicyAgreement=Conditions d'utilisation
+createAccountForm.fieldset.consentAgreement=Consentement
 editUserDetailsForm.title=Détails du compte.
 editUserDetailsForm.subtitle=Actualisez vos informations.
 editUserDetailsForm.description=Sur cette page vous pouvez gérer les informations de votre compte, et modifier votre mot de passe.
@@ -139,6 +140,9 @@ phone.error.nonNumeric=Le numéro de téléphone doit contenir uniquement des ch
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=J''ai lu et j''accepte les <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Veuillez accepter les conditions afin de créer le compte
+consentAgreed.label=Consentement
+consentAgreed.checkboxLabel=Je consens à  ce que mes informations personnelles soient traitéees afin d'avoir accès aux services de la plateforme. <a href="{0}" target="_blank">Plus d''informations.</a>
+consentAgreed.error.notChecked=Veuillez accepter le consentement afin de créeer le compte
 recaptcha_response_field.error.required=Cochez la case
 recaptcha.incorrect=Erreur. Réessayez
 surname.label=Nom

--- a/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
@@ -22,7 +22,7 @@ createAccountForm.description=Een bevestigingsmail zal naar het aangegeven adres
 createAccountForm.fieldset.userDetails=Accountgegevens
 createAccountForm.fieldset.credentials=Identificatie
 createAccountForm.fieldset.privacyPolicyAgreement=Terms and conditions
-createAccountForm.fieldset.consentAgreement=Consent
+createAccountForm.fieldset.consentAgreement=Toestemming
 editUserDetailsForm.title=Accountgegevens.
 editUserDetailsForm.subtitle=Bijwerk uw gegevens.
 editUserDetailsForm.description=Op deze pagina kunt u uw accountinformatie beheren en uw wachtwoord wijzigen.
@@ -140,9 +140,9 @@ phone.error.nonNumeric=Telefoonnummer mag alleen nummers bevatten
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
-consentAgreed.label=Consent
-consentAgreed.checkboxLabel=I consent to my personal information being processed in order to access the platform's services. <a href="{0}" target="_blank">More informations.</a>
-consentAgreed.error.notChecked=Consent is required, in order to create the account
+consentAgreed.label=Toestemming
+consentAgreed.checkboxLabel=Ik ga ermee akkoord dat mijn persoonlijke gegevens worden verwerkt om toegang te krijgen tot de diensten van het platform. <a href="{0}" target="_blank">Meer informatie</a>
+consentAgreed.error.notChecked=Om het account aan te maken is toestemming vereist
 recaptcha_response_field.error.required=Vink het vakje aan
 recaptcha.incorrect=Fout. Probeer het opnieuw
 surname.label=Naam

--- a/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
@@ -22,6 +22,7 @@ createAccountForm.description=Een bevestigingsmail zal naar het aangegeven adres
 createAccountForm.fieldset.userDetails=Accountgegevens
 createAccountForm.fieldset.credentials=Identificatie
 createAccountForm.fieldset.privacyPolicyAgreement=Terms and conditions
+createAccountForm.fieldset.consentAgreement=Consent
 editUserDetailsForm.title=Accountgegevens.
 editUserDetailsForm.subtitle=Bijwerk uw gegevens.
 editUserDetailsForm.description=Op deze pagina kunt u uw accountinformatie beheren en uw wachtwoord wijzigen.
@@ -139,6 +140,9 @@ phone.error.nonNumeric=Telefoonnummer mag alleen nummers bevatten
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
+consentAgreed.label=Consent
+consentAgreed.checkboxLabel=I consent to my personal information being processed in order to access the platform's services. <a href="{0}" target="_blank">More informations.</a>
+consentAgreed.error.notChecked=Consent is required, in order to create the account
 recaptcha_response_field.error.required=Vink het vakje aan
 recaptcha.incorrect=Fout. Probeer het opnieuw
 surname.label=Naam

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -88,6 +88,14 @@
     <constructor-arg value="${privacy.policy.agreement.url:}" />
   </bean>
 
+  <bean id="consentAgreementActivated" class="java.lang.Boolean">
+    <constructor-arg value="${consent.agreement.activated:false}" />
+  </bean>
+
+  <bean id="consentAgreementUrl" class="java.lang.String">
+    <constructor-arg value="${consent.agreement.url:}" />
+  </bean>
+
   <!-- LDAP connection -->
   <bean id="singleContextSource" class="org.springframework.ldap.core.support.LdapContextSource">
     <property name="url" value="${ldapScheme}://${ldapHost}:${ldapPort}"/>

--- a/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
@@ -231,17 +231,17 @@
             </c:if>
 
             <c:if test="${consentAgreementActivated}">
-                <fieldset>
-                    <legend><s:message code="createAccountForm.fieldset.consentAgreement"/></legend>
-                    <t:privacyPolicyAgreement path="consentAgreed" required="true">
+            <fieldset>
+                <legend><s:message code="createAccountForm.fieldset.consentAgreement"/></legend>
+                <t:privacyPolicyAgreement path="consentAgreed" required="true">
                     <jsp:attribute name="label">
                         <s:message code="consentAgreed.label" />
                     </jsp:attribute>
-                        <jsp:attribute name="checkboxLabel">
+                    <jsp:attribute name="checkboxLabel">
                         <s:message code="consentAgreed.checkboxLabel" arguments="${consentAgreementUrl}" />
                     </jsp:attribute>
-                    </t:privacyPolicyAgreement>
-                </fieldset>
+                </t:privacyPolicyAgreement>
+            </fieldset>
             </c:if>
 
             <c:if test="${recaptchaActivated}">

--- a/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/createAccountForm.jsp
@@ -230,6 +230,20 @@
             </fieldset>
             </c:if>
 
+            <c:if test="${consentAgreementActivated}">
+                <fieldset>
+                    <legend><s:message code="createAccountForm.fieldset.consentAgreement"/></legend>
+                    <t:privacyPolicyAgreement path="consentAgreed" required="true">
+                    <jsp:attribute name="label">
+                        <s:message code="consentAgreed.label" />
+                    </jsp:attribute>
+                        <jsp:attribute name="checkboxLabel">
+                        <s:message code="consentAgreed.checkboxLabel" arguments="${consentAgreementUrl}" />
+                    </jsp:attribute>
+                    </t:privacyPolicyAgreement>
+                </fieldset>
+            </c:if>
+
             <c:if test="${recaptchaActivated}">
             <fieldset>
                 <t:recaptcha path="g-recaptcha" />
@@ -297,6 +311,7 @@
         if (testFirstname() & testSurname() & testEmail() & testUid() & testPassword() & testConfirmPassword() &
                <c:if test="${recaptchaActivated}"> testRecaptcha() & </c:if>
                <c:if test="${privacyPolicyAgreementActivated}"> testPrivacyPolicyAgreed() & </c:if>
+               <c:if test="${consentAgreementActivated}"> testConsentAgreed() & </c:if>
                testField("phone") & testField("title") & testField("description") & testOrg()
         ) {
             return true;

--- a/console/src/main/webapp/WEB-INF/views/validation.jsp
+++ b/console/src/main/webapp/WEB-INF/views/validation.jsp
@@ -93,6 +93,15 @@ function testPrivacyPolicyAgreed(){
     return true;
 }
 
+function testConsentAgreed(){
+    removeError("consentAgreed");
+    if(!$('#consentAgreed').is(':checked')){
+        addError("consentAgreed", "<s:message code="consentAgreed.error.notChecked" />");
+        return false;
+    }
+    return true;
+}
+
 /**
  * First verification, be sure g-recaptcha-response textarea is not empty
  */

--- a/console/src/test/java/org/georchestra/console/ws/newaccount/NewAccountFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/newaccount/NewAccountFormControllerTest.java
@@ -339,7 +339,7 @@ public class NewAccountFormControllerTest {
         assertEquals("required", resultErrors.getFieldError("privacyPolicyAgreed").getDefaultMessage());
         assertEquals("required", resultErrors.getFieldError("consentAgreed").getDefaultMessage());
 
-        assertEquals(9, resultErrors.getFieldErrorCount());
+        assertEquals(10, resultErrors.getFieldErrorCount());
     }
 
     @Test

--- a/console/src/test/java/org/georchestra/console/ws/newaccount/NewAccountFormControllerTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/newaccount/NewAccountFormControllerTest.java
@@ -119,6 +119,7 @@ public class NewAccountFormControllerTest {
         assertTrue(allowedField.contains("confirmPassword"));
         assertTrue(allowedField.contains("recaptcha_response_field"));
         assertTrue(allowedField.contains("privacyPolicyAgreed"));
+        assertTrue(allowedField.contains("consentAgreed"));
     }
 
     @Test
@@ -277,6 +278,7 @@ public class NewAccountFormControllerTest {
         t.setTitle("software engineer");
         t.setUid("123123-21465456-3434");
         t.setPrivacyPolicyAgreed(false);
+        t.setConsentAgreed(false);
 
         assertTrue(t.getConfirmPassword().equals("test"));
         assertTrue(t.getDescription().equals("testing account"));
@@ -293,7 +295,8 @@ public class NewAccountFormControllerTest {
                 + "firstName=Test, surname=testmaster, org=geOrchestra, "
                 + "title=software engineer, email=test@localhost.com, "
                 + "phone=+331234567890, description=testing account, " + "password=monkey123, confirmPassword=test, "
-                + "privacyPolicyAgreed=false, " + "recaptcha_response_field=wrong]", t.toString());
+                + "privacyPolicyAgreed=false, " + "consentAgreed=false, " + "recaptcha_response_field=wrong]",
+                t.toString());
     }
 
     /**
@@ -317,6 +320,7 @@ public class NewAccountFormControllerTest {
         NewAccountFormController toTest = createToTest("firstName,surname,org,orgType");
         toTest.reCaptchaActivated = true;
         toTest.privacyPolicyAgreementActivated = true;
+        toTest.consentAgreementActivated = true;
         AccountFormBean formBean = new AccountFormBean();
         formBean.setPassword("");
         formBean.setConfirmPassword("");
@@ -333,6 +337,7 @@ public class NewAccountFormControllerTest {
         assertEquals("required", resultErrors.getFieldError("password").getDefaultMessage());
         assertEquals("required", resultErrors.getFieldError("confirmPassword").getDefaultMessage());
         assertEquals("required", resultErrors.getFieldError("privacyPolicyAgreed").getDefaultMessage());
+        assertEquals("required", resultErrors.getFieldError("consentAgreed").getDefaultMessage());
 
         assertEquals(9, resultErrors.getFieldErrorCount());
     }
@@ -341,12 +346,14 @@ public class NewAccountFormControllerTest {
     public void specialValidators() throws IOException, SQLException {
         NewAccountFormController toTest = createToTest("firstName,surname,org,orgType,phone,title,description");
         toTest.privacyPolicyAgreementActivated = true;
+        toTest.consentAgreementActivated = true;
         AccountFormBean formBean = new AccountFormBean();
         formBean.setUid("I am no compliant !!!!");
         formBean.setEmail("I am no compliant !!!!");
         formBean.setPassword("Pré$ident");
         formBean.setConfirmPassword("lapinmalin");
         formBean.setPrivacyPolicyAgreed(false);
+        formBean.setConsentAgreed(false);
         BindingResult resultErrors = new MapBindingResult(new HashMap<>(), "errors");
 
         toTest.create(request, formBean, "", resultErrors, status, UiModel);
@@ -358,6 +365,7 @@ public class NewAccountFormControllerTest {
         assertEquals("required", resultErrors.getFieldError("title").getDefaultMessage());
         assertEquals("required", resultErrors.getFieldError("description").getDefaultMessage());
         assertEquals("required", resultErrors.getFieldError("privacyPolicyAgreed").getDefaultMessage());
+        assertEquals("required", resultErrors.getFieldError("consentAgreed").getDefaultMessage());
     }
 
     @Test

--- a/console/src/test/resources/webmvc-config-test.xml
+++ b/console/src/test/resources/webmvc-config-test.xml
@@ -76,6 +76,14 @@
     <constructor-arg value="${privacy.policy.agreement.url:}" />
   </bean>
 
+  <bean id="consentAgreementActivated" class="java.lang.Boolean">
+    <constructor-arg value="${consent.agreement.activated:false}" />
+  </bean>
+
+  <bean id="consentAgreementUrl" class="java.lang.String">
+    <constructor-arg value="${consent.agreement.url:}" />
+  </bean>
+
   <!-- LDAP connection -->
   <bean id="singleContextSource" class="org.springframework.ldap.core.support.LdapContextSource">
     <property name="url" value="${ldapScheme}://${ldapHost}:${ldapPort}"/>


### PR DESCRIPTION
This PR adds a new consent checkbox under Conditions in console account creation. 

Can be configured by setting :
```
consent.agreement.activated=true
consent.agreement.url=https://mydomain/consent.html
```

*Upcoming PR on datadir*

![image](https://github.com/georchestra/georchestra/assets/39771412/6dc5074a-57ed-4473-82ac-e54efe11e042)
