### PR TITLE
User link for oauth users available in admin logs

### DIFF
--- a/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
+++ b/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
@@ -63,13 +63,9 @@ public class RabbitmqEventsListener implements MessageListener {
                         providerName, providerUid, organization, true);
 
                 synReceivedMessageUid.add(uid);
-                logUtils.createOAuth2Log(email, AdminLogType.OAUTH2_USER_CREATED, null);
+                logUtils.createOAuth2Log(localUid, AdminLogType.OAUTH2_USER_CREATED, null);
                 rabbitmqEventsSender.sendAcknowledgementMessageToGateway(
                         "new OAuth2 account creation notification for " + email + " has been received by console");
-            } catch (DataServiceException e) {
-                throw new RuntimeException(e);
-            } catch (MessagingException e) {
-                throw new RuntimeException(e);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
When an external account is created, logs in console doesn't have links because the target is the email and not the user local name. 

In [logger.es6](https://github.com/georchestra/georchestra/blob/master/console/src/main/webapp/manager/app/components/logger/logger.es6#L173), it needs to be inside users to get the right match