### PR TITLE
Upgrade GeoWebCache webapp to 1.26-SNAPSHOT

### DIFF
--- a/geowebcache-webapp/pom.xml
+++ b/geowebcache-webapp/pom.xml
@@ -17,11 +17,12 @@
     <gwc.unpack.dir>${project.build.directory}/unpacked-webapp</gwc.unpack.dir>
     <geowebcache.war.excludes />
     <maven.test.skip>false</maven.test.skip>
-    <spring.version>5.3.32</spring.version>
-    <spring-security.version>5.7.11</spring-security.version>
-    <gwc.version>1.25.2</gwc.version>
-    <gt.version>31.2</gt.version><!-- must match the version used by gwc@gwc.version -->
-    <hazelcast.version>5.3.6</hazelcast.version>
+    <gwc.version>1.26-SNAPSHOT</gwc.version>
+    <!-- override dependencies from parent pom to match the ones for the gwc version -->
+    <gt.version>32-SNAPSHOT</gt.version>
+    <spring.version>5.3.39</spring.version>
+    <spring-security.version>5.7.12</spring-security.version>
+    <hazelcast.version>5.3.8</hazelcast.version>
     <context.name>geowebcache</context.name>
     <packageDatadirScmVersion>master</packageDatadirScmVersion>
 


### PR DESCRIPTION

@pmauduit help. I don't know why I'm getting this error about resolving `instanceName`. Does it ring a bell?

```shell
make docker-build-geowebcache
...
docker run --rm --name gwc --env "GEOWEBCACHE_CONFIG_DIR=/var/run" \
--mount type=bind,src=./geowebcache-webapp/src/docker/docker-entrypoint.d/geowebcache.xml,dst=/var/run/geowebcache.xml,readonly \
georchestra/geowebcache:latest

run-parts: executing /docker-entrypoint.d/00-geowebcache-bootstrap
Datadir already initialized: /var/run
...
2025-02-24 19:39:08.845:INFO:oejshC.geowebcache:main: Initializing Spring root WebApplicationContext
19:39:09.331 [main] ERROR org.springframework.web.context.ContextLoader - Context initialization failed
org.springframework.beans.factory.BeanDefinitionStoreException: Invalid bean definition with name 'geowebcacheDispatcher' defined in ServletContext resource [/WEB-INF/geowebcache-georchestra.xml]: Could not resolve placeholder 'instanceName' in value "${instanceName}"; nested exception is java.lang.IllegalArgumentException: Could not resolve placeholder 'instanceName' in value "${instanceName}"
	at org.springframework.beans.factory.config.PlaceholderConfigurerSupport.doProcessProperties(PlaceholderConfigurerSupport.java:230) ~[spring-beans-5.3.39.jar:5.3.39]
...
Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'instanceName' in value "${instanceName}"
	at org.springframework.util.PropertyPlaceholderHelper.parseStringValue(PropertyPlaceholderHelper.java:180) ~[spring-core-5.3.39.jar:5.3.39]
	at org.springframework.util.PropertyPlaceholderHelper.replacePlaceholders(PropertyPlaceholderHelper.java:126) ~[spring-core-5.3.39.jar:5.3.39]
	at org.springframework.beans.factory.config.PropertyPlaceholderConfigurer$PlaceholderResolvingStringValueResolver.resolveStringValue(PropertyPlaceholderConfigurer.java:230) ~[spring-beans-5.3.39.jar:5.3.39]
	at org.springframework.beans.factory.config.BeanDefinitionVisitor.resolveStringValue(BeanDefinitionVisitor.java:296) 	... 49 more
2025-02-24 19:39:09.339:WARN:oejw.WebAppContext:main: Failed startup of context o.e.j.w.WebAppContext@7ce026d3{GeoWebCache,/geowebcache,file:///var/lib/jetty/webapps/geowebcache/,UNAVAILABLE}{/var/lib/jetty/webapps/geowebcache}
org.springframework.beans.factory.BeanDefinitionStoreException: Invalid bean definition with name 'geowebcacheDispatcher' defined in ServletContext resource [/WEB-INF/geowebcache-georchestra.xml]: Could not resolve placeholder 'instanceName' in value "${instanceName}"; nested exception is java.lang.IllegalArgumentException: Could not resolve placeholder 'instanceName' in value "${instanceName}"
...
Caused by:
java.lang.IllegalArgumentException: Could not resolve placeholder 'instanceName' in value "${instanceName}"
	at org.springframework.util.PropertyPlaceholderHelper.parseStringValue(PropertyPlaceholderHelper.java:180)
	at org.springframework.util.PropertyPlaceholderHelper.replacePlaceholders(PropertyPlaceholderHelper.java:126)
...
```