### PR TITLE
Hide user list in edit user details conditionnaly.

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -80,7 +80,7 @@ public class EditUserDetailsFormController {
     @Setter
     private @Value("${gdpr.allowAccountDeletion:true}") Boolean gdprAllowAccountDeletion;
 
-    private @Value("${gdpr.displayMemberList:false}") Boolean displayMemberList;
+    private @Value("${gdpr.displayMemberList:false}") boolean displayMemberList;
 
     @Autowired
     protected LogUtils logUtils;

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import lombok.Setter;
 import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.console.ws.utils.LogUtils;
 import org.georchestra.console.ws.utils.PasswordUtils;
@@ -76,17 +77,16 @@ public class EditUserDetailsFormController {
 
     private Validation validation;
 
+    @Setter
     private @Value("${gdpr.allowAccountDeletion:true}") Boolean gdprAllowAccountDeletion;
+
+    private @Value("${gdpr.displayMemberList:false}") Boolean displayMemberList;
 
     @Autowired
     protected LogUtils logUtils;
 
     @Autowired
     protected PasswordUtils passwordUtils;
-
-    public void setGdprAllowAccountDeletion(Boolean gdprAllowAccountDeletion) {
-        this.gdprAllowAccountDeletion = gdprAllowAccountDeletion;
-    }
 
     @Autowired
     public EditUserDetailsFormController(AccountDao dao, OrgsDao orgsDao, RoleDao roleDao, Validation validation) {
@@ -282,9 +282,11 @@ public class EditUserDetailsFormController {
 
         ObjectNode jsonOrg = objectMapper.valueToTree(org);
         jsonOrg.replace("members",
-                org.getMembers().stream().map(x -> uncheckedFindAccountByUID(x, objectMapper)).collect(
-                        () -> new ArrayNode(objectMapper.getNodeFactory()),
-                        (col, elem) -> col.add(elem.retain("sn", "givenName")), (col1, col2) -> col1.addAll(col2)));
+                displayMemberList
+                        ? org.getMembers().stream().map(x -> uncheckedFindAccountByUID(x, objectMapper)).collect(
+                                () -> new ArrayNode(objectMapper.getNodeFactory()),
+                                (col, elem) -> col.add(elem.retain("sn", "givenName")), ArrayNode::addAll)
+                        : objectMapper.createArrayNode());
         return jsonOrg;
     }
 

--- a/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/edituserdetails/EditUserDetailsFormController.java
@@ -80,7 +80,7 @@ public class EditUserDetailsFormController {
     @Setter
     private @Value("${gdpr.allowAccountDeletion:true}") Boolean gdprAllowAccountDeletion;
 
-    private @Value("${gdpr.displayMemberList:false}") boolean displayMemberList;
+    private @Value("${gdpr.displayMembersList:false}") boolean displayMembersList;
 
     @Autowired
     protected LogUtils logUtils;
@@ -282,7 +282,7 @@ public class EditUserDetailsFormController {
 
         ObjectNode jsonOrg = objectMapper.valueToTree(org);
         jsonOrg.replace("members",
-                displayMemberList
+                displayMembersList
                         ? org.getMembers().stream().map(x -> uncheckedFindAccountByUID(x, objectMapper)).collect(
                                 () -> new ArrayNode(objectMapper.getNodeFactory()),
                                 (col, elem) -> col.add(elem.retain("sn", "givenName")), ArrayNode::addAll)

--- a/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editUserDetailsForm.jsp
@@ -248,9 +248,9 @@ var gdprAllowAccountDeletion = ${gdprAllowAccountDeletion};
         <br>
       </c:if>
 
-      <h4><s:message code="editUserDetailsForm.members"/> <span
+      <h4 ng-if="users.length > 0"><s:message code="editUserDetailsForm.members"/> <span
           class="badge">{{ users.length }}</span></h4>
-      <ul>
+      <ul ng-if="users.length > 0">
         <li dir-paginate="user in users | itemsPerPage: 10">
           {{::user.sn}} {{::user.givenName}}
         </li>


### PR DESCRIPTION
Introduce a new configuration parameter in 24.0.x and upper :
`gdpr.displayMemberList=false/true` by default `false`

If users are empty, doesn't display the list in editUserDetailsForm.