### PR TITLE
fix: console - actually use the sender configured in datadir

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/emails/EmailController.java
+++ b/console/src/main/java/org/georchestra/console/ws/emails/EmailController.java
@@ -504,7 +504,7 @@ public class EmailController {
         final MimeMessage message = this.emailFactory.createEmptyMessage();
 
         Account recipient = this.accountDao.findByUID(email.getRecipient());
-        InternetAddress[] senders = { new InternetAddress(this.accountDao.findByUID(email.getSender()).getEmail()) };
+        InternetAddress[] senders = { new InternetAddress(this.emailProxyFromAddress) };
 
         message.addFrom(senders);
         message.addRecipient(Message.RecipientType.TO, new InternetAddress(recipient.getEmail()));


### PR DESCRIPTION
Until this PR, we use the mail address of the administrator currently being connected to send mail via the console's email controller.

This seems to be the behaviour since almost the first implementation of the mail sending feature of the console. It actually confuses me as well as some users from the community - Rennes Métropole - as it reveals the email address of the administrators when they send mail via the console.

In my humble & technical opinion:

1. does it make sense to have a parameter in the datadir, if we actually ignore it and use the mails from the LDAP instead ?
2. Aren't we "recoding" a webmail ? e.g. If the administrators want to send a mail using their own ones, they can do it outside of geOrchestra using their mail system.
3. Inpersonating unexpected email addresses can probably lead to mail-filtering (spam / blacklist and so on) issues.

After having discussed this issue with @fvanderbiest and our customer, it makes more sense to send mail on behalf on the "mail from:" configured in the datadir.

Tests:
* runtime tested at Rennes-Métropole
* considering the modification, I wonder if it would be relevant to add a test.