### PR TITLE
chore: Add github-actions + dockerfile for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,11 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   target-branch: 23.1.x
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,41 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: "weekly"
-- package-ecosystem: "docker"
-  directory: "/"
+    interval: weekly
+- package-ecosystem: docker
+  directory: /ldap
   schedule:
-    interval: "weekly"
+    interval: weekly
+- package-ecosystem: docker
+  directory: /postgresql
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /console/src/docker
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /datafeeder/src/docker
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /datafeeder-ui/src/docker
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /geoserver/webapp/src/docker
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /analytics/src/docker
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /security-proxy/src/docker
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /geowebcache-webapp/src/docker
+  schedule:
+    interval: weekly
+

--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for the geOrchestra openldap service
 #
 
-FROM debian:bookworm
+FROM debian:12
 
 ARG PM_POLICY=default
 ENV OPENLDAP_VERSION 2.5.13


### PR DESCRIPTION
We often have very outdated github actions version and our Dockerfile may contain some outdated Docker images.

This commit ask dependabot to:
- Create new PR for updating the github actions
- Create new PR for updating new base images (FROM:) in the existing Dockerfile.

Benefits:
- Avoid getting messages such as "This github action will stop working by XX XX XX" and avoid having the github action failing to work anymore.
- Keep the Dockerfile secure and up to date.
