### PR TITLE
geoserver -  bump to GeOserver 2.25.3

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,12 +8,12 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.25.2</gs.version>
-    <gt.version>31.2</gt.version>
-    <geofence.version>3.5.1</geofence.version>
+    <gs.version>2.25.3</gs.version>
+    <gt.version>31.3</gt.version>
+    <geofence.version>3.7-SNAPSHOT</geofence.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <marlin.version>0.9.3</marlin.version>
-    <jackson2.version>2.15.2</jackson2.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <packageDatadirScmVersion>24.0</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->


### PR DESCRIPTION
Bumps GeoServer to 2.25.3 version.

Main motivation for the bump is to fix this upstream issue: https://osgeo-org.atlassian.net/browse/GEOS-11446

tests: utests OK, runtime tested [into a docker compo](https://github.com/georchestra/sample-docker-composition/tree/main/geoserver) OK