### PR TITLE
feat: gs - bump to 2.25.3 (backport to geOr 23.1.x)

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -8,12 +8,12 @@
   <name>GeoServer 2.x root module</name>
   <properties>
     <skipTests>true</skipTests>
-    <gs.version>2.25.2</gs.version>
-    <gt.version>31.2</gt.version>
-    <geofence.version>3.5.1</geofence.version>
+    <gs.version>2.25.3</gs.version>
+    <gt.version>31.3</gt.version>
+    <geofence.version>3.7-SNAPSHOT</geofence.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <marlin.version>0.9.3</marlin.version>
-    <jackson2.version>2.15.2</jackson2.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <packageDatadirScmVersion>23.0</packageDatadirScmVersion>
     <server>generic</server>
     <!-- overrides the versions provided by spring-boot in the geOrchestra root pom -->


### PR DESCRIPTION
Same as https://github.com/georchestra/georchestra/pull/4417, for 23.1.x.
