### PR TITLE
chore: ldap - removes the geoserver_privileged_user user (fixes #1073)

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -140,12 +140,9 @@ Once created, set the following parameters:
 
 ### Protected Users
 
-Several user accounts can be protected against deletion or modification, with the `protectedUsersList` property, which holds a comma separated list of user accounts `uid`. These users also do not show up in the manager.
-
-By default, only `geoserver_privileged_user` is protected:
-```
-protectedUsersList=geoserver_privileged_user
-```
+Several user accounts can be protected against deletion or modification, with
+the `protectedUsersList` property, which holds a comma separated list of user
+accounts `uid`. These users also do not show up in the console.
 
 ## Developer's corner
 

--- a/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
+++ b/console/src/main/webapp/WEB-INF/spring/webmvc-config.xml
@@ -135,7 +135,7 @@
     <property name="listOfprotectedUsers">
       <description>Comma separated list of one or more user identifiers (uid) of protected user</description>
         <!-- Users are defined as a comma separated list of uid and can be overridden in data dir with "protectedUsersList" key-->
-        <value>${protectedUsersList:geoserver_privileged_user}</value>
+        <value>${protectedUsersList:}</value>
     </property>
   </bean>
 

--- a/docsv1/check.md
+++ b/docsv1/check.md
@@ -26,14 +26,14 @@ First thing to check is the [proxy mapping](https://github.com/georchestra/templ
 Now testing the security proxy Basic Authentication.  
 The following command shall return the public and protected layers:
 ```
-curl --insecure --user "geoserver_privileged_user:password" "https://private:8443/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"
+curl --insecure --user "testadmin:password" "https://private:8443/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"
 ```
 
 Several potential issues if it's not :
  * the security proxy can't query the LDAP,
- * ```geoserver_privileged_user``` is not a valid LDAP account,
- * ```geoserver_privileged_user``` does not belong to the ```ADMINISTRATOR``` LDAP group,
- * ```geoserver_privileged_user```'s password is incorrect.
+ * ```testadmin``` is not a valid LDAP account,
+ * ```testadmin``` does not belong to the ```ADMINISTRATOR``` LDAP group,
+ * ```testadmin```'s password is incorrect.
 
 
 ## Apache
@@ -45,7 +45,7 @@ curl "http://mysdi.org/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"
 
 Then...
 ```
-curl --insecure --user "geoserver_privileged_user:password" "http://mysdi.org/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"
+curl --insecure --user "testadmin:password" "http://mysdi.org/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"
 ```
 
 Finally, open QGIS and register the service with and without the privileged account.

--- a/docsv1/setup/openldap.md
+++ b/docsv1/setup/openldap.md
@@ -116,7 +116,7 @@ ldapadd -D"cn=admin,dc=georchestra,dc=org" -W -f georchestra.ldif
 This will also ask the password for the ```cn=admin,dc=georchestra,dc=org``` dn.
 
 
-Note that you are free to customize the users (entries under the "users" OrganizationUnit) to fit your needs, provided you keep the required ```geoserver_privileged_user```.
+Note that you are free to customize the users (entries under the "users" OrganizationUnit) to fit your needs.
 
 
 
@@ -142,7 +142,7 @@ sudo ldapadd -Y EXTERNAL -H ldapi:/// -f ppolicy-rotation.ldif
 ```
 sudo ldapadd -Y EXTERNAL -H ldapi:/// -f rotationpolicyoverlay.ldif
 ```
-To disable password expire for no humain users (geoserver_privileged_user, idatafeeder), please run the following commands:
+To disable password expiration for non-human users (`idatafeeder`), please run the following commands:
 ```
 sudo ldapadd -Y EXTERNAL -H ldapi:/// -f pwd_no_expire.ldif
 ```

--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -33,4 +33,4 @@ ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD [ "sh", "-c", "exec slapd -d ${SLAPD_LOG_LEVEL:-32768} -u ${RUN_AS_UID} -g ${RUN_AS_GID}" ]
 
 HEALTHCHECK --interval=30s --timeout=10s \
-  CMD ldapsearch -xLLL uid=geoserver_privileged_user || exit 1
+  CMD ldapsearch -xLLL -s one ou=users | grep  '^dn:' || exit 1

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -37,7 +37,6 @@ The basic users:
  * ```testeditor``` has the USER & GN_EDITOR roles. The password is **testeditor**.
  * ```testadmin``` has the USER, GN_ADMIN, ADMINISTRATOR and MOD_* roles. The password is **testadmin**.
  * ```testdelegatedadmin``` has the USER role. Is able to grant the EXTRACTORAPP & GN_EDITOR roles to members of the psc & c2c orgs. The password is **testdelegatedadmin**.
- * ```geoserver_privileged_user``` is a required user. It is internally used by the geofence module. The default password is ```gerlsSnFd6SmM``` (you should change it, and update the datadir as explained in its [README](https://github.com/georchestra/datadir/blob/18.06/README.md)).
  * ```testpendinguser``` is inside the pending users organizational unit, which means an admin has to validate it. The password is **testpendinguser**.
 
 Please note that `test*` users should be deleted before going into production !

--- a/ldap/docker-compose.yml
+++ b/ldap/docker-compose.yml
@@ -10,14 +10,12 @@ services:
     build: ./
     secrets:
       - slapd_password
-      - geoserver_privileged_user_passwd
     environment:
       - SLAPD_DOMAIN=georchestra.org
       - SLAPD_ORGANIZATION=georchestra
       - SLAPD_ADDITIONAL_MODULES=groupofmembers,openssh
       - SLAPD_PASSWORD_FILE=/run/secrets/slapd_password
       - SLAPD_PASSWORD=
-      - GEOSERVER_PRIVILEGED_USER_PASSWORD_FILE=/run/secrets/geoserver_privileged_user_passwd
       - SLAPD_LOG_LEVEL=32768
     volumes:
       - ldap_data_test:/var/lib/ldap
@@ -28,5 +26,3 @@ services:
 secrets:
   slapd_password:
     file: ./secrets/slapd_password.txt
-  geoserver_privileged_user_passwd:
-    file: ./secrets/geoserver_privileged_user_passwd.txt

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -44,15 +44,6 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
     if [ "$IGNORE_DATA" = 'true' ]; then
         echo "$0: ignoring /georchestra.ldif";
     else
-        if [ -n "$GEOSERVER_PRIVILEGED_USER_PASSWORD" ]; then
-            # Allow changing the geoserver master password.
-            # Works on first run only
-            echo "replacing geoserver master password"
-            GEOSERVER_PRIVILEGED_USER_PASSWORD=`slappasswd -s "$GEOSERVER_PRIVILEGED_USER_PASSWORD"`
-            GEOSERVER_PRIVILEGED_USER_PASSWORD=`echo $GEOSERVER_PRIVILEGED_USER_PASSWORD |base64 -`
-            perl -p -i -e "s/e1NIQX1XMlY4d2UrOFdNanpma28rMUtZVDFZcWZFVDQ9/${GEOSERVER_PRIVILEGED_USER_PASSWORD}/" /georchestra.ldif
-        fi
-
         perl -p -i -e "s/georchestra.org/${SLAPD_DOMAIN}/"        /georchestra.ldif
         perl -p -i -e "s/dc=georchestra,dc=org/${dc_string}/"     /georchestra.ldif
         ldapadd -D "cn=admin,${dc_string}" -w "$SLAPD_PASSWORD" -f /georchestra.ldif

--- a/ldap/docker-root/docker-entrypoint.d/utils/load_secrets.sh
+++ b/ldap/docker-root/docker-entrypoint.d/utils/load_secrets.sh
@@ -26,6 +26,3 @@ file_env() {
 # (usual way of passing secrets)
 file_env 'SLAPD_PASSWORD'
 
-# Accept GEOSERVER_PRIVILEGED_USER_PASSWORD_FILE containing the password
-# Allows to change the geoserver master password on first run
-file_env 'GEOSERVER_PRIVILEGED_USER_PASSWORD'

--- a/ldap/docker-root/georchestra.ldif
+++ b/ldap/docker-root/georchestra.ldif
@@ -83,22 +83,6 @@ knowledgeInformation: Internal CRM notes on testadmin
 cn: testadmin
 georchestraObjectIdentifier: 0c6bb556-4ee8-46f2-892d-6116e262b489
 
-# geoserver_privileged_user, users, georchestra.org
-dn: uid=geoserver_privileged_user,ou=users,dc=georchestra,dc=org
-objectClass: georchestraUser
-objectClass: organizationalPerson
-objectClass: person
-objectClass: inetOrgPerson
-objectClass: shadowAccount
-objectClass: top
-sn: geoserver_privileged_user
-mail: psc+geoserver_privileged_user@georchestra.org
-uid: geoserver_privileged_user
-cn: geoserver_privileged_user
-description: Do not modify. This is a required user for server-to-server internal communications...
-userPassword:: e1NIQX1XMlY4d2UrOFdNanpma28rMUtZVDFZcWZFVDQ9
-georchestraObjectIdentifier: 82dc7198-6fea-4e9a-b30d-d1e414c30f30
-
 dn: uid=idatafeeder,ou=users,dc=georchestra,dc=org
 objectClass: georchestraUser
 objectClass: inetOrgPerson
@@ -161,7 +145,6 @@ objectClass: groupOfMembers
 objectClass: georchestraRole
 cn: ADMINISTRATOR
 description: This role grants admin access to GeoServer
-member: uid=geoserver_privileged_user,ou=users,dc=georchestra,dc=org
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
 georchestraObjectIdentifier: 6b98583f-0ff0-465f-bb29-e9696a634c74
 

--- a/ldap/docker-root/pwd_no_expire_users.ldif
+++ b/ldap/docker-root/pwd_no_expire_users.ldif
@@ -1,8 +1,3 @@
-dn: uid=geoserver_privileged_user,ou=users,dc=georchestra,dc=org
-changetype: modify
-add: pwdPolicySubentry
-pwdPolicySubentry: cn=pwd-no-expire,ou=pwpolicy,dc=georchestra,dc=org
-
 dn: uid=idatafeeder,ou=users,dc=georchestra,dc=org
 changetype: modify
 add: pwdPolicySubentry

--- a/ldap/secrets/geoserver_privileged_user_passwd.txt
+++ b/ldap/secrets/geoserver_privileged_user_passwd.txt
@@ -1,1 +1,0 @@
-gerlsSnFd6SmM

--- a/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -241,7 +241,7 @@
     <property name="listOfprotectedUsers">
       <description>Comma separated list of one or more user identifiers (uid) of protected user</description>
         <!-- Users are defined as a comma separated list of uid and can be overridden in data dir with "protectedUsersList" key-->
-        <value>${protectedUsersList:geoserver_privileged_user}</value>
+        <value>${protectedUsersList:}</value>
     </property>
   </bean>
 

--- a/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
+++ b/security-proxy/src/main/webapp/WEB-INF/proxy-servlet.xml
@@ -85,7 +85,7 @@
                 <bean class="org.georchestra.security.TrustedProxyRequestHeaderProvider" />
                 <bean class="org.georchestra.security.SecurityRequestHeaderProvider"/>
                 <bean class="org.georchestra.security.ImpersonateUserRequestHeaderProvider">
-                    <property name="trustedUsers" value="${trustedUsers:geoserver_privileged_user}"/>
+                    <property name="trustedUsers" value="${trustedUsers:}"/>
                 </bean>
                 <bean class="org.georchestra.security.LdapUserDetailsRequestHeaderProvider">
                     <constructor-arg index="0" ref="contextSource" />


### PR DESCRIPTION
The title is self-explanatory: see #1073 for the context.

Since the user is "protected", it won't show up in the console, and if not configured explicitely to use another password, will come with a default one, allowing people to connect to the platform with an `ADMINISTRATOR` account.

It seems that this user is no longer used, as geofence is not an external module anymore and integrated as an option to geoserver, and extractorapp also disappeared some years ago.

There are still some occurences of the user in the codebase:
1. still some references in the testsuite
2. It has been kept into the analytics configuration, as it sounds relevant to still filter it out from this module.
