### PR TITLE
add the wfs-freemarker geoserver extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Docker related targets
 
-GEOSERVER_EXTENSION_PROFILES=wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,jp2k,authkey,mapstore2,mbstyle,web-resource,sldservice,geopkg-output
+GEOSERVER_EXTENSION_PROFILES=wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,jp2k,authkey,mapstore2,mbstyle,web-resource,sldservice,geopkg-output,wfs-freemarker
 BTAG=latest
 
 docker-pull-jetty:

--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -355,6 +355,16 @@
       </dependencies>
     </profile>
     <profile>
+      <id>wfs-freemarker</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-wfs-freemarker</artifactId>
+          <version>${gs.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>geopkg</id>
       <dependencies>
         <dependency>


### PR DESCRIPTION
this is used by mapstore 2024.02 since geosolutions-it/MapStore2#10233

to ensure this is enabled, the *HTML* format is available in the list of WFS formats in the layer preview:

![image](https://github.com/user-attachments/assets/b3d3db99-0dcf-4206-a6a5-2ee029fac0b1)
