### PR TITLE
fix: rework LDAP startup logic

### DIFF
--- a/ldap/docker-root/docker-entrypoint.d/00-init
+++ b/ldap/docker-root/docker-entrypoint.d/00-init
@@ -10,6 +10,8 @@ source /docker-entrypoint.d/utils/load_secrets.sh
 
 SLAPD_FORCE_RECONFIGURE="${SLAPD_FORCE_RECONFIGURE:-false}"
 
+mkdir -p /var/run/slapd && chown ${RUN_AS_UID}:${RUN_AS_GID} /var/run/slapd
+
 first_run=true
 
 if [[ -f "/var/lib/ldap/DB_CONFIG" || -f "/var/lib/ldap/data.mdb" ]]; then
@@ -82,10 +84,10 @@ EOF
             slapadd -n0 -F /etc/ldap/slapd.d -l "/etc/ldap/schema/${schema}.ldif"
         done
     fi
-    
+
     if [ "$SLAPD_PASSWORD_MGT_POLICY" == 'rotation' ]; then
     	cp /etc/ldap/modules/ppolicy-rotation.ldif /etc/ldap/modules/ppolicy.ldif
-    else 
+    else
     	cp /etc/ldap/modules/ppolicy-default.ldif /etc/ldap/modules/ppolicy.ldif
     fi
 

--- a/ldap/docker-root/docker-entrypoint.d/01-populate
+++ b/ldap/docker-root/docker-entrypoint.d/01-populate
@@ -7,7 +7,6 @@ if [ ! -f /etc/ldap/slapd.d/initialized ]; then
 
     # start slapd in background
     echo -n "Starting slapd daemon in background..."
-    mkdir -p /var/run/slapd && chown ${RUN_AS_UID}:${RUN_AS_GID} /var/run/slapd
     slapd -u ${RUN_AS_UID} -g ${RUN_AS_GID} -h "ldapi:/// ldap://127.0.0.1/"
     echo "Started: OK"
 


### PR DESCRIPTION
The `/var/run/slapd` directory is not provided by the package, I am not sure it was the case before, but we have to ensure the directory exists before trying to launch slapd. moving the mkdir -p/chown logic into the early beginning of the 00-init script, and executing regardless of whether the LDAP has already been initialized or not.

Tests: directly onto a test infra (with an existing setup), and running the docker image by hand locally to make sure the bootstrap process has not been broken by the change.