### PR TITLE
console: add org display name to user private route

### DIFF
--- a/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
+++ b/console/src/main/java/org/georchestra/console/ws/backoffice/users/UsersController.java
@@ -237,8 +237,11 @@ public class UsersController {
         // Check delegation
         this.checkAuthorization(uid);
 
-        return this.accountDao.findByUID(uid);
-
+        Account a = this.accountDao.findByUID(uid);
+        if (!StringUtils.isEmpty(a.getOrg()){
+            a.setOrgDisplayName(this.orgDao.findByUser(a).getName());
+        }
+        return a;
     }
 
     /**

--- a/ldap-account-management/src/main/java/org/georchestra/ds/users/Account.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/users/Account.java
@@ -196,4 +196,8 @@ public interface Account extends Comparable<Account> {
     boolean getIsExternalAuth();
 
     void setIsExternalAuth(boolean isExternalAuth);
+
+    String getOrgDisplayName();
+
+    void setOrgDisplayName(String orgDisplayName);
 }


### PR DESCRIPTION
It allows to directly get Organization full name without the need to match it with org route.

