### PR TITLE
console - attachClasses set to true on maven-war-plugin

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -444,6 +444,7 @@
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <packagingExcludes>manager/node_modules/**</packagingExcludes>
+          <attachClasses>true</attachClasses>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This allows to create an extra artifact containing only the classes of the webapp (basically the ones under src/main/java), so that we can publish a new jar on artifactory and use it to extend the console in new projects.

This should only add a new artifact as a jar file, the way the console is being built (in term of "console.war" layout) is not affected.
