### PR TITLE
drop header from maven commands, should fix the buildbot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docker-build-datafeeder: build-deps
 	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl datafeeder
 
 docker-build-georchestra: build-deps docker-pull-jetty docker-build-database docker-build-ldap docker-build-geoserver docker-build-geowebcache docker-build-gn
-	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl security-proxy,header,console,analytics,datafeeder
+	mvn clean package docker:build -DdockerImageTags=${BTAG} -Pdocker -DskipTests --pl security-proxy,console,analytics,datafeeder
 
 docker-build: docker-build-gn docker-build-geoserver docker-build-georchestra
 
@@ -100,7 +100,7 @@ deb-build-geowebcache: war-build-geowebcache
 	mvn package deb:package -pl geowebcache-webapp -PdebianPackage -DskipTests -Dfmt.skip=true ${DEPLOY_OPTS}
 
 deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver deb-build-geowebcache
-	mvn package deb:package -pl datafeeder,datafeeder-ui,security-proxy,header,analytics,console,geonetwork/web -PdebianPackage -DskipTests ${DEPLOY_OPTS}
+	mvn package deb:package -pl datafeeder,datafeeder-ui,security-proxy,analytics,console,geonetwork/web -PdebianPackage -DskipTests ${DEPLOY_OPTS}
 
 # Base geOrchestra common modules
 build-deps:


### PR DESCRIPTION
the header webapp was dropped in 380d1dbd04be

tested locally with `make deb-build-georchestra`