### PR TITLE
feat: bump cobertura, mapstruct, geotools, postgres, c3po, itextpdf, ldaptive

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -981,7 +981,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.5.2</version>
+        <version>2.7</version>
       </plugin>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -380,7 +380,7 @@
     <dependency>
       <groupId>org.ldaptive</groupId>
       <artifactId>ldaptive</artifactId>
-      <version>1.0.3</version>
+      <version>1.3.3</version>
     </dependency>
 	<dependency>
 	  <groupId>com.vladmihalcea</groupId>

--- a/datafeeder/pom.xml
+++ b/datafeeder/pom.xml
@@ -21,7 +21,7 @@
 
     <gt.version>29.0</gt.version>
     <openapi-generator-maven-plugin.version>5.0.1</openapi-generator-maven-plugin.version>
-    <mapstruct.version>1.5.5.Final</mapstruct.version>
+    <mapstruct.version>1.6.0</mapstruct.version>
     <lombok.version>1.18.22</lombok.version>
 
     <jersey-version>2.29.1</jersey-version>

--- a/ldap-account-management/pom.xml
+++ b/ldap-account-management/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <name>LDAP users and groups management library</name>
   <properties>
-    <mapstruct.version>1.5.5.Final</mapstruct.version>
+    <mapstruct.version>1.6.0</mapstruct.version>
   </properties>
   <dependencies>
     <!-- geOrchestra commons -->

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
     <skipUT>false</skipUT>
     <!-- flag to disable integration tests -->
     <skipIT>false</skipIT>
-    <gt.version>26.4</gt.version>
+    <gt.version>29.5</gt.version>
     <guava.version>33.2.1-jre</guava.version>
     <lombok.version>1.18.22</lombok.version>
-    <postgres.version>42.4.3</postgres.version>
+    <postgres.version>42.7.4</postgres.version>
     <json.version>20180813</json.version>
     <camel.version>2.25.0</camel.version>
     <camel-extras.version>2.14.1</camel-extras.version>
@@ -130,7 +130,7 @@
       <dependency>
         <groupId>com.mchange</groupId>
         <artifactId>c3p0</artifactId>
-        <version>0.9.5.5</version>
+        <version>0.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
@@ -480,7 +480,7 @@
       <dependency>
         <groupId>com.itextpdf</groupId>
         <artifactId>itextpdf</artifactId>
-        <version>5.5.13.3</version>
+        <version>5.5.13.4</version>
       </dependency>
       <!-- REVISIT: are the following two the same but different versions? -->
       <dependency>
@@ -784,7 +784,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.5.2</version>
+        <version>2.7</version>
         <configuration>
           <check />
           <formats>


### PR DESCRIPTION
- org.ldaptive : 1.0.3 -> 1.3.3
- cobertura-maven-plugin : 2.5.2 -> 2.7
- mapstruct : 1.5.5-Final -> 1.6.0
- geotools : 26.4 -> 29.5
- postgres : 42.4.3 -> 42.7.4
- com.mchange.c3p0 : 0.9.5 -> 0.10.1
- com.itextpdf : 5.5.13.3 -> 5.5.13.4

Closes :
- #4297 
- #4314
- #4313
- #4312 
- #3906 
- 
