### PR TITLE
update geoserver to 2.26.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "geoserver/geoserver-submodule"]
 	path = geoserver/geoserver-submodule
 	url = https://github.com/georchestra/geoserver.git
-	branch = 2.25.x-georchestra
+	branch = 2.26.2-georchestra

--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,17 +8,17 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.25.2</gs.version>
-    <gt.version>31.2</gt.version>
+    <gs.version>2.26.2</gs.version>
+    <gt.version>32.2</gt.version>
     <geofence.version>3.5.1</geofence.version>
-    <jetty.version>9.4.52.v20230823</jetty.version>
-    <marlin.version>0.9.3</marlin.version>
-    <jackson2.version>2.15.2</jackson2.version>
+    <jetty.version>9.4.57.v20241219</jetty.version>
+    <marlin.version>0.9.4.8</marlin.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->
-    <spring.version>5.3.34</spring.version>
-    <spring.security.version>5.7.12</spring.security.version>
+    <spring.version>5.3.39</spring.version>
+    <spring.security.version>5.8.16</spring.security.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
 <!--
     <commons-beanutils.version>1.8.0</commons-beanutils.version>


### PR DESCRIPTION
https://geoserver.org/announcements/vulnerability/2025/01/27/geoserver-2-26-2-released.html

takes the work done in #4378, and manually reapplies the custom commits to our branch, manually because  https://github.com/geoserver/geoserver/wiki/GSIP-228 was applied in 2.26.x since 2.26.1

same steps:
- checkout the parent of https://github.com/geoserver/geoserver/releases/tag/2.26.2
```
[28/01 10:28] .../georchestra/geoserver/geoserver-submodule $git checkout 5afdbaeb5
```
- create a branch
```
[28/01 10:29] .../georchestra/geoserver/geoserver-submodule $git switch -c 2.26.2-georchestra
Switched to a new branch '2.26.2-georchestra'
```
- recreate the commit for the upstream tag/release -> georchestra/geoserver@8846e30ab1
```
[28/01 10:31] .../georchestra/geoserver/geoserver-submodule $
    find . -name pom.xml -exec sed -i 's/2.26-SNAPSHOT/2.26.2/g' {} \;
    sed -i 's/-SNAPSHOT/.2/' src/pom.xml
```
- reapply our commits:
  - spring fix from @f-necas : georchestra/geoserver@36229b16e
  - webcomponent header: georchestra/geoserver@90573f7056 
  - ignore login form tests: georchestra/geoserver@799c177bd8
  - gwc: bump maximumSize to 400: georchestra/geoserver@ecc0a6d8bb 
  - dont bump updateSequence if we're currently reloading config: georchestra/geoserver@6f5d46b318 
  - fix failing test: georchestra/geoserver@7cfd13f937
  - bump version to 2.26.2-georchestra: georchestra/geoserver@4964351ef7 
  - code reformat by palantir : georchestra/geoserver@6e517dfd68 
  - feat: set favicon to root: georchestra/geoserver@059b01670d

and bump the submodule: f8ae0cc5

builds and runs fine here in extremely limited testing:

![image](https://github.com/user-attachments/assets/bb1780ac-1436-4c44-aa43-4ee02707d53e)

to note: https://github.com/geoserver/geoserver/wiki/GSIP-229 might have impacts if enabled.