### PR TITLE
console: Use logback.xml to avoid console spamming in debug mode

### DIFF
--- a/console/src/main/resources/logback.xml
+++ b/console/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Since spring-amqp bump to v2, console seems to use logback instead of log4j. 

This PR aims just to shut down debug's log by default.