### PR TITLE
testcontainers - removing configuration via setProperties (#4661)

### DIFF
--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -42,6 +42,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/testcontainers/src/main/java/org/geonetwork/testcontainers/postgres/GeonetworkPostgresContainer.java
+++ b/testcontainers/src/main/java/org/geonetwork/testcontainers/postgres/GeonetworkPostgresContainer.java
@@ -18,6 +18,7 @@
  */
 package org.geonetwork.testcontainers.postgres;
 
+import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
@@ -50,9 +51,12 @@ import org.testcontainers.utility.DockerImageName;
  * {@code jdbc.port=<mapped port>}, following standard georchestra
  * datadirectory's property name.
  */
+@Slf4j
 public class GeonetworkPostgresContainer extends PostgreSQLContainer<GeonetworkPostgresContainer> {
 
     static final String INIT_SCRIPT = "testcontainers/GeonetworkPostgresContainer.sql";
+
+    private int mappedPort;
 
     public GeonetworkPostgresContainer() {
         super(DockerImageName.parse("postgres:13-alpine"));
@@ -65,20 +69,17 @@ public class GeonetworkPostgresContainer extends PostgreSQLContainer<GeonetworkP
     }
 
     public GeonetworkPostgresContainer withLogToStdOut() {
-        return withLogConsumer(outputFrame -> System.out.print("--- database: " + outputFrame.getUtf8String()));
+        return withLogConsumer(outputFrame -> System.out.println("--- database: " + outputFrame.getUtf8String()));
     }
 
     public int getMappedPostgresPort() {
-        return getMappedPort(5432);
+        return mappedPort;
     }
 
     protected @Override void doStart() {
         super.doStart();
-        int mappedPort = getMappedPostgresPort();
-        String host = super.getHost();
-        System.setProperty("jdbc.port", String.valueOf(mappedPort));
-        System.setProperty("jdbc.host", host);
-        System.out.println("Automatically set system property jdbc.port=" + mappedPort);
-        System.out.println("Automatically set system property jdbc.host=" + host);
+        mappedPort = getMappedPort(5432);
+        log.info("jdbc.port=" + mappedPort);
+        log.info("jdbc.host=" + getHost());
     }
 }

--- a/testcontainers/src/main/java/org/geonetwork/testcontainers/postgres/GeorchestraDatabaseContainer.java
+++ b/testcontainers/src/main/java/org/geonetwork/testcontainers/postgres/GeorchestraDatabaseContainer.java
@@ -22,6 +22,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 import java.time.Duration;
 
+import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.Base58;
@@ -41,11 +42,14 @@ import org.testcontainers.utility.DockerImageName;
  * {@code jdbc.port=<mapped port>}, and {@code jdbc.host=<host>}, with
  * {@link #getHost()}'s value (may not be the local machine).
  */
+@Slf4j
 public class GeorchestraDatabaseContainer extends GenericContainer<GeorchestraDatabaseContainer> {
 
     public GeorchestraDatabaseContainer() {
         this(DockerImageName.parse("georchestra/database:latest"));
     }
+
+    private int mappedPort;
 
     GeorchestraDatabaseContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
@@ -68,16 +72,14 @@ public class GeorchestraDatabaseContainer extends GenericContainer<GeorchestraDa
     }
 
     public int getMappedDatabasePort() {
-        return getMappedPort(5432);
+        return mappedPort;
     }
 
     protected @Override void doStart() {
         super.doStart();
-        int mappedPort = getMappedDatabasePort();
+        mappedPort = getMappedPort(5432);
         String host = super.getHost();
-        System.setProperty("jdbc.port", String.valueOf(mappedPort));
-        System.setProperty("jdbc.host", host);
-        System.out.println("Automatically set system property jdbc.port=" + mappedPort);
-        System.out.println("Automatically set system property jdbc.host=" + host);
+        log.info("jdbc.port=" + mappedPort);
+        log.info("jdbc.host=" + host);
     }
 }

--- a/testcontainers/src/main/java/org/georchestra/testcontainers/console/GeorchestraConsoleContainer.java
+++ b/testcontainers/src/main/java/org/georchestra/testcontainers/console/GeorchestraConsoleContainer.java
@@ -18,6 +18,7 @@
  */
 package org.georchestra.testcontainers.console;
 
+import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.Base58;
@@ -35,7 +36,10 @@ import org.testcontainers.utility.DockerImageName;
  * will automatically set as a {@link System#getProperty System property}
  * {@code console.port=<mapped port>}.
  */
+@Slf4j
 public class GeorchestraConsoleContainer extends GenericContainer<GeorchestraConsoleContainer> {
+
+    private int mappedPort;
 
     public GeorchestraConsoleContainer() {
         this(DockerImageName.parse("georchestra/console:latest"));
@@ -57,20 +61,17 @@ public class GeorchestraConsoleContainer extends GenericContainer<GeorchestraCon
     }
 
     public GeorchestraConsoleContainer withLogToStdOut() {
-        return withLogConsumer(outputFrame -> System.out.print("--- console: " + outputFrame.getUtf8String()));
+        return withLogConsumer(outputFrame -> System.out.println("--- console: " + outputFrame.getUtf8String()));
     }
 
     public int getMappedConsolePort() {
-        return getMappedPort(8080);
+        return mappedPort;
     }
 
     protected @Override void doStart() {
         super.doStart();
-        int mappedPort = getMappedConsolePort();
-        String host = getHost();
-        System.setProperty("console.port", String.valueOf(mappedPort));
-        System.setProperty("console.host", host);
-        System.out.println("Automatically set system property console.port=" + mappedPort);
-        System.out.println("Automatically set system property console.host=" + host);
+        mappedPort = getMappedPort(8080);
+        log.info("console.port=" + mappedPort);
+        log.info("console.host=" + getHost());
     }
 }

--- a/testcontainers/src/main/java/org/georchestra/testcontainers/ldap/GeorchestraLdapContainer.java
+++ b/testcontainers/src/main/java/org/georchestra/testcontainers/ldap/GeorchestraLdapContainer.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.testcontainers.ldap;
 
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.Base58;
@@ -36,7 +38,10 @@ import org.testcontainers.utility.DockerImageName;
  * {@code ldapPort=<mapped port>}, following standard georchestra
  * datadirectory's property name.
  */
+@Slf4j
 public class GeorchestraLdapContainer extends GenericContainer<GeorchestraLdapContainer> {
+
+    private int mappedLdapPort;
 
     public GeorchestraLdapContainer() {
         this(DockerImageName.parse("georchestra/ldap:latest"));
@@ -45,7 +50,6 @@ public class GeorchestraLdapContainer extends GenericContainer<GeorchestraLdapCo
     GeorchestraLdapContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         withExposedPorts(389);
-//        addFixedExposedPort(hostPort, 389);
         addEnv("SLAPD_ORGANISATION", "georchestra");
         addEnv("SLAPD_DOMAIN", "georchestra.org");
         addEnv("SLAPD_PASSWORD", "secret");
@@ -62,17 +66,21 @@ public class GeorchestraLdapContainer extends GenericContainer<GeorchestraLdapCo
         return withLogConsumer(outputFrame -> System.out.print("--- ldap: " + outputFrame.getUtf8String()));
     }
 
+    /**
+     * Returns the mapped LDAP port. The getter should be called after having started the container
+     * (e.g. `doStart()` having been instanciated).
+     *
+     * @return the port number locally mapped to the usual LDAP port (389).
+     */
     public int getMappedLdapPort() {
-        return getMappedPort(389);
+        return mappedLdapPort;
     }
 
     protected @Override void doStart() {
         super.doStart();
-        int mappedLdapPort = getMappedLdapPort();
-        String host = getHost();
-        System.setProperty("ldapPort", String.valueOf(mappedLdapPort));
-        System.setProperty("ldapHost", host);
-        System.out.println("Automatically set system property ldapPort=" + mappedLdapPort);
-        System.out.println("Automatically set system property ldapHost=" + host);
+        mappedLdapPort = getMappedPort(389);
+
+        log.info("Automatically set system property ldapPort=" + mappedLdapPort);
+        log.info("Automatically set system property ldapHost=" + getHost());
     }
 }


### PR DESCRIPTION
See mentioned issue for the details. Using Java properties to pass the dynamic configuration of where the service is available, as the testcontainer object already provides the info. Also the Java properties can lead to race condition in case the tets are run in parallel.

Note: this introduces a breaking change and will require adaptations everywhere the library is being used. Going through spring dynamic properties for the tests as described in the issue is quite straightforward though

tests: I was wondering if introducing a testsuite to test the testcontainers was really relevant / desirable ? :-)