### PR TITLE
datafeeder: removes suffixes from DF to match names in datahub

### DIFF
--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -131,8 +131,7 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
             }
 
             m.getOnlineResources()
-                    .add(onlineResource(d, databaseTableName, "OGC API - Features",
-                            publishing.getTitle(),
+                    .add(onlineResource(d, databaseTableName, "OGC API - Features", publishing.getTitle(),
                             buildUri(publishingConfiguration.getOgcfeatures().getPublicUrl(),
                                     "/collections/" + databaseTableName + "/items", "")));
         }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -132,7 +132,7 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
 
             m.getOnlineResources()
                     .add(onlineResource(d, databaseTableName, "OGC API - Features",
-                            publishing.getTitle() + " - OGC API Features",
+                            publishing.getTitle(),
                             buildUri(publishingConfiguration.getOgcfeatures().getPublicUrl(),
                                     "/collections/" + databaseTableName + "/items", "")));
         }
@@ -318,14 +318,14 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
 
     private OnlineResource wmsOnlineResource(DatasetUploadState d) {
         String protocol = "OGC:WMS";
-        String description = d.getPublishing().getTitle() + " - WMS";
+        String description = d.getPublishing().getTitle();
         String layerName = d.getPublishing().getPublishedName();
         return onlineResource(d, layerName, protocol, description, buildGeoserverUri(d));
     }
 
     private OnlineResource wfsOnlineResource(DatasetUploadState d) {
         String protocol = "OGC:WFS";
-        String description = d.getPublishing().getTitle() + " - WFS";
+        String description = d.getPublishing().getTitle();
         String layerName = fullyQualifiedLayerName(d.getPublishing());
         return onlineResource(d, layerName, protocol, description, buildGeoserverUri(d));
     }

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/it/GeorchestraMetadataPublicationServiceIT.java
@@ -185,8 +185,8 @@ public class GeorchestraMetadataPublicationServiceIT {
         assertXpath(dom, "MD_Metadata/hierarchyLevel/MD_ScopeCode[@codeListValue='dataset']");
 
         final String title = publishing.getTitle();
-        assertOnlineResource(dom, "OGC:WMS", PUBLISHED_LAYERNAME, title + " - WMS");
-        assertOnlineResource(dom, "OGC:WFS", PUBLISHED_LAYERNAME, title + " - WFS");
+        assertOnlineResource(dom, "OGC:WMS", PUBLISHED_LAYERNAME, title);
+        assertOnlineResource(dom, "OGC:WFS", PUBLISHED_LAYERNAME, title);
 
         URL publicUrl = configProperties.getPublishing().getGeonetwork().getPublicUrl();
         final String uniqueResourceIdentifier = URI.create(publicUrl + "?uuid=" + createdMdId).normalize().toString();
@@ -326,8 +326,8 @@ public class GeorchestraMetadataPublicationServiceIT {
                 "MD_Metadata/dataQualityInfo/DQ_DataQuality/lineage/LI_Lineage/statement/CharacterString[text() = 'Test process description']");
         assertXpath(dom, "MD_Metadata/hierarchyLevel/MD_ScopeCode[@codeListValue='dataset']");
         final String title = publishing.getTitle();
-        assertOnlineResource(dom, "OGC:WMS", PUBLISHED_LAYERNAME, title + " - WMS");
-        assertOnlineResource(dom, "OGC:WFS", PUBLISHED_LAYERNAME, title + " - WFS");
+        assertOnlineResource(dom, "OGC:WMS", PUBLISHED_LAYERNAME, title);
+        assertOnlineResource(dom, "OGC:WFS", PUBLISHED_LAYERNAME, title);
         URL publicUrl = configProperties.getPublishing().getGeonetwork().getPublicUrl();
         final String uniqueResourceIdentifier = URI.create(publicUrl + "?uuid=" + createdMdId).normalize().toString();
         assertXpath(dom,


### PR DESCRIPTION
This PR removes the suffixes (" - WMS", " - WFS", and " - OGC API Features") from online resource descriptions so that they match the names in datahub.

