### PR TITLE
Fixed GDPR account data download when OGC statistics are disabled

### DIFF
--- a/console/src/main/java/org/georchestra/console/ds/AccountGDPRDaoImpl.java
+++ b/console/src/main/java/org/georchestra/console/ds/AccountGDPRDaoImpl.java
@@ -172,7 +172,7 @@ public class AccountGDPRDaoImpl implements AccountGDPRDao {
                     AccountGDPRDaoImpl::createOgcStatisticsRecord, consumer);
             log.info("Extracted {} OGC statistics records for user {}", reccount, userName);
         } catch (DataServiceException e) {
-            throw new IllegalStateException(e);
+            log.info("No OGC statistics recorded for user {}", userName);
         }
     }
 


### PR DESCRIPTION
When OGC statistics is disabled, related tables are not present in database so trying to download complete account data using dedicated button in Data protection panel on user profile fails when trying to retrieve data from OGC statistics table with this error :

```
java.lang.IllegalStateException: org.georchestra.ds.DataServiceException: org.postgresql.util.PSQLException: ERROR: relation "ogcstatistics.ogc_services_log" does not exist
  Position: 59
	at org.georchestra.console.ds.AccountGDPRDaoImpl.visitOgcStatsRecords(AccountGDPRDaoImpl.java:175)
```