### PR TITLE
console - rework rabbitMQ integration (#4330)

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -272,13 +272,8 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.amqp</groupId>
-      <artifactId>spring-amqp</artifactId>
-      <version>2.3.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.amqp</groupId>
       <artifactId>spring-rabbit</artifactId>
-      <version>1.1.1.RELEASE</version>
+      <version>1.7.12.RELEASE</version>
     </dependency>
     <!-- commons -->
     <dependency>
@@ -418,6 +413,12 @@
     <dependency>
       <groupId>org.georchestra</groupId>
       <artifactId>georchestra-testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>rabbitmq</artifactId>
+      <version>1.16.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -582,7 +583,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <!-- fork to avoid system properties for different ITs stepping onto each other -->
-          <forkCount>2</forkCount>
+          <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
         </configuration>
       </plugin>

--- a/console/src/test/java/org/georchestra/console/integration/RabbitMqEventsIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/RabbitMqEventsIT.java
@@ -1,0 +1,121 @@
+package org.georchestra.console.integration;
+
+import org.georchestra.console.events.RabbitmqEventsListener;
+import org.georchestra.console.events.RabbitmqEventsSender;
+import org.georchestra.console.mailservice.EmailFactory;
+import org.json.JSONObject;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.mail.MessagingException;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+@RunWith(SpringRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = { "classpath:/webmvc-config-test.xml" })
+@TestPropertySource(properties = { "enableRabbitmqEvents = true" })
+public class RabbitMqEventsIT extends ConsoleIntegrationTest {
+
+    public static RabbitMQContainer rabbitmq = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.12"));
+
+    public @Rule @Autowired IntegrationTestSupport support;
+
+    @Autowired
+    private CachingConnectionFactory rabbitFactory;
+    @Autowired
+    private RabbitmqEventsListener eventsListener;
+    @Autowired
+    private AmqpTemplate eventTemplate;
+
+    private static AmqpAdmin admin;
+
+    private static final MockEmailFactory emailFactory = new MockEmailFactory();
+
+    @BeforeClass
+    public static void setUpClass() {
+        rabbitmq.start();
+        System.setProperty("rabbitmqHost", "localhost");
+        System.setProperty("rabbitmqPort", String.valueOf(rabbitmq.getAmqpPort()));
+        System.setProperty("rabbitmqUser", rabbitmq.getAdminUsername());
+        System.setProperty("rabbitmqPassword", rabbitmq.getAdminPassword());
+        System.setProperty("pgsqlPort", System.getProperty("jdbc.port"));
+
+        // This is normally configured by the geOrchestra gateway, see
+        // *
+        // https://github.com/georchestra/georchestra-gateway/blob/main/gateway/src/main/resources/rabbit-listener-context.xml
+        // *
+        // https://github.com/georchestra/georchestra-gateway/blob/main/gateway/src/main/resources/rabbit-sender-context.xml
+
+        CachingConnectionFactory fac = new CachingConnectionFactory("localhost", rabbitmq.getAmqpPort());
+        admin = new RabbitAdmin(fac);
+        TopicExchange ex = new TopicExchange("OAUTH2-EXCHANGE-GATEWAY");
+        admin.declareExchange(ex);
+        Queue q = new AnonymousQueue();
+        admin.declareQueue(q);
+        Binding b = BindingBuilder.bind(q).to(ex).with("routing-console");
+        admin.declareBinding(b);
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        rabbitmq.stop();
+    }
+
+    @Before
+    public void before() {
+        // the test should success and stop everything before giving a chance to send an
+        // event to the gateway via rabbitMq, mocking the object sounds good enough
+        // here.
+        eventsListener.setRabbitmqEventsSender(Mockito.mock(RabbitmqEventsSender.class));
+        eventsListener.setEmailFactory(emailFactory);
+
+    }
+
+    public @Test void testReceiveEvent() {
+        sendGatewayOauth2MessageCreationToRabbitMq();
+
+        await().atMost(30, SECONDS).until(() -> {
+            return emailFactory.sendNewOAuth2AccountNotificationEmailCalled;
+        });
+    }
+
+    private void sendGatewayOauth2MessageCreationToRabbitMq() {
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("uid", UUID.randomUUID());
+        jsonObj.put("subject", "OAUTH2-ACCOUNT-CREATION");
+        jsonObj.put("fullName", "flup");
+        jsonObj.put("localUid", "aaa");
+        jsonObj.put("email", "martinh@thefiddlingcompany.com");
+        jsonObj.put("organization", "thefiddlingcompany");
+        jsonObj.put("providerName", "myoauth2provider");
+        jsonObj.put("providerUid", "martinhoauth2");
+
+        eventTemplate.convertAndSend("OAUTH2-EXCHANGE", "routing-gateway", jsonObj.toString());
+    }
+
+    private static class MockEmailFactory extends EmailFactory {
+        public boolean sendNewOAuth2AccountNotificationEmailCalled = false;
+
+        @Override
+        public void sendNewOAuth2AccountNotificationEmail(List<String> recipients, String fullName, String localUid,
+                String emailAddress, String providerName, String providerUid, String userOrg, boolean reallySend)
+                throws MessagingException {
+            sendNewOAuth2AccountNotificationEmailCalled = true;
+        }
+    }
+}

--- a/console/src/test/java/org/georchestra/console/integration/autoconfiguration/RabbitMqAutoconfigurationIT.java
+++ b/console/src/test/java/org/georchestra/console/integration/autoconfiguration/RabbitMqAutoconfigurationIT.java
@@ -36,4 +36,5 @@ public class RabbitMqAutoconfigurationIT extends ConsoleIntegrationTest {
         assertEquals(rabbitFactory.getHost(), "my-rabbit");
         assertEquals(rabbitFactory.getPort(), 1234);
     }
+
 }


### PR DESCRIPTION
### 1. Fixing version mismatch between dependencies in the pom

Some weeks ago, a version bump of `spring-amqp` broke the rabbitmq integration (see CICD of the gateway and
https://github.com/georchestra/georchestra-gateway/issues/143 for the details). While digging into the issue, it turned out that PR #4295 upgraded the dependency to a version non compatible with `spring-rabbitmq`, which generated a docker image for the console which won't be viable in regards to the rabbitmq integration.

spring-rabbitmq already depends on spring-amqp, which by the way should be forced into a specific version somewhere else. Sticking to 1.7.12.RELEASE of spring-rabbit, so that we keep a compatible version with amqp, and removing the explicit dependency to spring-amqp.

### 2. Rework console message consumption

When a user account from a third-party oauth2 identity provider is saved into the LDAP (at first connection through the gateway), a message is sent via rabbitMq and consumed by the console.

In order to avoid consumption of the same message several times, a `Set<String>` was created as a static member of the `RabbitmqEventsListener` class. But if an exception popped before reaching the call to add the message uid to the list, then the `onMessage` method was then called once again, in a kind of (aggressive) infinite loop.

We had some issues with the console service recently on one of our infrastructure, and we suspect that this behaviour generated a huge amount of unecessary logs because of this infinite loop.

This PR suggests to rewrite the `onMessage()` in the following way:

* removing the `Set<String>` (what will it look like in some centuries of console uptime ?)
* log the error to the logs
* discards the message (by simply returning from the `onMessage()` without throwing any exception)

### 3. tests

Added an integration test (along with a dependency against testcontainers).

Actually adding this new IT  was the reason leading me to the 2. above. And by running the testsuite with maven instead of directly the test into my IDE, I stumbled upon this: https://github.com/georchestra/georchestra/blob/master/console/pom.xml#L584-L585 but could not figure out how limiting forks to 2 was a way to avoid race conditions, as it is enough to already get IT stepping onto each other. Fact is the ports / hostnames being used by the testcontainers are passed using `system.setProperties()` calls before being consumed into the spring xml definition files, and having 2 tests running in parallel is already enough to trigger a race condition, targetting the wrong docker containers. Best way to workaround this would be to use a `DynamicPropertySource`, but it does not exist yet in the spring version being used here ... :(

### 4. Caveats

we are late on the spring-amqp/rabbit version (and spring version generally speaking), but at least we will have a test ready when we will go for a version bump.