### PR TITLE
ci: backport ci version + version output

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,3 @@
+{
+  "autoMerge": true
+}

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v9.3.0
+        uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-to-

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Getting image tag
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Docker build database"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/geonetwork.yml
+++ b/.github/workflows/geonetwork.yml
@@ -32,7 +32,7 @@ jobs:
       run: git submodule update --init --recursive --depth 1 geonetwork/
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'adopt'
@@ -93,7 +93,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/geonetwork.yml
+++ b/.github/workflows/geonetwork.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Build GeoNetwork docker image"
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Building docker image with native security"
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/geowebcache.yml
+++ b/.github/workflows/geowebcache.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/ldap.yml
+++ b/.github/workflows/ldap.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Getting image tag
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra'

--- a/.github/workflows/ldap.yml
+++ b/.github/workflows/ldap.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: "Update Docker Hub Description"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/sp.yml
+++ b/.github/workflows/sp.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Getting image tag
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
       id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
     - name: "Building docker image"
       if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## 1 - Change output version in CIs
As set-output will be deprecated: 
![image](https://github.com/user-attachments/assets/a36fc1b7-a585-41f5-a0d4-1461b90d9b97)

example: https://github.com/georchestra/georchestra/actions/runs/15468669334

Change to getting version to following according to github doc
```
echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
```

## 2 - bump version of GHAs
Bump dockerhub, setup java action and sorenlouv GHAs versions

## 3 - Add automerge to backported PRs
Backported PRs will now automerge https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#automerge