### PR TITLE
security update to geoserver 2.25.2/geotools 31.2

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,8 +8,8 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.25.1</gs.version>
-    <gt.version>31.1</gt.version>
+    <gs.version>2.25.2</gs.version>
+    <gt.version>31.2</gt.version>
     <geofence.version>3.5.1</geofence.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <marlin.version>0.9.3</marlin.version>


### PR DESCRIPTION
not yet announced, but tagged/released:
- https://github.com/geotools/geotools/releases/tag/31.2
- https://github.com/geoserver/geoserver/releases/tag/2.25.2

should be announced tomorrow. Runs fine locally and on https://demo.georchestra.org/geoserver/

i've pushed -f on the https://github.com/georchestra/geoserver/commits/2.25.x-georchestra branch after having rebased georchestra commits on top of https://github.com/geoserver/geoserver/commit/fa9a11137fdf92ed359ea05030f1e2b0af4c4540

@fvanderbiest i've added it to 24.0 milestone, nicer to have the latest security release.. the PR is here mostly for GH actions to run.