### PR TITLE
console: password hints display in newPassword page

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/passwordrecovery/NewPasswordFormController.java
+++ b/console/src/main/java/org/georchestra/console/ws/passwordrecovery/NewPasswordFormController.java
@@ -96,6 +96,7 @@ public class NewPasswordFormController {
             formBean.setUid(uid);
 
             model.addAttribute(formBean);
+            model.addAttribute("pwdUtils", passwordUtils);
 
             return "newPasswordForm";
 

--- a/console/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application.properties
@@ -22,7 +22,7 @@ createAccountForm.description=An email will be sent to the above address to conf
 createAccountForm.fieldset.userDetails=User details
 createAccountForm.fieldset.credentials=Credentials
 createAccountForm.fieldset.privacyPolicyAgreement=Terms and conditions
-createAccountForm.fieldset.consentAgreement=Consent
+createAccountForm.fieldset.consentAgreement=Data processing consent
 editUserDetailsForm.title=User details.
 editUserDetailsForm.subtitle=Update your account.
 editUserDetailsForm.description=In this page you can manage your account informations and modify your password.
@@ -145,7 +145,7 @@ phone.error.nonNumeric=The phone number should only contain digits
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
-consentAgreed.label=Consent
+consentAgreed.label=Data processing consent
 consentAgreed.checkboxLabel=I consent to my personal information being processed in order to access the platform''s services. <a href="{0}" target="_blank">More informations.</a>
 consentAgreed.error.notChecked=Consent is required, in order to create the account
 recaptcha_response_field.error.required=Required

--- a/console/src/main/webapp/WEB-INF/i18n/application_de.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_de.properties
@@ -22,7 +22,7 @@ createAccountForm.description=Eine E-Mail wird an die Adresse geschickt, um die 
 createAccountForm.fieldset.userDetails=Benutzerdetails
 createAccountForm.fieldset.credentials=Referenzen
 createAccountForm.fieldset.privacyPolicyAgreement=Geschäftsbedingungen
-createAccountForm.fieldset.consentAgreement=Einwilligung
+createAccountForm.fieldset.consentAgreement=Datenschutzvereinbarung
 editUserDetailsForm.title=Benutzerdetails.
 editUserDetailsForm.subtitle=Aktualisieren Sie Ihr Konto.
 editUserDetailsForm.description=Auf dieser Seite können Sie Ihre Kontoinformationen verwalten und Ihr Passwort ändern.
@@ -143,7 +143,7 @@ phone.error.nonNumeric=Die Telefonnummer sollte nur Ziffern enthalten
 privacyPolicyAgreed.label=Bedingungen
 privacyPolicyAgreed.checkboxLabel=Ich habe die <a href="{0}" target="_blank">Bedingungen</a> gelesen und akzeptiert
 privacyPolicyAgreed.error.notChecked=Bitte akzeptieren Sie die Bedingungen, um das Konto zu erstellen
-consentAgreed.label=Einwilligung
+consentAgreed.label=Datenschutzvereinbarung
 consentAgreed.checkboxLabel=Ich bin damit einverstanden, dass meine personenbezogenen Daten verarbeitet werden, um auf die Dienste der Plattform zuzugreifen. <a href="{0}" target="_blank">Mehr Informationen</a>
 consentAgreed.error.notChecked=Für die Erstellung des Kontos ist eine Einwilligung erforderlich
 recaptcha_response_field.error.required=Notwendig

--- a/console/src/main/webapp/WEB-INF/i18n/application_es.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_es.properties
@@ -22,7 +22,7 @@ createAccountForm.description=Un correo de confirmación será mandado a la dire
 createAccountForm.fieldset.userDetails=Detalles del usuario
 createAccountForm.fieldset.credentials=Credenciales
 createAccountForm.fieldset.privacyPolicyAgreement=Condiciones de uso
-createAccountForm.fieldset.consentAgreement=Consentimiento
+createAccountForm.fieldset.consentAgreement=Consentimiento de procesamiento de datos
 editUserDetailsForm.title=Detalles de la cuenta.
 editUserDetailsForm.subtitle=Actualice sus informaciones.
 editUserDetailsForm.description=En esta página, puede manejar las informaciones de su cuenta y modificar su contraseña.
@@ -142,7 +142,7 @@ phone.error.nonNumeric=El número de teléfono solo puede contener dígitos
 privacyPolicyAgreed.label=Condiciones
 privacyPolicyAgreed.checkboxLabel=Leí y acepto las <a href="{0}" target="_blank">condiciones</a>
 privacyPolicyAgreed.error.notChecked=Por favor, aceptar las condiciones para crear la cuenta
-consentAgreed.label=Consentimiento
+consentAgreed.label=Consentimiento de procesamiento de datos
 consentAgreed.checkboxLabel=Doy mi consentimiento para que mi información personal sea procesada para poder acceder a los servicios de la plataforma. <a href="{0}" target="_blank">Más información</a>
 consentAgreed.error.notChecked=Se requiere consentimiento para crear la cuenta
 recaptcha_response_field.error.required=Requerido

--- a/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -22,7 +22,7 @@ createAccountForm.description=Un courriel de confirmation sera envoyé à l'adre
 createAccountForm.fieldset.userDetails=Détails du compte
 createAccountForm.fieldset.credentials=Identification
 createAccountForm.fieldset.privacyPolicyAgreement=Conditions d'utilisation
-createAccountForm.fieldset.consentAgreement=Consentement
+createAccountForm.fieldset.consentAgreement=Collecte des données personnelles
 editUserDetailsForm.title=Détails du compte.
 editUserDetailsForm.subtitle=Actualisez vos informations.
 editUserDetailsForm.description=Sur cette page vous pouvez gérer les informations de votre compte, et modifier votre mot de passe.
@@ -144,7 +144,7 @@ phone.error.nonNumeric=Le numéro de téléphone doit contenir uniquement des ch
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=J''ai lu et j''accepte les <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Veuillez accepter les conditions afin de créer le compte
-consentAgreed.label=Consentement
+consentAgreed.label=Collecte des données personnelles
 consentAgreed.checkboxLabel=Je consens à ce que mes informations personnelles soient traitées afin d''avoir accès aux services de la plateforme. <a href="{0}" target="_blank">Plus d''informations</a>
 consentAgreed.error.notChecked=Veuillez accepter le consentement afin de créeer le compte
 recaptcha_response_field.error.required=Cochez la case

--- a/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
+++ b/console/src/main/webapp/WEB-INF/i18n/application_nl.properties
@@ -22,7 +22,7 @@ createAccountForm.description=Een bevestigingsmail zal naar het aangegeven adres
 createAccountForm.fieldset.userDetails=Accountgegevens
 createAccountForm.fieldset.credentials=Identificatie
 createAccountForm.fieldset.privacyPolicyAgreement=Terms and conditions
-createAccountForm.fieldset.consentAgreement=Toestemming
+createAccountForm.fieldset.consentAgreement=Data processing consent
 editUserDetailsForm.title=Accountgegevens.
 editUserDetailsForm.subtitle=Bijwerk uw gegevens.
 editUserDetailsForm.description=Op deze pagina kunt u uw accountinformatie beheren en uw wachtwoord wijzigen.
@@ -143,7 +143,7 @@ phone.error.nonNumeric=Telefoonnummer mag alleen nummers bevatten
 privacyPolicyAgreed.label=Conditions
 privacyPolicyAgreed.checkboxLabel=I read and agree to the <a href="{0}" target="_blank">conditions</a>
 privacyPolicyAgreed.error.notChecked=Please accept the conditions, in order to create the account
-consentAgreed.label=Toestemming
+consentAgreed.label=Data processing consent
 consentAgreed.checkboxLabel=Ik ga ermee akkoord dat mijn persoonlijke gegevens worden verwerkt om toegang te krijgen tot de diensten van het platform. <a href="{0}" target="_blank">Meer informatie</a>
 consentAgreed.error.notChecked=Om het account aan te maken is toestemming vereist
 recaptcha_response_field.error.required=Vink het vakje aan


### PR DESCRIPTION
Also address issue #4345 

console wasn't disaplying password hints in newPassword page :
![image](https://github.com/user-attachments/assets/377ffeff-6b87-4c15-bcc7-7fdb684270c2)

Password policy is not correctly displayed:
![image](https://github.com/user-attachments/assets/f86cdab3-9bc7-46b4-a29b-f2bbfce39342)
