### PR TITLE
console - small issue for fixing npe in Email.java:122

### DIFF
--- a/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
+++ b/console/src/main/java/org/georchestra/console/events/RabbitmqEventsListener.java
@@ -12,12 +12,14 @@ import org.json.JSONObject;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.context.ServletContextAware;
 
+import javax.servlet.ServletContext;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class RabbitmqEventsListener implements MessageListener {
+public class RabbitmqEventsListener implements MessageListener, ServletContextAware {
 
     private @Autowired @Setter LogUtils logUtils;
 
@@ -28,6 +30,12 @@ public class RabbitmqEventsListener implements MessageListener {
     private @Autowired @Setter EmailFactory emailFactory;
 
     private @Autowired @Setter RabbitmqEventsSender rabbitmqEventsSender;
+
+    private ServletContext context;
+
+    public void setServletContext(ServletContext servletContext) {
+        this.context = servletContext;
+    }
 
     public void onMessage(Message message) {
         String messageBody = new String(message.getBody());
@@ -55,8 +63,8 @@ public class RabbitmqEventsListener implements MessageListener {
                             }
                         }).collect(Collectors.toList());
 
-                this.emailFactory.sendNewOAuth2AccountNotificationEmail(superUserAdmins, fullName, localUid, email,
-                        providerName, providerUid, organization, true);
+                this.emailFactory.sendNewOAuth2AccountNotificationEmail(context, superUserAdmins, fullName, localUid,
+                        email, providerName, providerUid, organization, true);
 
                 logUtils.createOAuth2Log(localUid, AdminLogType.OAUTH2_USER_CREATED, null);
                 rabbitmqEventsSender.sendAcknowledgementMessageToGateway(

--- a/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
+++ b/console/src/main/java/org/georchestra/console/mailservice/EmailFactory.java
@@ -231,14 +231,15 @@ public class EmailFactory {
         email.send(reallySend);
     }
 
-    public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String fullName, String localUid,
-            String emailAddress, String providerName, String providerUid, String userOrg, boolean reallySend)
-            throws MessagingException {
+    public void sendNewOAuth2AccountNotificationEmail(ServletContext context, List<String> recipients, String fullName,
+            String localUid, String emailAddress, String providerName, String providerUid, String userOrg,
+            boolean reallySend) throws MessagingException {
 
         Email email = new Email(recipients, this.newOAuth2AccountNotificationEmailSubject, this.smtpHost, this.smtpPort,
                 this.emailHtml, emailAddress, // Reply-to
                 this.from, this.bodyEncoding, this.subjectEncoding, this.templateEncoding,
-                this.newOAuth2AccountNotificationEmailFile, null, this.georConfig, this.publicUrl, this.instanceName);
+                this.newOAuth2AccountNotificationEmailFile, context, this.georConfig, this.publicUrl,
+                this.instanceName);
         email.set("name", fullName);
         email.set("uid", localUid);
         email.set("email", emailAddress);

--- a/console/src/test/java/org/georchestra/console/integration/RabbitMqEventsIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/RabbitMqEventsIT.java
@@ -19,6 +19,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import javax.mail.MessagingException;
+import javax.servlet.ServletContext;
 import java.util.List;
 import java.util.UUID;
 
@@ -112,9 +113,9 @@ public class RabbitMqEventsIT extends ConsoleIntegrationTest {
         public boolean sendNewOAuth2AccountNotificationEmailCalled = false;
 
         @Override
-        public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String fullName, String localUid,
-                String emailAddress, String providerName, String providerUid, String userOrg, boolean reallySend)
-                throws MessagingException {
+        public void sendNewOAuth2AccountNotificationEmail(ServletContext context, List<String> recipients,
+                String fullName, String localUid, String emailAddress, String providerName, String providerUid,
+                String userOrg, boolean reallySend) throws MessagingException {
             sendNewOAuth2AccountNotificationEmailCalled = true;
         }
     }


### PR DESCRIPTION
As the email factory didn't have servlet context for oauth account creation, it was ending with an NPE in [Email.java:122](https://github.com/georchestra/georchestra/blob/master/console/src/main/java/org/georchestra/console/mailservice/Email.java#L122)