### PR TITLE
Move lastbind precision configuration to bootstrap.ldif (fixes #4613)

### DIFF
--- a/ldap/bootstrap.ldif
+++ b/ldap/bootstrap.ldif
@@ -12,6 +12,7 @@ olcDbIndex: mail eq,sub,subfinal
 olcDbIndex: member eq
 olcDbIndex: uid eq
 olcLastMod: TRUE
+olcLastBindPrecision: 14400
 olcDbCheckpoint: 512 30
 olcDbMaxSize: 1073741824
 olcAccess: to attrs=userPassword by dn="cn=admin,dc=georchestra,dc=org" write by anonymous auth by self write by * none

--- a/ldap/docker-root/lastbind.ldif
+++ b/ldap/docker-root/lastbind.ldif
@@ -11,4 +11,3 @@ objectClass: olcOverlayConfig
 objectClass: olcConfig
 objectClass: top
 olcOverlay: lastbind
-olcLastBindPrecision: 14400


### PR DESCRIPTION
with slapd 2.6 it complains about the attribute 'olcLastBindPrecision' not being allowed.

after extensive testing, the 4h-precision setup works, eg after waiting 4h after a testadmin logging, logging out and re-logging in, the attribute is updated:
```
root@trixie:/etc/georchestra# slapcat|grep authTime
authTimestamp: 20260114104923Z
```