### PR TITLE
fix: GS - bump GS version

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -30,6 +30,7 @@
     <module>geoserver-submodule/src/restconfig</module>
     <module>geoserver-submodule/src/gwc</module>
     <module>geoserver-submodule/src/web/core</module>
+    <module>geoserver-submodule/src/wms</module>
     <!-- this ones are not provided onto the osgeo m2 repo -->
     <module>geoserver-submodule/src/extension/wmts-multi-dimensional</module>
     <module>geoserver-submodule/src/community/ogcapi</module>

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms</artifactId>
-      <version>${gs.version}</version>
+      <version>${gs.version}-georchestra</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>


### PR DESCRIPTION
This PR ensures we integrate the following one:
https://github.com/georchestra/geoserver/pull/39

tests: compilation + decompiled the gs-wms module in the generated GS webapp, to make sure the added `EntityResolver` is indeed being used for entity resolution.