### PR TITLE
datafeeder - Don't override conf and warn if local and geoserver schema are desync

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
@@ -24,10 +24,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import javax.sql.DataSource;
 
@@ -176,7 +173,8 @@ public class GeorchestraDataBackendService implements DataBackendService {
     }
 
     public @VisibleForTesting Map<String, String> resolveConnectionParams(@NonNull UserInfo user) {
-        Map<String, String> connectionParams = props.getPublishing().getBackend().getLocal();
+        Map<String, String> connectionParams = new HashMap<>(
+                props.getPublishing().getBackend().getLocal());
         Organization org = user.getOrganization();
         String orgName = org == null ? null : org.getShortName();
         if (orgName == null) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraDataBackendService.java
@@ -173,8 +173,7 @@ public class GeorchestraDataBackendService implements DataBackendService {
     }
 
     public @VisibleForTesting Map<String, String> resolveConnectionParams(@NonNull UserInfo user) {
-        Map<String, String> connectionParams = new HashMap<>(
-                props.getPublishing().getBackend().getLocal());
+        Map<String, String> connectionParams = new HashMap<>(props.getPublishing().getBackend().getLocal());
         Organization org = user.getOrganization();
         String orgName = org == null ? null : org.getShortName();
         if (orgName == null) {

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraOwsPublicationService.java
@@ -105,6 +105,10 @@ public class GeorchestraOwsPublicationService implements OWSPublicationService {
                 "importedName is required to resolve the native feature type name");
 
         final Map<String, String> geoserverConfig = this.configProperties.getPublishing().getBackend().getGeoserver();
+        final String localSchema = this.configProperties.getPublishing().getBackend().getLocal().get("schema");
+        if (!Objects.equals(localSchema, geoserverConfig.get("schema"))) {
+            log.warn("Local schema {} does not match geoserver schema {}", localSchema, geoserverConfig.get("schema"));
+        }
         final String workspaceName = resolveWorkspace(user, geoserverConfig.get("workspacename"));
         final String dataStoreName = nameResolver.resolveDataStoreName(workspaceName, geoserverConfig.get("storename"));
         final String publishedLayerName = resolveUniqueLayerName(workspaceName, publishing.getPublishedName());


### PR DESCRIPTION
If `datafeeder.publishing.backend.local.schema=public` and `datafeeder.publishing.backend.geoserver.schema=<schema>` are unsync, it may crash beacause geoserver tries to get the data in another schema. It results of DF frontend showing the error, "Is this valid geo data ?", and backend showing an error on geoserver featuretypes which has no attributes.

Also create a new Hashmap to avoid erasing connectionParams.

Solves #4343