### PR TITLE
update geoserver to 2.26.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "geoserver/geoserver-submodule"]
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
-	branch = 2.25.x-georchestra
+	branch = 2.26.1-georchestra

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,17 +8,17 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.25.2</gs.version>
-    <gt.version>31.2</gt.version>
+    <gs.version>2.26.1</gs.version>
+    <gt.version>32.1</gt.version>
     <geofence.version>3.5.1</geofence.version>
-    <jetty.version>9.4.52.v20230823</jetty.version>
-    <marlin.version>0.9.3</marlin.version>
-    <jackson2.version>2.15.2</jackson2.version>
+    <jetty.version>9.4.56.v20240826</jetty.version>
+    <marlin.version>0.9.4.8</marlin.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.3.34</spring.version>
-    <spring.security.version>5.7.12</spring.security.version>
+    <spring.version>5.3.39</spring.version>
+    <spring.security.version>5.8.15</spring.security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--
     <commons-beanutils.version>1.8.0</commons-beanutils.version>


### PR DESCRIPTION
see:
- https://geoserver.org/announcements/vulnerability/2024/09/18/geoserver-2-26-0-released.html for branch details, this release was also a security release.
- https://geoserver.org/announcements/vulnerability/2024/11/18/geoserver-2-26-1-released.html which had a high CVE (no details published yet, cf https://osgeo-org.atlassian.net/browse/GEOS-11557)
- that CVE affects the 2.25.2 we're shipping now, it's been fixed in https://geoserver.org/announcements/vulnerability/2024/10/29/geoserver-2-25-4-released.html

 
To note there from those, maybe https://osgeo-org.atlassian.net/browse/GEOS-11612 could impact the way we build urls from headers ? https://github.com/geoserver/geoserver/wiki/GSIP-229 will have impact but that's not in 2.26.1.

i pondered updating to 2.25.5 but https://geoserver.org/announcements/2024/12/18/geoserver-2-25-5-released.html says:
> The final release of the 2.25 series is planned for February 2025, please start making plans for an upgrade to 2.26.x or newer.

so we might aswell update 24.0.x branch with it too.

note that i didnt take the tip of 2.26.x branch since https://github.com/geoserver/geoserver/pull/8155 was merged in the meantime, and it reformats the whole codebase so applying our patches on top will need a bit more time :)

i know theres georchestra/geoserver#38 in the works but it will be easy to apply on top.

the `2.26.1-georchestra` branch i've pushed on https://github.com/georchestra/geoserver/branches has been done this way (im documenting that for future myself):
- checkout the parent of https://github.com/geoserver/geoserver/releases/tag/2.26.1 (which isnt on github) and branch from it
```
landry@.../georchestra/geoserver/geoserver-submodule $git checkout 60c5e045 # parent commit of tag 2.26.1
landry@.../georchestra/geoserver/geoserver-submodule $git switch -c 2.26.1-georchestra
Switched to a new branch '2.26.1-georchestra'
```
- replicate the tag -> produces georchestra/geoserver@4ac3e2129d:
```
landry@.../georchestra/geoserver/geoserver-submodule $find . -name pom.xml -exec sed -i 's/2.26-SNAPSHOT/2.26.1/g' {} \;
landry@.../georchestra/geoserver/geoserver-submodule $git commit -a
[2.26.1-georchestra 4ac3e2129d] updating version numbers and release notes for 2.26.1
 282 files changed, 293 insertions(+), 293 deletions(-)
```
- bump `gt.version` and `gwc.version`, forgotten in previous -> georchestra/geoserver@8677dd983
- reapply the geor customizations from georchestra/geoserver@af88b9cc4 and georchestra/geoserver@fb69309a, trying to use meaningful commit messages from the bits i understood, havent found related commits/PRs (and i looked in all branches up to 2.12..)
  - the filter thing from georchestra/geoserver@772f91e468 -> georchestra/geoserver@af65aceb45
  - reenable CORS for tomcat -> georchestra/geoserver@9731fdc2e79
  - the new geor-header (without keeping the iframe from the previous commits) -> georchestra/geoserver@1ddcec7d824ca
  - set the favicon to root -> georchestra/geoserver@73d982204
  - reapply some fixes/disables for tests -> georchestra/geoserver@c5feded93 and georchestra/geoserver@754240a09c
  - other customizations from .. the past ? georchestra/geoserver@6696e4f5c9 and georchestra/geoserver@ce72ebeac
  - bump version for customized modules -> georchestra/geoserver@815441f28d
- in the parent repo, bump the version for the components in `geoserver/pom.xml`, comparing with `geoserver/geoserver-submodule/src/pom.xml`, and switch the submodule to point to the new branch -> commit 316c6d273

from there, `make deb-build-geoserver` in the toplevel dir produced a debian package i've been able to deploy locally on 24.0.x, which works in my limited testing (login/logout, accessing admin menus, viewing layers with the openlayers format, loading layers in mapstore....) - it still ships the `gs:LongitudinalProfile` used by mapstore's addon but i havent tested it yet. The OGCAPI module is still disabled/not built.

![image](https://github.com/user-attachments/assets/29486dc5-d200-4898-9704-a92fd13775c6)


i also know there's work for ogcapi integration, but afaict this will only happen with 2.27 which is due upstream in 3 months, so in the meantime better get some platforms updated to 2.26 ?