### PR TITLE
console: Change logger limit for console dashboard page to improve loading time

### DIFF
--- a/console/src/main/webapp/manager/app/components/logger/logger.es6
+++ b/console/src/main/webapp/manager/app/components/logger/logger.es6
@@ -46,7 +46,7 @@ class LoggerController {
     // manage query params to get user's or complete logs
     let typeQuery = 'Logs'
     const params = {
-      limit: 100000,
+      limit: 100,
       page: 0
     }
     if (this.user) {


### PR DESCRIPTION
Set logger limit to 100 instead of 100000