### PR TITLE
feat: Bump to GeoNetwork 4.4.8

### DIFF
--- a/.github/workflows/geonetwork.yml
+++ b/.github/workflows/geonetwork.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: "Build GeoNetwork"
       working-directory: geonetwork/
-      run: ../mvnw install -DskipTests -T1C -ntp -B -Dadditionalparam=-Xdoclint:none
+      run: ../mvnw install -DskipTests -T1C -ntp -B -Dadditionalparam=-Xdoclint:none -Pdatahub-integration
 
     - name: "Build required docker images (ldap, database)"
       run: |
@@ -67,7 +67,7 @@ jobs:
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       run: |
         cd geonetwork/web
-        ../../mvnw package docker:build -Pdocker -DdockerImageName=georchestra/geonetwork -DdockerImageTags=${{ steps.version.outputs.VERSION }},latest -DskipTests -ntp
+        ../../mvnw package -Pdocker,datahub-integration -DdockerImageName=georchestra/geonetwork -DdockerImageTags=${{ steps.version.outputs.VERSION }},latest -DskipTests -ntp
 
     - name: "Logging in docker.io"
       uses: azure/docker-login@v2

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ docker-build-database:
 docker-build-gn: docker-pull-jetty
 	mvn install -pl security-proxy-spring-integration --also-make -DskipTests; \
 	cd geonetwork; \
-	mvn -DskipTests clean install; \
+	mvn -DskipTests -Pdatahub-integration clean install; \
 	cd web; \
-	mvn -P docker -DskipTests package docker:build -DdockerImageTags=${BTAG}
+	mvn -Pdocker,datahub-integration -DskipTests package -DdockerImageTags=${BTAG}
 
 docker-build-geoserver: docker-pull-jetty
 	cd geoserver; \
@@ -80,7 +80,7 @@ war-build-geowebcache: build-deps
 
 war-build-gn: build-deps
 	mvn clean install -pl testcontainers,ldap-account-management,security-proxy-spring-integration -DskipTests
-	mvn clean install -f geonetwork/pom.xml -DskipTests
+	mvn clean install -f geonetwork/pom.xml -Pdatahub-integration -DskipTests
 
 war-build-georchestra: war-build-gn war-build-geoserver
 	mvn -Dmaven.test.skip=true -DskipTests clean install
@@ -100,7 +100,7 @@ deb-build-geowebcache: war-build-geowebcache
 	mvn package deb:package -pl geowebcache-webapp -PdebianPackage -DskipTests -Dfmt.skip=true ${DEPLOY_OPTS}
 
 deb-build-georchestra: war-build-georchestra build-deps deb-build-geoserver deb-build-geowebcache
-	mvn package deb:package -pl datafeeder,datafeeder-ui,security-proxy,analytics,console,geonetwork/web -PdebianPackage -DskipTests ${DEPLOY_OPTS}
+	mvn package deb:package -pl datafeeder,datafeeder-ui,security-proxy,analytics,console,geonetwork/web -PdebianPackage,datahub-integration -DskipTests ${DEPLOY_OPTS}
 
 # Base geOrchestra common modules
 build-deps:


### PR DESCRIPTION
* docker:build is not necessary anymore, as the target provided by the docker maven module has been attached to the package phase. See: https://github.com/georchestra/geonetwork/blob/georchestra-gn4.4.x/web/pom.xml#L1662-L1667

* Activating the datahub-integration profile by default.

TODO: The buildbot CI will probably also require some adjustments.
