### PR TITLE
console: display names in logger, delegations and org when availables

### DIFF
--- a/console/src/main/webapp/manager/app/components/delegations/delegations.es6
+++ b/console/src/main/webapp/manager/app/components/delegations/delegations.es6
@@ -2,14 +2,21 @@ import 'components/delegations/delegations.tpl'
 import 'services/delegations'
 
 class DelegationsController {
-  static $inject = ['Delegations', 'Orgs']
+  static $inject = ['Delegations', 'Orgs', 'User']
 
-  constructor (Delegations, Orgs) {
+  constructor (Delegations, Orgs, User) {
     this.delegations = Delegations.query()
     this.orgs = {}
     Orgs.query({ logos: false }, (orgs) => orgs.forEach(org => (this.orgs[org.id] = org)))
     this.q = ''
     this.itemsPerPage = 15
+    this.users = {}
+    User.query(users => {
+      this.users = users.reduce((acc, u) => {
+        acc[u.uid] = u.sn + ' ' + u.givenName
+        return acc
+      }, {})
+    })
   }
 }
 

--- a/console/src/main/webapp/manager/app/components/delegations/delegations.tpl.html
+++ b/console/src/main/webapp/manager/app/components/delegations/delegations.tpl.html
@@ -25,7 +25,7 @@
       <tbody>
         <tr dir-paginate="delegation in delegations.delegations | filter:delegations.q | itemsPerPage: delegations.itemsPerPage">
           <td style="max-width: 15vw">
-            <a ng-link="user({id: delegation.uid, tab: 'delegations'})" class="break-word">{{::delegation.uid}}</a>
+            <a ng-link="user({id: delegation.uid, tab: 'delegations'})" class="break-word">{{::(delegations.users[delegation.uid] ? delegations.users[delegation.uid] : delegation.uid)}}</a>
           </td>
           <td>
             <span ng-repeat="org in delegation.orgs">

--- a/console/src/main/webapp/manager/app/components/logger/logger.es6
+++ b/console/src/main/webapp/manager/app/components/logger/logger.es6
@@ -154,8 +154,13 @@ class LoggerController {
 
     // get all users
     this.users = []
+    this.usersNames = {}
     this.$injector.get('User').query(users => {
       this.users = users.map(user => user.uid)
+      this.usersNames = users.reduce((acc, u) => {
+        acc[u.uid] = u.sn + ' ' + u.givenName
+        return acc
+      }, {})
     })
   }
 

--- a/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
+++ b/console/src/main/webapp/manager/app/components/logger/logger.tpl.html
@@ -51,12 +51,12 @@
     <tbody>
         <tr dir-paginate="log in logger.logs | logs: logger.type:logger.admin:logger.target:logger.date | orderBy: '-date' | itemsPerPage: logger.itemsPerPage">
           <td><abbr ng-bind-html="log.date | dateFormat"></abbr></td>
-          <td style="max-width: 10vw" class="text-overflow"><a ng-link="user({id: log.admin, tab: 'infos'})" title="">{{::log.admin}}</a>
+          <td style="max-width: 10vw" class="text-overflow"><a ng-link="user({id: log.admin, tab: 'infos'})" title="">{{logger.usersNames[log.admin] ? logger.usersNames[log.admin] : log.admin}}</a>
           <!--Target-->
           <td style="max-width: 10vw" class="text-overflow">
             <!--user or user's role modification-->
             <a ng-if="logger.getType(log) === 'USER'" ng-link="user({id: log.target, tab: 'infos'})">
-              {{::log.target}}
+              {{::(logger.usersNames[log.target] ? logger.usersNames[log.target] : log.target)}}
             </a>
             <!--org-->
             <a ng-if="logger.getType(log) === 'ORG'" ng-link="org({org: log.target, tab: 'infos'})">

--- a/console/src/main/webapp/manager/app/components/org/org.es6
+++ b/console/src/main/webapp/manager/app/components/org/org.es6
@@ -49,6 +49,10 @@ class OrgController {
     User.query(users => {
       this.users = users.filter(u => u.org === this.org.name)
       this.notUsers = users.filter(u => u.org !== this.org.name)
+      this.usersNames = users.reduce((acc, u) => {
+        acc[u.uid] = u.sn + ' ' + u.givenName
+        return acc
+      }, {})
     })
   }
 

--- a/console/src/main/webapp/manager/app/components/org/org.tpl.html
+++ b/console/src/main/webapp/manager/app/components/org/org.tpl.html
@@ -23,7 +23,7 @@
       <div class="panel-heading text-center" ng-if="org.tab=='infos' && org.delegations.length > 0 && profile === 'SUPERUSER'">
         <span translate>org.ohasdeleg</span>
         <span ng-repeat="delegation in org.delegations">
-          <a ng-link="user({id: delegation.uid, tab: 'delegations'})">{{ delegation.uid }}</a>{{$last ? '' : ', '}}
+          <a ng-link="user({id: delegation.uid, tab: 'delegations'})">{{ org.usersNames[delegation.uid] ? org.usersNames[delegation.uid] : delegation.uid }}</a>{{$last ? '' : ', '}}
         </span>
       </div>
 


### PR DESCRIPTION
Displays correctly names on some pages
Instead of 
![image](https://github.com/user-attachments/assets/a733ada6-ef2e-4449-9286-f1da3275c0f6)
Now it's 
![image](https://github.com/user-attachments/assets/f63ccb4c-0b02-4219-a547-964fb3f3be44)
