### PR TITLE
datafeeder: record ownership wasn't set if sync is based on roles

### DIFF
--- a/datafeeder/docker-compose.yml
+++ b/datafeeder/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - "28080:8080"
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.21
     environment:
       discovery.type: single-node
       ES_JAVA_OPTS: "-Xms1g -Xmx1g"

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
@@ -179,6 +179,7 @@ public class DefaultGeoNetworkClient implements GeoNetworkClient {
         try {
             impersonatedUser = usersApi.getUsers().stream().filter(usr -> usr.getUsername().equals(user.getUsername()))
                     .findFirst();
+            String computedGroupName = groupName;
             if (!orgBasedSync && impersonatedUser.isPresent()) {
                 User usr = impersonatedUser.get();
                 // skip "hardcoded" GN groups
@@ -186,11 +187,11 @@ public class DefaultGeoNetworkClient implements GeoNetworkClient {
                 gps = ugs.stream().map(UserGroup::getGroup).filter(ugGroup -> ugGroup.getId() > 2)
                         .collect(Collectors.toList());
                 groupId = !gps.isEmpty() ? Optional.of(gps.get(0).getId()) : Optional.empty();
-                groupName = !gps.isEmpty() ? gps.get(0).getName() : "null";
+                computedGroupName = !gps.isEmpty() ? gps.get(0).getName() : "null";
             }
             if ((impersonatedUser.isEmpty()) || (groupId.isEmpty())) {
                 log.warn("Unable to find user {} and/or group {} in GeoNetwork, skipping record impersonation",
-                        user.getUsername(), groupName);
+                        user.getUsername(), computedGroupName);
             } else {
                 api.setRecordOwnership(metadataId, groupId.get(), impersonatedUser.get().getId(), true);
             }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
@@ -173,27 +173,37 @@ public class DefaultGeoNetworkClient implements GeoNetworkClient {
 
         UsersApi usersApi = new UsersApi(client);
         Optional<User> impersonatedUser = Optional.empty();
+        List<UserGroup> ugs;
+        List<Group> gps = List.of();
+
         try {
             impersonatedUser = usersApi.getUsers().stream().filter(usr -> usr.getUsername().equals(user.getUsername()))
                     .findFirst();
+            if (!orgBasedSync && impersonatedUser.isPresent()) {
+                User usr = impersonatedUser.get();
+                // skip "hardcoded" GN groups
+                ugs = usersApi.retrieveUserGroups(usr.getId());
+                gps = ugs.stream().map(UserGroup::getGroup).filter(ugGroup -> ugGroup.getId() > 2)
+                        .collect(Collectors.toList());
+                groupId = !gps.isEmpty() ? Optional.of(gps.get(0).getId()) : Optional.empty();
+                groupName = !gps.isEmpty() ? gps.get(0).getName() : "null";
+            }
+            if ((impersonatedUser.isEmpty()) || (groupId.isEmpty())) {
+                log.warn("Unable to find user {} and/or group {} in GeoNetwork, skipping record impersonation",
+                        user.getUsername(), groupName);
+            } else {
+                api.setRecordOwnership(metadataId, groupId.get(), impersonatedUser.get().getId(), true);
+            }
         } catch (ApiException e) {
-            log.error("Unable to retrieve user {}", user, e);
+            log.error("Unable to give ownership on record {} to user {}", metadataId, user, e);
         }
-
         // if the GN synchronization is not based on the organizations, then we have to
         // add the 'editing'
         // privilege to each groups (e.g. geOrchestra roles) the user belongs to.
         if (!orgBasedSync) {
             try {
-                if (impersonatedUser.isPresent()) {
-                    User usr = impersonatedUser.get();
-                    List<UserGroup> ugs = usersApi.retrieveUserGroups(usr.getId());
+                if (!gps.isEmpty()) {
                     List<GroupOperations> lgo = new ArrayList<>();
-                    // skip "hardcoded" GN groups
-                    List<Group> gps = ugs.stream().map(UserGroup::getGroup).filter(ugGroup -> ugGroup.getId() > 2)
-                            .collect(Collectors.toList());
-                    groupId = !gps.isEmpty() ? Optional.of(gps.get(0).getId()) : Optional.empty();
-                    groupName = !gps.isEmpty() ? gps.get(0).getName() : "null";
                     gps.forEach(ug -> lgo.add(allowEditing(ug.getId())));
                     SharingParameter shareParams = new SharingParameter();
                     shareParams.clear(false);
@@ -204,17 +214,6 @@ public class DefaultGeoNetworkClient implements GeoNetworkClient {
             } catch (Exception e) {
                 log.error("Error while trying to give 'editing' privileges to the author, giving up.", e);
             }
-        }
-
-        try {
-            if ((impersonatedUser.isEmpty()) || (groupId.isEmpty())) {
-                log.warn("Unable to find user {} and/or group {} in GeoNetwork, skipping record impersonation",
-                        user.getUsername(), groupName);
-            } else {
-                api.setRecordOwnership(metadataId, groupId.get(), impersonatedUser.get().getId(), true);
-            }
-        } catch (ApiException e) {
-            log.error("Unable to give ownership on record {} to user {}", metadataId, user, e);
         }
 
         GeoNetworkResponse r = new GeoNetworkResponse();

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
@@ -174,8 +174,8 @@ public class DefaultGeoNetworkClient implements GeoNetworkClient {
         UsersApi usersApi = new UsersApi(client);
         Optional<User> impersonatedUser = Optional.empty();
         try {
-            impersonatedUser = usersApi.getUsers().stream()
-                    .filter(usr -> usr.getUsername().equals(user.getUsername())).findFirst();
+            impersonatedUser = usersApi.getUsers().stream().filter(usr -> usr.getUsername().equals(user.getUsername()))
+                    .findFirst();
         } catch (ApiException e) {
             log.error("Unable to retrieve user {}", user, e);
         }

--- a/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
+++ b/datafeeder/src/main/java/org/georchestra/datafeeder/service/geonetwork/DefaultGeoNetworkClient.java
@@ -177,7 +177,7 @@ public class DefaultGeoNetworkClient implements GeoNetworkClient {
             impersonatedUser = usersApi.getUsers().stream()
                     .filter(usr -> usr.getUsername().equals(user.getUsername())).findFirst();
         } catch (ApiException e) {
-            log.error("Unable to give ownership on record {} to user {}", metadataId, user, e);
+            log.error("Unable to retrieve user {}", user, e);
         }
 
         // if the GN synchronization is not based on the organizations, then we have to


### PR DESCRIPTION
 `api.setRecordOwnership(metadataId, groupId.get(), impersonatedUser.get().getId(), true);` wasn't set if sync was based on roles because `groupId` was only set based on organization's name whcich doesn't work in roles context.
 
 - Set orgBasedSync check when we set `api.setRecordOwnership`  
 - If roles based sync, override groupId and groupName with first valid (not GN adminstration groups) group where user belongs to.
 
 
  