### PR TITLE
datafeeder - Some improvements on metadata publishing

### DIFF
--- a/datafeeder/README.md
+++ b/datafeeder/README.md
@@ -6,7 +6,8 @@ The separate front-end UI service provides the wizard-like user interface to int
 
 ## Add georchestra/data-api
 
-In order to implement [geOrchestra's data-api](https://github.com/georchestra/data-api) you must implement:
+In order to integrate the Datafeeder with [geOrchestra's data-api](https://github.com/georchestra/data-api), you will have to follow the
+next sections, depending on the version of the data-api you are using.
 
 ### For all data-api versions
 In datafeeder.properties:
@@ -48,35 +49,31 @@ georchestra$ make docker-build-datafeeder
 Use the following maven properties to skip tests and/or integration tests:
 
 * `-DskipTests` skips both unit and integration tests
-* `-DskipITs` skips only integration tests and also avoid launching the docker composition (see section below)
-* `-D-Ddocker-compose.skip=true` avoids running the docker composition (see section below)
+* `-DskipITs` skips only integration tests
 
 ### Integration testing: docker compose
 
-For integration testing, some external services are required. For instance:
+For integration testing, some external services are required:
 - A geOrchestra GeoServer instance
 - A geOrchestra GeoNetwork instance
 - A PostgreSQL database with PostGIS extension, for which we're using geOrchestra's `database` docker image
 
-There is a docker composition with just the required extenal services in the `docker-compose.yml` file.
+There is a docker composition with just the required external services in the `docker-compose.yml` file.
 
-A normal build with no extra aguments (e.g. `mvn verify`) will take care of running the docker composition before the integration tests are run, and shut it down afterwards. This is performed by the `com.dkanejs.maven.plugins:docker-compose-maven-plugin`, launching the composition at maven's `pre-integration-test` phase, and shutting it down during `post-integration-test`.
-
-Since this process may take a while, during development it is desirable to have the composition already running through several runs of the integration tests suite. To do so, launch the composition manually with
+Prior to launch the integration tests, you will have to set up the provided docker
+composition by hand,  as follows:
 
 ```bash
 $ docker-compose -f docker-compose.yml up -d
 ```
 
-With that in place, run the tests as many times as needed from the IDE or the console by enabling the `docker-compose.skip` flag:
+With the services from the composition in place, run the tests as many times as needed from the IDE or the console:
 
 ```bash
-$ mvn verify -Ddocker-compose.skip=true
+$ mvn verify
 ```
 
-so that the `docker-compose-maven-plugin` does not run.
-
-The integration tests ough to be written in a way that support multiple runs without re-initializing the external services state (for example, randomizing database schema names when going to create a schema and such).
+The integration tests ought to be written in a way that support multiple runs without re-initializing the external services state (for example, randomizing database schema names when going to create a schema and such).
 
 ### Build the docker image:
 

--- a/datafeeder/api-geonetwork.yaml
+++ b/datafeeder/api-geonetwork.yaml
@@ -4268,7 +4268,7 @@ paths:
       consumes:
         - application/json
       produces:
-        - '*/*'
+        - application/json
       parameters:
         - name: metadataUuid
           in: path

--- a/datafeeder/docker-compose.yml
+++ b/datafeeder/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
 
   database:
-    image: georchestra/database:24.0.x
+    image: georchestra/database:latest
     environment:
       - POSTGRES_USER=georchestra
       - POSTGRES_PASSWORD=georchestra
@@ -31,7 +31,7 @@ services:
         - SLAPD_LOG_LEVEL=32768 # See https://www.openldap.org/doc/admin24/slapdconfig.html#loglevel%20%3Clevel%3E
 
   console:
-    image: georchestra/console:24.0.x
+    image: georchestra/console:latest
     depends_on:
       - ldap
       - database
@@ -45,7 +45,7 @@ services:
       - "38080:8080"
 
   geoserver:
-    image: georchestra/geoserver:24.0.x
+    image: georchestra/geoserver:latest
     healthcheck:
       test: [ "CMD-SHELL", "curl -s -f http://localhost:8080/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities >/dev/null || exit 1" ]
       interval: 30s
@@ -62,7 +62,7 @@ services:
       - "18080:8080"
 
   geonetwork:
-    image: georchestra/geonetwork:24.0.x
+    image: georchestra/geonetwork:latest
     healthcheck:
       test: [ "CMD-SHELL", "curl -s -f http://localhost:8080/geonetwork/srv/eng/catalog.search >/dev/null || exit 1" ]
       interval: 30s

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -92,6 +92,12 @@ public @Data class DataFeederConfigurationProperties {
         private URI templateTransform;
         private String defaultResourceType = "dataset";
         private boolean publishMetadata = true;
+        // Sets the GeoNetwork group synchronization mode, defaults to "orgs".
+        // should be set to "roles" if a role-based synch is configured GeoNetwork-side.
+        //
+        // See:
+        // https://github.com/georchestra/datadir/blob/master/geonetwork/geonetwork.properties#L25-L32
+        private String syncMode = "orgs";
     }
 
     @Data

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/config/DataFeederConfigurationProperties.java
@@ -91,6 +91,7 @@ public @Data class DataFeederConfigurationProperties {
         private URI templateRecord;
         private URI templateTransform;
         private String defaultResourceType = "dataset";
+        private boolean publishMetadata = true;
     }
 
     @Data

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
@@ -36,7 +36,7 @@ public interface GeoNetworkClient {
     void checkServiceAvailable() throws IOException;
 
     GeoNetworkResponse putXmlRecord(@NonNull String metadataId, @NonNull String xmlRecord, String groupName,
-            UserInfo user, Boolean publishToAll);
+            UserInfo user, Boolean publishToAll, Boolean orgBasedSync);
 
     String getXmlRecord(@NonNull String recordId);
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkClient.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.util.Map;
 
 import lombok.NonNull;
+import org.georchestra.datafeeder.model.UserInfo;
 
 public interface GeoNetworkClient {
 
@@ -34,7 +35,8 @@ public interface GeoNetworkClient {
 
     void checkServiceAvailable() throws IOException;
 
-    GeoNetworkResponse putXmlRecord(@NonNull String metadataId, @NonNull String xmlRecord, String groupName);
+    GeoNetworkResponse putXmlRecord(@NonNull String metadataId, @NonNull String xmlRecord, String groupName,
+            UserInfo user, Boolean publishToAll);
 
     String getXmlRecord(@NonNull String recordId);
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.ExternalApiConfiguration;
+import org.georchestra.datafeeder.model.UserInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -114,10 +115,10 @@ public class GeoNetworkRemoteService {
      * @return
      */
     public GeoNetworkResponse publish(@NonNull String metadataId, @NonNull Supplier<String> xmlRecordAsString,
-            String group) {
+            String group, UserInfo user, Boolean actuallyPublish) {
         final String xmlRecord = xmlRecordAsString.get();
 
-        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord, group);
+        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord, group, user, actuallyPublish);
 
         HttpStatus statusCode = response.getStatus();
         String statusText = response.getStatusText();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteService.java
@@ -115,10 +115,11 @@ public class GeoNetworkRemoteService {
      * @return
      */
     public GeoNetworkResponse publish(@NonNull String metadataId, @NonNull Supplier<String> xmlRecordAsString,
-            String group, UserInfo user, Boolean actuallyPublish) {
+            String group, UserInfo user, Boolean actuallyPublish, Boolean orgBasedSync) {
         final String xmlRecord = xmlRecordAsString.get();
 
-        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord, group, user, actuallyPublish);
+        GeoNetworkResponse response = client.putXmlRecord(metadataId, xmlRecord, group, user, actuallyPublish,
+                orgBasedSync);
 
         HttpStatus statusCode = response.getStatus();
         String statusText = response.getStatusText();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -96,14 +96,21 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
 
         Supplier<String> record = templateMapper.apply(mdProps);
         Organization organization = user.getOrganization();
+        // In case of organization-based synchronization in GeoNetwork:
+        //
         // The metadata is inserted into the group which already exists due to
         // GeoNetwork's LDAP sync (which currently guarantees that a geonetwork group
         // exists for the publishing organization)
-        // TODO what if the sync is configured to synchronize against the roles, and not
-        // against the orgs ?
+        //
+        // In case of roles-based synchronization:
+        //
+        // The 'editing' privilege is added for each roles (groups in GN) the publisher
+        // belongs to.
         String mdGroupId = organization.getShortName();
         Boolean actuallyPublish = publishingConfiguration.getGeonetwork().isPublishMetadata();
-        GeoNetworkResponse response = geonetwork.publish(metadataId, record, mdGroupId, user, actuallyPublish);
+        Boolean orgBasedSync = publishingConfiguration.getGeonetwork().getSyncMode().equals("orgs");
+        GeoNetworkResponse response = geonetwork.publish(metadataId, record, mdGroupId, user, actuallyPublish,
+                orgBasedSync);
         dataset.getPublishing().setMetadataRecordId(metadataId);
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -109,8 +109,7 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
         String mdGroupId = organization.getShortName();
         Boolean actuallyPublish = publishingConfiguration.getGeonetwork().isPublishMetadata();
         Boolean orgBasedSync = publishingConfiguration.getGeonetwork().getSyncMode().equals("orgs");
-        GeoNetworkResponse response = geonetwork.publish(metadataId, record, mdGroupId, user, actuallyPublish,
-                orgBasedSync);
+        geonetwork.publish(metadataId, record, mdGroupId, user, actuallyPublish, orgBasedSync);
         dataset.getPublishing().setMetadataRecordId(metadataId);
     }
 

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraMetadataPublicationService.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import org.georchestra.datafeeder.autoconf.GeorchestraNameNormalizer;
+import org.georchestra.datafeeder.config.DataFeederConfigurationProperties;
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.PublishingConfiguration;
 import org.georchestra.datafeeder.config.PostgisSchemasConfiguration;
 import org.georchestra.datafeeder.model.DatasetUploadState;
@@ -63,6 +64,8 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
     private GeorchestraNameNormalizer nameResolver;
     private @Autowired(required = false) PostgisSchemasConfiguration postgisSchemasConfiguration;
 
+    private @Autowired DataFeederConfigurationProperties dataFeederConfigurationProperties;
+
     public @Autowired GeorchestraMetadataPublicationService(//
             @NonNull GeoNetworkRemoteService geonetwork, //
             @NonNull TemplateMapper templateMapper, //
@@ -94,10 +97,13 @@ public class GeorchestraMetadataPublicationService implements MetadataPublicatio
         Supplier<String> record = templateMapper.apply(mdProps);
         Organization organization = user.getOrganization();
         // The metadata is inserted into the group which already exists due to
-        // GeoNetwork's LDAP sync (which currently garantees that a geonetwork group
+        // GeoNetwork's LDAP sync (which currently guarantees that a geonetwork group
         // exists for the publishing organization)
+        // TODO what if the sync is configured to synchronize against the roles, and not
+        // against the orgs ?
         String mdGroupId = organization.getShortName();
-        GeoNetworkResponse response = geonetwork.publish(metadataId, record, mdGroupId);
+        Boolean actuallyPublish = publishingConfiguration.getGeonetwork().isPublishMetadata();
+        GeoNetworkResponse response = geonetwork.publish(metadataId, record, mdGroupId, user, actuallyPublish);
         dataset.getPublishing().setMetadataRecordId(metadataId);
     }
 

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -149,6 +149,7 @@ datafeeder:
       api-url: http://localhost:28080/geonetwork
       public-url: https://georchestra.mydomain.org/geonetwork
       log-requests: false
+      publish-metadata: true
     ogcfeatures:
       public-url: https://georchestra.mydomain.org/ogc
     backend:

--- a/datafeeder/src/main/resources/application.yml
+++ b/datafeeder/src/main/resources/application.yml
@@ -62,7 +62,7 @@ datafeeder:
 
 feign:
   okhttp.enabled: false
-  httpclient.enabled: false 
+  httpclient.enabled: false
   client:
     config:
       default:
@@ -119,7 +119,7 @@ spring:
     driverClassName: org.h2.Driver
     username: sa
     password: password
-      
+
 georchestra.datadir: src/test/resources/datadir
 ---
 spring.profiles: it
@@ -150,6 +150,7 @@ datafeeder:
       public-url: https://georchestra.mydomain.org/geonetwork
       log-requests: false
       publish-metadata: true
+      sync-mode: orgs
     ogcfeatures:
       public-url: https://georchestra.mydomain.org/ogc
     backend:

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceIT.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceIT.java
@@ -27,12 +27,18 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.UUID;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.fao.geonet.client.RecordsApi;
+import org.fao.geonet.client.model.GroupPrivilege;
+import org.fao.geonet.client.model.SharingResponse;
 import org.georchestra.datafeeder.autoconf.GeorchestraIntegrationAutoConfiguration;
 import org.georchestra.datafeeder.it.IntegrationTestSupport;
+import org.georchestra.datafeeder.model.Organization;
+import org.georchestra.datafeeder.model.UserInfo;
 import org.georchestra.datafeeder.service.DataFeederServiceConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,6 +66,8 @@ public class GeoNetworkRemoteServiceIT {
 
     private @Autowired GeoNetworkRemoteService service;
 
+    private @Autowired DefaultGeoNetworkClient client;
+
     @Test
     public void buildMetadataRecordURI() {
         URI recordUri = service.buildMetadataRecordIdentifier("someid");
@@ -71,9 +79,90 @@ public class GeoNetworkRemoteServiceIT {
         final String id = UUID.randomUUID().toString();
         final String record = loadSampleRecord(id);
 
+        final UserInfo user = new UserInfo();
+        user.setEmail("psc@georchestra.org");
+        user.setTitle("testadmin");
+        user.setUsername("testadmin");
+        user.setRoles(Arrays.asList("ROLE_ADMINISTRATOR", "ROLE_GN_ADMIN", "ROLE_IMPORT"));
+        user.setFirstName("admin");
+        user.setLastName("test");
+
         // we don't have gn groups in the it compose?
         String group = null;
-        GeoNetworkResponse response = service.publish(id, () -> record, group);
+        GeoNetworkResponse response = service.publish(id, () -> record, group, user, true);
+        assertNotNull(response);
+        assertEquals(HttpStatus.CREATED, response.getStatus());
+
+        final String publishedRecord = service.getRecordById(id);
+        assertNotNull(publishedRecord);
+        try {
+            DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                    .parse(new InputSource(new StringReader(publishedRecord)));
+        } catch (Exception e) {
+            fail("Published record not returned as valid XML", e);
+        }
+
+        RecordsApi api = new RecordsApi(client.newApiClient());
+        SharingResponse resp = api.getRecordSharingSettings(id);
+
+        GroupPrivilege privPubGroupAll = resp.getPrivileges().stream().filter(grp -> grp.getGroup() == 1).findAny()
+                .get();
+
+        // A metadata is published if the privilege "view" is set to true on the
+        // hardcoded "All" group
+        assertEquals(privPubGroupAll.getOperations().get("view"), true);
+    }
+
+    @Test
+    public void publish_OK_skip_publication() throws IOException {
+        final String id = UUID.randomUUID().toString();
+        final String record = loadSampleRecord(id);
+
+        final UserInfo user = new UserInfo();
+        user.setEmail("psc@georchestra.org");
+        user.setTitle("testadmin");
+        user.setUsername("testadmin");
+        user.setRoles(Arrays.asList("ROLE_ADMINISTRATOR", "ROLE_GN_ADMIN", "ROLE_IMPORT"));
+        user.setFirstName("admin");
+        user.setLastName("test");
+        String group = "PSC";
+        GeoNetworkResponse response = service.publish(id, () -> record, group, user, false);
+        assertNotNull(response);
+        assertEquals(HttpStatus.CREATED, response.getStatus());
+
+        final String publishedRecord = service.getRecordById(id);
+        assertNotNull(publishedRecord);
+        try {
+            DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                    .parse(new InputSource(new StringReader(publishedRecord)));
+        } catch (Exception e) {
+            fail("Published record not returned as valid XML", e);
+        }
+
+        RecordsApi api = new RecordsApi(client.newApiClient());
+        SharingResponse resp = api.getRecordSharingSettings(id);
+
+        GroupPrivilege privPubGroupAll = resp.getPrivileges().stream().filter(grp -> grp.getGroup() == 1).findAny()
+                .get();
+
+        assertEquals(privPubGroupAll.getOperations().get("view"), false);
+    }
+
+    @Test
+    public void publish_OK_with_group() throws IOException {
+        final String id = UUID.randomUUID().toString();
+        final String record = loadSampleRecord(id);
+
+        final UserInfo user = new UserInfo();
+        user.setEmail("psc@georchestra.org");
+        user.setTitle("testadmin");
+        user.setUsername("testadmin");
+        user.setRoles(Arrays.asList("ROLE_ADMINISTRATOR", "ROLE_GN_ADMIN", "ROLE_IMPORT"));
+        user.setFirstName("admin");
+        user.setLastName("test");
+
+        String group = "PSC";
+        GeoNetworkResponse response = service.publish(id, () -> record, group, user, true);
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatus());
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
@@ -84,10 +84,10 @@ public class GeoNetworkRemoteServiceTest {
         response.setStatus(HttpStatus.CREATED);
 
         String group = "psc";
-        when(mockClient.putXmlRecord(eq(id), eq(record), eq(group), any(UserInfo.class), eq(true)))
+        when(mockClient.putXmlRecord(eq(id), eq(record), eq(group), any(UserInfo.class), eq(true), eq(true)))
                 .thenReturn(response);
 
-        GeoNetworkResponse ret = service.publish(id, () -> record, group, mock(UserInfo.class), true);
+        GeoNetworkResponse ret = service.publish(id, () -> record, group, mock(UserInfo.class), true, true);
         assertSame(response, ret);
     }
 

--- a/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
+++ b/datafeeder/src/test/java/org/georchestra/datafeeder/service/geonetwork/GeoNetworkRemoteServiceTest.java
@@ -21,6 +21,7 @@ package org.georchestra.datafeeder.service.geonetwork;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -30,6 +31,7 @@ import java.net.URI;
 import java.net.URL;
 
 import org.georchestra.datafeeder.config.DataFeederConfigurationProperties.ExternalApiConfiguration;
+import org.georchestra.datafeeder.model.UserInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -82,9 +84,10 @@ public class GeoNetworkRemoteServiceTest {
         response.setStatus(HttpStatus.CREATED);
 
         String group = "psc";
-        when(mockClient.putXmlRecord(eq(id), eq(record), eq(group))).thenReturn(response);
+        when(mockClient.putXmlRecord(eq(id), eq(record), eq(group), any(UserInfo.class), eq(true)))
+                .thenReturn(response);
 
-        GeoNetworkResponse ret = service.publish(id, () -> record, group);
+        GeoNetworkResponse ret = service.publish(id, () -> record, group, mock(UserInfo.class), true);
         assertSame(response, ret);
     }
 

--- a/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
+++ b/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties
@@ -71,7 +71,7 @@ datafeeder.publishing.geonetwork.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR;ROL
 datafeeder.publishing.geonetwork.auth.headers.[X-XSRF-TOKEN]=c9f33266-e242-4198-a18c-b01290dce5f1
 datafeeder.publishing.geonetwork.auth.headers.[Cookie]=XSRF-TOKEN=c9f33266-e242-4198-a18c-b01290dce5f1
 
-#template-record-id, an existing geonetwork record id to use as template. If provided, takes precedence over template-record 
+#template-record-id, an existing geonetwork record id to use as template. If provided, takes precedence over template-record
 datafeeder.publishing.geonetwork.template-record-id:
 #let's use the default template and transform for testing
 datafeeder.publishing.geonetwork.template-record:
@@ -79,6 +79,16 @@ datafeeder.publishing.geonetwork.template-transform:
 #datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml
 #datafeeder.publishing.geonetwork.template-transform: file:${georchestra.datadir}/datafeeder/metadata_transform.xsl
 datafeeder.publishing.geonetwork.defaultResourceType=dataset
+
+# Indicates whether to publish the metadata (e.g. "make it public") after having inserted it into the catalogue
+# defaults to true
+#datafeeder.publishing.geonetwork.publishMetadata=true
+
+# Indicates the GeoNetwork group synchronization mode, defaults to orgs. Should be set to
+# 'roles' in accordance with the GeoNetwork configuration, see
+# https://github.com/georchestra/datadir/blob/master/geonetwork/geonetwork.properties#L25-L32
+#datafeeder.publishing.geonetwork.syncMode=orgs
+
 
 datafeeder.publishing.backend.local.dbtype=postgis
 datafeeder.publishing.backend.local.host=${pgsqlHost}
@@ -98,7 +108,7 @@ datafeeder.publishing.backend.geoserver.schema=<schema>
 datafeeder.publishing.backend.geoserver.workspacename=<workspacename>
 datafeeder.publishing.backend.geoserver.storename=<storename>
 #datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
-#if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
+#if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones
 datafeeder.publishing.backend.geoserver.host=database
 datafeeder.publishing.backend.geoserver.port=${pgsqlPort}
 datafeeder.publishing.backend.geoserver.database=${pgsqlDatabase}
@@ -108,6 +118,10 @@ datafeeder.publishing.backend.geoserver.passwd=${pgsqlPassword}
 # note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
 datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
+
+
+# OGC Features API public URL - Enable link at the end of the process.
+# datafeeder.publishing.ogcfeatures.public-url=https://${domainName}/data/ogcapi
 
 datafeeder.email.send=false
 datafeeder.email.ackTemplate=file:${georchestra.datadir}/datafeeder/templates/analysis-started-email-template.txt


### PR DESCRIPTION
This PR aims to provide some improvements on datafeeder's metadata publication job:

* adds the ability to skip metadata publication on GeoNetwork
* impersonates (e.g. transfer ownership to) the user having actually pushed the dataset on the created metadata
* in case of role-based groups synchronization in GeoNetwork: adds the editing privileges to each groups the publisher belongs to

Adding a flag in the configuration so that the publication of the metadata becomes optional. If `datafeeder.publishing.geonetwork.publish-metadata` set to `false` (kept `true` by default), then the metadata is not published by the publication job.

With the current state of the DF code, when a user uploads a dataset, the user responsible for creating a metadata and publish it onto the catalogue is a bot account, making it impossible for the user having pushed the data to modify the metadata being generated from it afterwards. This PR also aims to impersonate the user, by giving the ownership on the metadata being created to the original user having uploaded the dataset.

Unrelated changes:

* updating README to reflect the fact that the docker-composition being used for integration testing is no longer managed by maven.
* updating docker-compose to use latest images, which makes more sense IMHO targeting the master branch.

Tests: mainly runtime, current testsuite adapted to reflect changes made onto the code.
