### PR TITLE
Enhance Docker setup for GeoWebCache with configurable data directories

### DIFF
--- a/geowebcache-webapp/src/docker/Dockerfile
+++ b/geowebcache-webapp/src/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM jetty:9.4.46-jre11
 
-ENV XMS=1G XMX=2G
+ENV XMS=1G \
+    XMX=2G \
+    GEOWEBCACHE_CONFIG_DIR=/mnt/geowebcache_datadir \
+    GEOWEBCACHE_CACHE_DIR=/mnt/geowebcache_tiles
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
@@ -24,8 +27,6 @@ ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Dgeorchestra.datadir=/etc/georchestra \
--DGEOWEBCACHE_CONFIG_DIR=/mnt/geowebcache_datadir \
--DGEOWEBCACHE_CACHE_DIR=/mnt/geowebcache_tiles \
 -Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
 ${JAVA_OPTIONS} \

--- a/geowebcache-webapp/src/docker/docker-entrypoint.d/00-geowebcache-bootstrap
+++ b/geowebcache-webapp/src/docker/docker-entrypoint.d/00-geowebcache-bootstrap
@@ -1,10 +1,26 @@
 #!/bin/bash
 
-if [ -f /mnt/geowebcache_datadir/geowebcache.xml ]
-then
-    echo 'Datadir already initialized'
-else
-    echo 'Initializing datadir'
+# Check if GEOWEBCACHE_CONFIG_DIR is defined and points to a valid directory
+if [ -z "$GEOWEBCACHE_CONFIG_DIR" ]; then
+    echo "Error: GEOWEBCACHE_CONFIG_DIR is not defined."
+    exit 1
+elif [ ! -d "$GEOWEBCACHE_CONFIG_DIR" ]; then
+    echo "Error: GEOWEBCACHE_CONFIG_DIR ('$GEOWEBCACHE_CONFIG_DIR') is not a directory."
+    exit 1
+fi
 
-    cp /docker-entrypoint.d/geowebcache.xml /mnt/geowebcache_datadir/
+# Check if geowebcache.xml already exists
+if [ -f "$GEOWEBCACHE_CONFIG_DIR/geowebcache.xml" ]; then
+    echo 'Datadir already initialized:' "$GEOWEBCACHE_CONFIG_DIR"
+else
+    echo 'Initializing datadir:' "$GEOWEBCACHE_CONFIG_DIR"
+
+    # Check if the directory is writable
+    if [ -w "$GEOWEBCACHE_CONFIG_DIR" ]; then
+        cp /docker-entrypoint.d/geowebcache.xml "$GEOWEBCACHE_CONFIG_DIR/"
+        echo 'Datadir initialization complete.'
+    else
+        echo "Error: Directory '$GEOWEBCACHE_CONFIG_DIR' is not writable."
+        exit 1
+    fi
 fi


### PR DESCRIPTION
This commit improves the Docker configuration for GeoWebCache by introducing environment variables for directory paths and enhancing initialization scripts to handle errors more gracefully.

1. **Dockerfile Updates**:
   - Added environment variables: - `GEOWEBCACHE_CONFIG_DIR` (default: `/mnt/geowebcache_datadir`) - `GEOWEBCACHE_CACHE_DIR` (default: `/mnt/geowebcache_tiles`)
   - Removed hardcoded directory references from the `CMD` instruction, relying on environment variables instead.

2. **Improved Datadir Initialization Script (`00-geowebcache-bootstrap`)**:
   - Added checks to ensure `GEOWEBCACHE_CONFIG_DIR` is defined and points to a valid directory.
   - Added a writable check to prevent failures when the target directory is not writable.
   - Enhanced error handling with appropriate error messages and non-zero exit codes.

- **Flexibility**: The configuration and cache directories are now configurable via environment variables, making it easier to adapt to different environments.
- **Improved Error Handling**: The initialization script validates critical conditions, such as directory existence and permissions, before proceeding.
- **Simplified Maintenance**: Hardcoded paths have been replaced by environment variables, reducing redundancy and simplifying updates.

These changes enhance both the usability and reliability of the Docker setup for GeoWebCache.