### PR TITLE
fix: fixing the editOrgDetailsForm.jsp template in the console

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -146,6 +146,19 @@ accounts `uid`. These users also do not show up in the console.
 
 ## Developer's corner
 
+### JSP templates testing
+
+In order to test the JSP templates, you one can launch the `jetty-jspc`
+maven plugin using the following command:
+
+```
+$ mvn frontend:npm jetty-jspc:jspc
+```
+Please note that the `frontend:npm` goal has to be called first, as
+the generated `manager/public/index.html` file is referenced into the
+templates, so it needs to be generated prior to leverage the jspc
+maven plugin.
+
 ### Integration Testing
 
 > TL;DR: run integration tests with `mvn verify`. 

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -468,6 +468,19 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <version>9.4.57.v20241219</version>
+                <executions>
+                    <execution>
+                        <id>jspc</id>
+                        <goals>
+                            <goal>jspc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/console/src/main/webapp/WEB-INF/views/editOrgDetailsForm.jsp
+++ b/console/src/main/webapp/WEB-INF/views/editOrgDetailsForm.jsp
@@ -89,7 +89,7 @@
             <jsp:attribute name="label"><s:message code="mail.label"/></jsp:attribute>
           </t:input>
           <t:input path="orgUniqueId" required="${orgUniqueIdRequired}">
-            <jsp:attribute name="orgUniqueId"><s:message code="orgUniqueId.label"/></jsp:attribute>
+            <jsp:attribute name="label"><s:message code="orgUniqueId.label"/></jsp:attribute>
           </t:input>
           <div class="form-group">
             <label for="logo" class="control-label col-lg-4"><s:message


### PR DESCRIPTION
Along with the following commit:
https://github.com/georchestra/georchestra/commit/a8d0733e8fab0aa56e8a2a437c4909cd094e1636#diff-b5a6c8a826b4bece338a05107c22595dc061f7475cb6b4a31924772fdfe276ecR92

A regression has been introduced to the console, making the servlet container unable to compile the JSP template, because the attribute name being used could not be resolved.

The fix is pretty trivial, but I took the opportunity to dig in how to test modifications onto the JSP.

Tests:

Considering that the bug was introduced almost one year ago without nobody ever noticing it since then (Thanks geo2france for the report), I was looking for a way to avoid such issues in the future.

I first tried to use an integration test, but stumbled upon an issue with testcontainers, and fixing things lead me to figure out that the JSP templates were not even being processed anyway. So integration tests were quite useless here, and probably depends on the servlet container implementation you choose to deploy the webapp.

So I ended up introducing a maven plugin to precompile the JSP files, which would fail in case of errors in the JSP files, which was my actual goal. The suggested procedure to test the JSP is now documented in the `README.md`.