### PR TITLE
Allow to find user by usernames and filter attributes output

### DIFF
--- a/commons/src/main/java/org/georchestra/security/api/UsersApi.java
+++ b/commons/src/main/java/org/georchestra/security/api/UsersApi.java
@@ -22,6 +22,7 @@ import org.georchestra.security.model.GeorchestraUser;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public interface UsersApi {
 
@@ -50,4 +51,13 @@ public interface UsersApi {
     }
 
     List<GeorchestraUser> findAll();
+
+    /**
+     * Find all users matching the provided filter. The filter is applied on the
+     * user properties, not on the underlying data source.
+     *
+     * @param filter a predicate to filter users
+     * @return a list of users matching the provided filter
+     */
+    List<GeorchestraUser> findAllBy(Predicate<GeorchestraUser> filter);
 }

--- a/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
@@ -20,6 +20,7 @@ package org.georchestra.console.ws.security.api;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletContext;
@@ -70,6 +71,12 @@ public class SecurityApiController {
     @ResponseBody
     public List<GeorchestraUser> findUsers() {
         return users.findAll();
+    }
+
+    @PostMapping(value = "/users/fetch-by-ids")
+    @ResponseBody
+    public List<GeorchestraUser> findUsersByIds(@RequestBody Set<String> ids) {
+        return users.findAllBy(user -> ids.contains(user.getId()));
     }
 
     /**

--- a/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
@@ -18,7 +18,9 @@
  */
 package org.georchestra.console.ws.security.api;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -73,10 +75,39 @@ public class SecurityApiController {
         return users.findAll();
     }
 
+    /**
+     * Fetch users by a list of IDs with optional field projection.
+     * <p>
+     * Request body example:
+     *
+     * <pre>
+     * {
+     *   "usernames": ["testadmin", "testuser"],
+     *   "fields": ["firstName", "lastName", "email"]
+     * }
+     * </pre>
+     *
+     * If {@code fields} is null or empty, all user fields are returned.
+     *
+     * @param request the batch request containing IDs and optional fields
+     * @return a list of users (as maps if fields are specified, or full objects
+     *         otherwise)
+     */
     @PostMapping(value = "/users/fetch-by-ids")
     @ResponseBody
-    public List<GeorchestraUser> findUsersByIds(@RequestBody Set<String> ids) {
-        return users.findAllBy(user -> ids.contains(user.getId()));
+    public List<?> findUsersByUsernames(@RequestBody UserBatchRequest request) {
+        Set<String> ids = request.getUsernames() != null ? new HashSet<>(request.getUsernames()) : Set.of();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        List<GeorchestraUser> userList = users.findAll().stream().filter(user -> ids.contains(user.getUsername()))
+                .collect(Collectors.toList());
+
+        List<String> fields = request.getFields();
+        if (fields != null && !fields.isEmpty()) {
+            return UserFieldsProjector.projectAll(userList, fields);
+        }
+        return userList;
     }
 
     /**

--- a/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/SecurityApiController.java
@@ -76,7 +76,7 @@ public class SecurityApiController {
     }
 
     /**
-     * Fetch users by a list of IDs with optional field projection.
+     * Fetch users by a list of usernames with optional field projection.
      * <p>
      * Request body example:
      *
@@ -89,18 +89,18 @@ public class SecurityApiController {
      *
      * If {@code fields} is null or empty, all user fields are returned.
      *
-     * @param request the batch request containing IDs and optional fields
+     * @param request the batch request containing usernames and optional fields
      * @return a list of users (as maps if fields are specified, or full objects
      *         otherwise)
      */
-    @PostMapping(value = "/users/fetch-by-ids")
+    @PostMapping(value = "/users/fetch-by-usernames")
     @ResponseBody
     public List<?> findUsersByUsernames(@RequestBody UserBatchRequest request) {
-        Set<String> ids = request.getUsernames() != null ? new HashSet<>(request.getUsernames()) : Set.of();
-        if (ids.isEmpty()) {
+        Set<String> usernames = request.getUsernames() != null ? new HashSet<>(request.getUsernames()) : Set.of();
+        if (usernames.isEmpty()) {
             return List.of();
         }
-        List<GeorchestraUser> userList = users.findAll().stream().filter(user -> ids.contains(user.getUsername()))
+        List<GeorchestraUser> userList = users.findAll().stream().filter(user -> usernames.contains(user.getUsername()))
                 .collect(Collectors.toList());
 
         List<String> fields = request.getFields();

--- a/console/src/main/java/org/georchestra/console/ws/security/api/UserBatchRequest.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/UserBatchRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2009-2026 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.console.ws.security.api;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Request DTO for batch user retrieval with optional field projection.
+ * <p>
+ * Example request body:
+ *
+ * <pre>
+ * {
+ *   "usernames": ["testadmin", "testuser"],
+ *   "fields": ["firstName", "lastName", "email"]
+ * }
+ * </pre>
+ *
+ * If {@code fields} is null or empty, all fields are returned.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserBatchRequest {
+
+    /**
+     * List of user IDs to retrieve.
+     */
+    private List<String> usernames;
+
+    /**
+     * Optional list of fields to include in the response. If null or empty, all
+     * fields are returned. Valid field names: id, username, firstName, lastName,
+     * email, organization, roles, lastUpdated, postalAddress, telephoneNumber,
+     * title, notes, isExternalAuth
+     */
+    private List<String> fields;
+}

--- a/console/src/main/java/org/georchestra/console/ws/security/api/UserFieldsProjector.java
+++ b/console/src/main/java/org/georchestra/console/ws/security/api/UserFieldsProjector.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2009-2025 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.console.ws.security.api;
+
+import org.georchestra.security.model.GeorchestraUser;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class to project GeorchestraUser fields dynamically. This avoids
+ * modifying the commons module while allowing field selection.
+ */
+public class UserFieldsProjector {
+
+    private static final Set<String> VALID_FIELDS = Set.of("id", "username", "firstName", "lastName", "email",
+            "organization", "roles", "lastUpdated", "postalAddress", "telephoneNumber", "title", "notes", "ldapWarn",
+            "ldapRemainingDays", "oAuth2Provider", "oAuth2Uid", "oAuth2OrgId", "isExternalAuth");
+
+    private static final Map<String, FieldGetter> FIELD_GETTERS = new HashMap<>();
+
+    static {
+        FIELD_GETTERS.put("id", GeorchestraUser::getId);
+        FIELD_GETTERS.put("username", GeorchestraUser::getUsername);
+        FIELD_GETTERS.put("firstName", GeorchestraUser::getFirstName);
+        FIELD_GETTERS.put("lastName", GeorchestraUser::getLastName);
+        FIELD_GETTERS.put("email", GeorchestraUser::getEmail);
+        FIELD_GETTERS.put("organization", GeorchestraUser::getOrganization);
+        FIELD_GETTERS.put("roles", GeorchestraUser::getRoles);
+        FIELD_GETTERS.put("lastUpdated", GeorchestraUser::getLastUpdated);
+        FIELD_GETTERS.put("postalAddress", GeorchestraUser::getPostalAddress);
+        FIELD_GETTERS.put("telephoneNumber", GeorchestraUser::getTelephoneNumber);
+        FIELD_GETTERS.put("title", GeorchestraUser::getTitle);
+        FIELD_GETTERS.put("notes", GeorchestraUser::getNotes);
+        FIELD_GETTERS.put("ldapWarn", GeorchestraUser::getLdapWarn);
+        FIELD_GETTERS.put("ldapRemainingDays", GeorchestraUser::getLdapRemainingDays);
+        FIELD_GETTERS.put("oAuth2Provider", GeorchestraUser::getOAuth2Provider);
+        FIELD_GETTERS.put("oAuth2Uid", GeorchestraUser::getOAuth2Uid);
+        FIELD_GETTERS.put("oAuth2OrgId", GeorchestraUser::getOAuth2OrgId);
+        FIELD_GETTERS.put("isExternalAuth", GeorchestraUser::getIsExternalAuth);
+    }
+
+    @FunctionalInterface
+    private interface FieldGetter {
+        Object get(GeorchestraUser user);
+    }
+
+    /**
+     * Projects a user to a Map containing only the requested fields.
+     *
+     * @param user   the user to project
+     * @param fields the fields to include (if null or empty, all fields are
+     *               included)
+     * @return a Map with field names as keys and field values as values
+     */
+    public static Map<String, Object> project(GeorchestraUser user, List<String> fields) {
+        Set<String> requestedFields = (fields == null || fields.isEmpty()) ? VALID_FIELDS
+                : fields.stream().filter(VALID_FIELDS::contains).collect(Collectors.toSet());
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String field : requestedFields) {
+            FieldGetter getter = FIELD_GETTERS.get(field);
+            if (getter != null) {
+                result.put(field, getter.get(user));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Projects a list of users to a list of Maps containing only the requested
+     * fields.
+     *
+     * @param users  the users to project
+     * @param fields the fields to include (if null or empty, all fields are
+     *               included)
+     * @return a list of Maps with projected fields
+     */
+    public static List<Map<String, Object>> projectAll(List<GeorchestraUser> users, List<String> fields) {
+        return users.stream().map(user -> project(user, fields)).collect(Collectors.toList());
+    }
+}

--- a/console/src/test/java/org/georchestra/console/ws/security/api/UserFieldsProjectorTest.java
+++ b/console/src/test/java/org/georchestra/console/ws/security/api/UserFieldsProjectorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2009-2025 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.console.ws.security.api;
+
+import org.georchestra.security.model.GeorchestraUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserFieldsProjectorTest {
+
+    private GeorchestraUser testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new GeorchestraUser();
+        testUser.setId("user-uuid-123");
+        testUser.setUsername("jdoe");
+        testUser.setFirstName("John");
+        testUser.setLastName("Doe");
+        testUser.setEmail("john.doe@example.com");
+        testUser.setOrganization("TestOrg");
+        testUser.setRoles(Arrays.asList("USER", "ADMIN"));
+        testUser.setTitle("Developer");
+        testUser.setTelephoneNumber("+33123456789");
+    }
+
+    @Test
+    void project_withSpecificFields_returnsOnlyRequestedFields() {
+        List<String> fields = Arrays.asList("firstName", "lastName", "email");
+
+        Map<String, Object> result = UserFieldsProjector.project(testUser, fields);
+
+        assertEquals(3, result.size());
+        assertEquals("John", result.get("firstName"));
+        assertEquals("Doe", result.get("lastName"));
+        assertEquals("john.doe@example.com", result.get("email"));
+        assertFalse(result.containsKey("id"));
+        assertFalse(result.containsKey("username"));
+    }
+
+    @Test
+    void project_withNullFields_returnsAllFields() {
+        Map<String, Object> result = UserFieldsProjector.project(testUser, null);
+
+        assertTrue(result.size() > 5);
+        assertEquals("user-uuid-123", result.get("id"));
+        assertEquals("jdoe", result.get("username"));
+        assertEquals("John", result.get("firstName"));
+        assertEquals("Doe", result.get("lastName"));
+        assertEquals("john.doe@example.com", result.get("email"));
+    }
+
+    @Test
+    void project_withEmptyFields_returnsAllFields() {
+        Map<String, Object> result = UserFieldsProjector.project(testUser, List.of());
+
+        assertTrue(result.size() > 5);
+        assertEquals("user-uuid-123", result.get("id"));
+    }
+
+    @Test
+    void project_withInvalidFields_ignoresInvalidFields() {
+        List<String> fields = Arrays.asList("firstName", "invalidField", "lastName");
+
+        Map<String, Object> result = UserFieldsProjector.project(testUser, fields);
+
+        assertEquals(2, result.size());
+        assertEquals("John", result.get("firstName"));
+        assertEquals("Doe", result.get("lastName"));
+        assertFalse(result.containsKey("invalidField"));
+    }
+
+    @Test
+    void projectAll_withMultipleUsers_projectsAllUsers() {
+        GeorchestraUser user2 = new GeorchestraUser();
+        user2.setId("user-uuid-456");
+        user2.setUsername("asmith");
+        user2.setFirstName("Alice");
+        user2.setLastName("Smith");
+        user2.setEmail("alice.smith@example.com");
+
+        List<GeorchestraUser> users = Arrays.asList(testUser, user2);
+        List<String> fields = Arrays.asList("firstName", "lastName");
+
+        List<Map<String, Object>> result = UserFieldsProjector.projectAll(users, fields);
+
+        assertEquals(2, result.size());
+
+        Map<String, Object> first = result.get(0);
+        assertEquals("John", first.get("firstName"));
+        assertEquals("Doe", first.get("lastName"));
+
+        Map<String, Object> second = result.get(1);
+        assertEquals("Alice", second.get("firstName"));
+        assertEquals("Smith", second.get("lastName"));
+    }
+
+    @Test
+    void project_withRolesField_returnsRolesList() {
+        List<String> fields = List.of("roles");
+
+        Map<String, Object> result = UserFieldsProjector.project(testUser, fields);
+
+        assertEquals(1, result.size());
+        assertTrue(result.get("roles") instanceof List);
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) result.get("roles");
+        assertEquals(2, roles.size());
+        assertTrue(roles.contains("USER"));
+        assertTrue(roles.contains("ADMIN"));
+    }
+}

--- a/ldap-account-management/src/main/java/org/georchestra/ds/security/UsersApiImpl.java
+++ b/ldap-account-management/src/main/java/org/georchestra/ds/security/UsersApiImpl.java
@@ -56,6 +56,19 @@ public class UsersApiImpl implements UsersApi {
     }
 
     @Override
+    public List<GeorchestraUser> findAllBy(Predicate<GeorchestraUser> filter) {
+        try {
+            return this.accountsDao.findAll(notPending().and(notProtected()))//
+                    .stream()//
+                    .map(mapper::map)//
+                    .filter(filter)//
+                    .collect(Collectors.toList());
+        } catch (DataServiceException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public Optional<GeorchestraUser> findById(String id) {
         try {
             UUID uuid = UUID.fromString(id);

--- a/security-proxy-spring-integration/src/main/java/org/georchestra/security/client/console/GeorchestraConsoleUsersApiImpl.java
+++ b/security-proxy-spring-integration/src/main/java/org/georchestra/security/client/console/GeorchestraConsoleUsersApiImpl.java
@@ -21,6 +21,7 @@ package org.georchestra.security.client.console;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.georchestra.security.api.UsersApi;
 import org.georchestra.security.model.GeorchestraUser;
@@ -43,6 +44,11 @@ public class GeorchestraConsoleUsersApiImpl implements UsersApi {
     @Override
     public List<GeorchestraUser> findAll() {
         return client.getAll("/console/internal/users", GeorchestraUser.class);
+    }
+
+    @Override
+    public List<GeorchestraUser> findAllBy(Predicate<GeorchestraUser> filter) {
+        return client.getAll("/console/internal/users", GeorchestraUser.class).stream().filter(filter).toList();
     }
 
     @Override


### PR DESCRIPTION
As console will soon be rewritten, attribute are intentionally duplicated under UserFieldsProjector to avoid importing some lib in commons lib.

```shell
curl --request POST \
  --url http://localhost:8080/console/internal/users/fetch-by-usernames \
  --header 'Authorization: Basic d...=' \
  --header 'Content-Type: application/json' \
  --data '{
	"usernames": ["testadmin"],
	"fields":  ["username", "firstName", "lastName"]
}'
```

```
[
	{
		"firstName": "Test",
		"lastName": "ADMIN",
		"username": "testadmin"
	}
]
```