### PR TITLE
switch to GN 4.4.5

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.3/apache-maven-3.8.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -10,16 +10,16 @@ From [master](https://github.com/georchestra/datadir/tree/master), create a new 
 ```
 git checkout master
 git pull origin master
-git checkout -b 23.1
-git push origin 23.1
+git checkout -b 24.1
+git push origin 24.1
 ```
 
 Same has to be done for the `docker-master` branch:
 ```
 git checkout docker-master
 git pull origin docker-master
-git checkout -b docker-23.1
-git push origin docker-23.1
+git checkout -b docker-24.1
+git push origin docker-24.1
 ```
 
 ### Docker
@@ -28,28 +28,28 @@ From [master](https://github.com/georchestra/docker/tree/master), create a new b
 ```
 git checkout master
 git pull origin master
-git checkout -b 23.1
+git checkout -b 24.1
 ```
 
 Update the image tags:
 ```
-sed -i 's/latest/23.1.x/g' docker-compose.yml
+sed -i 's/latest/24.1.x/g' docker-compose.yml
 ```
 
-Make sure the config folder tracks the `docker-23.1` datadir branch:
+Make sure the config folder tracks the `docker-24.1` datadir branch:
 ```
 $ cat .gitmodules
 [submodule "config"]
 	path = config
 	url = https://github.com/georchestra/datadir.git
-	branch = docker-23.1
+	branch = docker-24.1
 ```
 
 Manually update the README and `.github/dependabot.yml`
 
 ```
-git commit -am "23.1 branch"
-git push origin 23.1
+git commit -am "24.1 branch"
+git push origin 24.1
 ```
 
 ### GeoServer minimal datadir
@@ -58,26 +58,26 @@ From [master](https://github.com/georchestra/geoserver_minimal_datadir/tree/mast
 ```
 git checkout master
 git pull origin master
-git checkout -b 23.1
-git push origin 23.1
+git checkout -b 24.1
+git push origin 24.1
 ```
 
 Same has to be done for the `geofence` branch:
 ```
 git checkout geofence
 git pull origin geofence
-git checkout -b 23.1-geofence
-git push origin 23.1-geofence
+git checkout -b 24.1-geofence
+git push origin 24.1-geofence
 ```
 
 ### GeoNetwork
 
 ```
 cd geonetwork
-git checkout georchestra-gn4.2.x
-git pull origin georchestra-gn4.2.x
-git tag 23.1.0
-git push origin 23.1.0
+git checkout georchestra-gn4.4.x
+git pull origin georchestra-gn4.4.x
+git tag 24.1.0
+git push origin 24.1.0
 ```
 
 Then [create a new release](https://github.com/georchestra/geonetwork/releases).
@@ -90,13 +90,13 @@ Then [create a new release](https://github.com/georchestra/geonetwork/releases).
 cd georchestra-cas-server
 git checkout master
 git pull -r # to get lastest commits
-git checkout -b 23.0.x
+git checkout -b 24.0.x
 
-# edit gradle.properties to replace dockerTag and datadirRef by: dockerTag=23.0.x and datadirRef=23.0
+# edit gradle.properties to replace dockerTag and datadirRef by: dockerTag=24.0.x and datadirRef=23.0
 git add gradle.properties
-git commit -am "23.0.x branch"
-git tag 23.0.0-georchestra
-git push --set-upstream origin 23.0.x --tag
+git commit -am "24.0.x branch"
+git tag 24.0.0-georchestra
+git push --set-upstream origin 24.0.x --tag
 
 ```
 
@@ -114,8 +114,8 @@ train](https://github.com/georchestra/mapstore2-georchestra/releases).
 It might not be necessary to make a release of mapstore2-georchestra when
 releasing geOrchestra, but if it's really needed, just place a tag on the
 latest commit in the stable branch (as of today,
-[2022.02.xx](https://github.com/georchestra/mapstore2-georchestra/tree/2022.02.xx)
-but will soon 2023.01.xx)
+[2023.02.xx](https://github.com/georchestra/mapstore2-georchestra/tree/2023.02.xx)
+but will soon 2024.01.xx)
 
 The versioning might not necessary match geOrchestra's, but follows mapstore's
 stable branch used in the
@@ -124,27 +124,27 @@ submodule.
 
 ### geOrchestra
 
-From the master branch of the [georchestra](https://github.com/georchestra/georchestra/tree/master) repository, derive a `23.1.x` branch:
+From the master branch of the [georchestra](https://github.com/georchestra/georchestra/tree/master) repository, derive a `24.1.x` branch:
 ```
 git checkout master
 git pull origin master
-git checkout -b 23.1.x
+git checkout -b 24.1.x
 ```
 
 Update the GeoNetwork submodule to the release commit:
 ```
 cd geonetwork
 git fetch origin
-git checkout 23.1.0
+git checkout 24.1.0
 cd -
 ```
 
 Other tasks:
  * Manually update the files mentionning the current release version (```README.md``` and ```RELEASE_NOTES.md```)
  * Update the branch name for the Travis status logo
- * Change the `packageDatadirScmVersion` parameter in the root `pom.xml` to `23.1`
+ * Change the `packageDatadirScmVersion` parameter in the root `pom.xml` to `24.1`
  * Replace `99.master` by `${build.closest.tag.name}` in the root `pom.xml` so that debian packages have the right version
- * Change the `BTAG` variable in the Makefile to `23.1.x`
+ * Change the `BTAG` variable in the Makefile to `24.1.x`
  * Check the submodule branches in `.gitmodules` are correct, since [dependabot](https://app.dependabot.com/accounts/georchestra/) depends on it to update submodules
  * Setup a [new dependabot job](https://app.dependabot.com/accounts/georchestra/) which takes care of updating the submodules for this new branch
  * Update the [github workflow](https://github.com/georchestra/georchestra/tree/master/.github/workflows) files to change the `refs/heads/22.` to `refs/heads/23.` to push on docker hub new images versions
@@ -154,24 +154,24 @@ Other tasks:
 Commit and propagate the changes:
 ```
 git add geonetwork
-git commit -am "23.1.x branch"
+git commit -am "24.1.x branch"
 ```
 
-When the release is ready on branch `23.1.x`, push a tag:
+When the release is ready on branch `24.1.x`, push a tag:
 ```
-git tag 23.1.0
-git push origin 23.1.x --tags
+git tag 24.1.0
+git push origin 24.1.x --tags
 ```
 
 The master branch requires some work too:
 ```
 git checkout master
-find ./ -name pom.xml -exec sed -i 's#<version>23.1-SNAPSHOT</version>#<version>20.2-SNAPSHOT</version>#' {} \;
+find ./ -name pom.xml -exec sed -i 's#<version>24.1-SNAPSHOT</version>#<version>24.2-SNAPSHOT</version>#' {} \;
 git submodule foreach 'git reset --hard'
 git commit -am "updated project version in pom.xml"
 ```
 
-geOrchestra 23.1.0 is now released, congrats !
+geOrchestra 24.1.0 is now released, congrats !
 
 Do not forget to :
  * update dependabot files (like https://github.com/georchestra/docker/blob/master/.github/dependabot.yml)
@@ -181,27 +181,27 @@ Do not forget to :
 
 ## Patch releases
 
-We're taking example on the 23.0.3 release.
+We're taking example on the 24.0.3 release.
 
 ### geOrchestra & GeoNetwork submodule
 
 Create the release commit:
 ```
 cd georchestra
-git checkout 23.0.x
-git pull origin 23.0.x
+git checkout 24.0.x
+git pull origin 24.0.x
 git submodule update --init --recursive
 cd geonetwork 
-git checkout georchestra-gn4.2.x
-git pull origin georchestra-gn4.2.x
+git checkout georchestra-gn4.4.x
+git pull origin georchestra-gn4.4.x
 cd ../
-find ./ -name pom.xml -exec sed -i 's#version>23.0.3-SNAPSHOT</#version>23.0.3</#' {} \;
+find ./ -name pom.xml -exec sed -i 's#version>24.0.3-SNAPSHOT</#version>24.0.3</#' {} \;
 cd geonetwork
 git add georchestra-integration/pom.xml
-git commit -m "23.0.3 release"
-git tag 23.0.3
-git push origin 23.0.3
-git push origin georchestra-gn4.2.x
+git commit -m "24.0.3 release"
+git tag 24.0.3
+git push origin 24.0.3
+git push origin georchestra-gn4.4.x
 
 ```
 Then [create a new release for GeoNetwork](https://github.com/georchestra/geonetwork/releases).
@@ -210,17 +210,17 @@ Then [create a new release for GeoNetwork](https://github.com/georchestra/geonet
 cd ../
 git add geonetwork
 git add -p
-git commit -m "23.0.3 release"
-git push origin 23.0.x
-git tag 23.0.3
-git push origin 23.0.3
+git commit -m "24.0.3 release"
+git push origin 24.0.x
+git tag 24.0.3
+git push origin 24.0.3
 ```
 
 Then [create a new release for geOrchestra](https://github.com/georchestra/georchestra/releases).
 
 Finally, revert the maven version back to SNAPSHOT and new patch release:
 ```
-find ./ -name pom.xml -exec sed -i 's#version>23.0.3</#version>20.0.4-SNAPSHOT</#' {} \; 
+find ./ -name pom.xml -exec sed -i 's#version>24.0.3</#version>24.0.4-SNAPSHOT</#' {} \; 
 cd geonetwork
 git add georchestra-integration/pom.xml
 git commit -m "back to SNAPSHOT"
@@ -228,7 +228,7 @@ git push
 cd ../
 git add -p
 git commit -m "back to SNAPSHOT"
-git push origin 23.0.x
+git push origin 24.0.x
 ```
 
 Create new milestones for [georchestra](https://github.com/georchestra/georchestra/milestones) and [geonetwork](https://github.com/georchestra/geonetwork/milestones).
@@ -256,8 +256,8 @@ Releasing a new version of geOrchestra when it comes to these new repositories i
 a branch so that an artifact can be generated.
 
 **To summarize, when releasing a patch release, do not forget to:**
-* `georchestra/mapstore2-georchestra`: Add a tag on top of the stable branch. As of today, `23.0.0-georchestra`, in branch `2022.02.xx`.
-* `georchestra/georchestra-cas-server`: Add a tag on top of the appropriate branch (`23.0.x`)
+* `georchestra/mapstore2-georchestra`: Add a tag on top of the stable branch. As of today, `24.0.0-georchestra`, in branch `2023.02.xx`.
+* `georchestra/georchestra-cas-server`: Add a tag on top of the appropriate branch (`24.0.x`)
 
 ### Packaging
 
@@ -267,7 +267,7 @@ The CICD processes provide 3 main types of artifacts:
 *  debian packages - from a self hosted buildbot
 *  docker images - via the Github Actions
 
-The generic WARS as well as the debian packages are built following a branch (master, 20.x, ...). The docker images are following the same rules,
+The generic WARS as well as the debian packages are built following a branch (master, 24.x, ...). The docker images are following the same rules,
 but are also creating an image for each tag (e.g. "releases"). The main difference here is that generic wars & debian packages do not have an artifact for tags / releases,
 as they follow the evolution of each branches.
 


### PR DESCRIPTION
with all the hard work from @f-necas in georchestra/geonetwork#297 .. ready for testing for the ones using master.

i'm not sure the GN PR should be merged to 4.2.x branch there, rather `[georchestra-gn4.4.5-rebase](https://github.com/georchestra/geonetwork/tree/georchestra-gn4.4.5-rebase)` branch should be renamed to `georchestra-gn4.4.x` and the submodule point to the tip of it as this PR does.

