### PR TITLE
fix: geoserver build should contain the ogcapi plugin

### DIFF
--- a/.github/workflows/geoserver.yml
+++ b/.github/workflows/geoserver.yml
@@ -1,7 +1,7 @@
 ---
 env:
   # The following variable should be set to the same value as in the Makefile at the root of the repository
-  GEOSERVER_EXTENSION_PROFILES: wps-download,app-schema,control-flow,csw,inspire,libjpeg-turbo,monitor,pyramid,wps,css,jp2k,authkey,mapstore2,mbstyle,web-resource,sldservice,geopkg-output
+  GEOSERVER_EXTENSION_PROFILES: wps-download,app-schema,control-flow,csw,libjpeg-turbo,monitor,pyramid,wps,css,jp2k,authkey,mapstore2,mbstyle,web-resource,sldservice,geopkg-output,wfs-freemarker,ogcapi
 
 name: "geoserver"
 on:


### PR DESCRIPTION
To be coherent with the Makefile which activates the maven profile when building geoserver, realigning both variables:

* removing inspire, see https://github.com/georchestra/georchestra/commit/9077d1f54c89b2fe24f011fd9eca8399b9555e7e
* adding wfs-freemarker, see https://github.com/georchestra/georchestra/commit/11ff5c5c2139aca170d292957a84e5c63a46a521

both the GHA and the Makefile are now aligned in this regard.