### PR TITLE
Bump dependencies v2

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -190,12 +190,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-      <version>2.4.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -273,7 +267,7 @@
     <dependency>
       <groupId>org.springframework.amqp</groupId>
       <artifactId>spring-amqp</artifactId>
-      <version>1.1.4.RELEASE</version>
+      <version>2.3.11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.amqp</groupId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -190,6 +190,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.9.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/console/src/main/webapp/manager/package-lock.json
+++ b/console/src/main/webapp/manager/package-lock.json
@@ -5713,7 +5713,7 @@
       }
     },
     "requirejs": {
-      "version": "2.3.6",
+      "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
       "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
       "dev": true

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -21,7 +21,7 @@
 
     <gt.version>29.0</gt.version>
     <openapi-generator-maven-plugin.version>5.0.1</openapi-generator-maven-plugin.version>
-    <mapstruct.version>1.4.1.Final</mapstruct.version>
+    <mapstruct.version>1.5.5.Final</mapstruct.version>
     <lombok.version>1.18.22</lombok.version>
 
     <jersey-version>2.29.1</jersey-version>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -177,7 +177,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1-jre</version>
+        <version>32.0.0-jre</version>
       </dependency>
       <!-- test deps -->
       <dependency>

--- a/ldap-account-management/pom.xml
+++ b/ldap-account-management/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <name>LDAP users and groups management library</name>
   <properties>
-    <mapstruct.version>1.4.1.Final</mapstruct.version>
+    <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
   <dependencies>
     <!-- geOrchestra commons -->

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
       <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
-        <version>1.6</version>
+        <version>1.7</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -473,16 +473,6 @@
         <version>${guava.version}</version>
       </dependency>
       <dependency>
-        <groupId>net.sf.jasperreports</groupId>
-        <artifactId>jasperreports</artifactId>
-        <version>6.1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>net.sf.jasperreports</groupId>
-        <artifactId>jasperreports-fonts</artifactId>
-        <version>6.0.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.velocity</groupId>
         <artifactId>velocity</artifactId>
         <version>1.7</version>


### PR DESCRIPTION
Removes jasperreports : closes 
- #4274 #4275

Closes :
- #4122 #4167 #4293

Update Mapstruct to 1.5.5 :
- #4294

Update guava to 32 in DF :
- #4306