### PR TITLE
ldap - removing unused & redundant attributes

### DIFF
--- a/ldap/docker-root/georchestraSchema.ldif
+++ b/ldap/docker-root/georchestraSchema.ldif
@@ -42,16 +42,3 @@ olcObjectClasses: ( 1.3.6.1.4.1.53611.1.1.3
     SUP top
     AUXILIARY
     MAY (georchestraObjectIdentifier))
-olcObjectClasses: ( 1.3.6.1.4.1.53611.1.1.4
-    NAME 'georchestraOAuth2Provider'
-    DESC 'OAuth2 provider object class for external identity provider users'
-    SUP top
-    AUXILIARY
-    MAY (oAuth2Provider))
-olcObjectClasses: ( 1.3.6.1.4.1.53611.1.1.5
-    NAME 'georchestraOAuth2Uid'
-    DESC 'OAuth2 UID object class for external identity provider users'
-    SUP top
-    AUXILIARY
-    MAY (oAuth2Uid))
-

--- a/migrations/master/ldap_migration.ldif
+++ b/migrations/master/ldap_migration.ldif
@@ -38,29 +38,3 @@ olcObjectClasses: ( 1.3.6.1.4.1.53611.1.1.1
     SUP top
     AUXILIARY
     MAY ( privacyPolicyAgreementDate $ knowledgeInformation $ georchestraObjectIdentifier $ oAuth2Provider $ oAuth2Uid))
-
--
-
-dn: cn=schema,cn=config
-changetype: modify
-add: olcObjectClasses
-olcObjectClasses: ( 1.3.6.1.4.1.53611.1.1.4
-    NAME 'georchestraOAuth2Provider'
-    DESC 'OAuth2 provider for external identity provider users'
-    SUP top
-    AUXILIARY
-    MAY (oAuth2Provider))
-
--
-
-dn: cn=schema,cn=config
-changetype: modify
-add: olcObjectClasses
-olcObjectClasses: ( 1.3.6.1.4.1.53611.1.1.5
-    NAME 'georchestraOAuth2Uid'
-    DESC 'OAuth2 UID for external identity provider users'
-    SUP top
-    AUXILIARY
-    MAY (oAuth2Uid))
-
-


### PR DESCRIPTION
git grepping both attributes, they did not seem to be used elsewhere (nor in this repository, nor in georchestra-gateway), and they also sound as redundant as the other ones defined above (`oauth2Provider`, `oauth2Uid`).

